### PR TITLE
Clear dependent rows before deleting an issue

### DIFF
--- a/backend/lib_softtrack/issues.py
+++ b/backend/lib_softtrack/issues.py
@@ -9,6 +9,7 @@ from sqlmodel import Session, select
 from lib_identity.models.identity import UserPublic
 from lib_softtrack.models.issues import IssueCreate, IssueRead, IssueUpdate
 from lib_softtrack.tables import (
+    Comment,
     Issue,
     IssueLabelLink,
     IssuePriority,
@@ -153,5 +154,25 @@ def update_issue(
 def delete_issue(session: Session, current_user: User, issue_id: int) -> None:
     issue = get_issue_or_404(session, issue_id)
     require_team_member(issue.team_id, current_user, session)
+
+    # Clear the rows that point at this issue before removing it. Postgres
+    # enforces these foreign keys and rejects the delete otherwise; SQLite only
+    # does so with PRAGMA foreign_keys=ON, which is why this survived until the
+    # stack moved to Postgres (soft-track#1).
+    #
+    # Done in the service rather than with ON DELETE CASCADE because the schema
+    # is still created by SQLModel.metadata.create_all, so a constraint change
+    # would never reach an existing database. Worth revisiting once Alembic
+    # lands (soft-track#5).
+    label_links = session.exec(
+        select(IssueLabelLink).where(IssueLabelLink.issue_id == issue_id)
+    ).all()
+    for link in label_links:
+        session.delete(link)
+
+    comments = session.exec(select(Comment).where(Comment.issue_id == issue_id)).all()
+    for comment in comments:
+        session.delete(comment)
+
     session.delete(issue)
     session.commit()

--- a/backend/tests/test_regressions.py
+++ b/backend/tests/test_regressions.py
@@ -1,8 +1,11 @@
-"""Regressions for known, filed bugs.
+"""Regressions for filed bugs.
 
-These are marked xfail(strict=True): they fail today, and the moment someone
-fixes the underlying bug pytest reports XPASS as a failure, which is the prompt
-to delete the marker. That keeps a fixed bug from quietly losing its test.
+Tests for bugs that are still open are marked xfail(strict=True): the moment
+someone fixes one, pytest reports XPASS as a failure, which is the prompt to
+delete the marker. That keeps a fixed bug from quietly losing its test.
+
+soft-track#1 is fixed, so its two tests now run normally and assert not just
+that the delete succeeds but that the dependent rows are actually gone.
 """
 
 import subprocess
@@ -10,14 +13,13 @@ import sys
 import textwrap
 
 import pytest
+from sqlmodel import select
+
+from lib_softtrack.tables import Comment, IssueLabelLink, Label
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="soft-track#1: delete_issue drops the Issue row without clearing "
-    "IssueLabelLink/Comment first, so the FK blocks it",
-)
-def test_deleting_an_issue_that_has_a_label(client, team):
+def test_deleting_an_issue_that_has_a_label(client, team, session):
+    """Regression for soft-track#1."""
     label = client.post(
         f"/teams/{team['team']['id']}/labels",
         json={"name": "Bug", "color": "#e0424a"},
@@ -32,12 +34,19 @@ def test_deleting_an_issue_that_has_a_label(client, team):
     response = client.delete(f"/issues/{issue['id']}", headers=team["headers"])
     assert response.status_code == 204
 
+    # the link row must be gone too, not merely orphaned
+    assert (
+        session.exec(
+            select(IssueLabelLink).where(IssueLabelLink.issue_id == issue["id"])
+        ).all()
+        == []
+    )
+    # the label itself survives -- it belongs to the team, not the issue
+    assert session.get(Label, label["id"]) is not None
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="soft-track#1: the same FK problem, reached through a comment",
-)
-def test_deleting_an_issue_that_has_a_comment(client, team):
+
+def test_deleting_an_issue_that_has_a_comment(client, team, session):
+    """Regression for soft-track#1."""
     issue = client.post(
         f"/teams/{team['team']['id']}/issues",
         json={"title": "has a comment"},
@@ -51,6 +60,10 @@ def test_deleting_an_issue_that_has_a_comment(client, team):
 
     response = client.delete(f"/issues/{issue['id']}", headers=team["headers"])
     assert response.status_code == 204
+
+    assert (
+        session.exec(select(Comment).where(Comment.issue_id == issue["id"])).all() == []
+    )
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Fixes #1.

Deleting an issue that had any label or comment returned **500**:

```
sqlalchemy.exc.IntegrityError: (psycopg.errors.ForeignKeyViolation)
update or delete on table "issue" violates foreign key constraint
"issuelabellink_issue_id_fkey" on table "issuelabellink"
```

`delete_issue` removed the `Issue` row while `IssueLabelLink` and `Comment` rows still pointed at it. Both now go first, in the same transaction.

### Two decisions worth reviewing

**Fixed in the service, not with `ON DELETE CASCADE`.** The schema is still built by `SQLModel.metadata.create_all`, so a constraint change would never reach a database that already exists — including the one running in `docker compose` right now. Worth revisiting once Alembic lands (#5); there's a comment in the code saying so.

**Labels are deliberately left alone.** A label belongs to the *team*, not the issue, so deleting an issue must not delete a label other issues share. The test asserts the label survives.

### Tests
The two regression tests added with the CI work were `xfail(strict=True)`. The markers are removed, and both now assert the dependent rows are *actually gone* rather than only that the request returned 204.

Suite: **33 passed, 1 xfailed** (the remaining xfail is #3, still open). Coverage 93%.

### Verified against Postgres
This only ever reproduced on Postgres, so I rebuilt the backend image and ran the exact repro from the issue:

| | Before | After |
|---|---|---|
| `DELETE /issues/{id}` | 500 | **204** |
| issue / link / comment rows | orphaned | **0 / 0 / 0** |
| label row | — | **survives** ✅ |
| `ForeignKeyViolation` in logs | yes | **0** |

`smoke_test.sh` also passes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)