### PR TITLE
Fix the smoke test for pagination and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           echo "openapi.json matches the running app."
 
   docker:
-    name: Docker · images build
+    name: Docker · build and smoke test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -129,3 +129,30 @@ jobs:
 
       - name: Build the stack
         run: docker compose build
+
+      # The unit suite runs against SQLite with the app in-process. This runs
+      # the real images against real Postgres over HTTP, which is the only
+      # place a response-shape change shows up before a user finds it.
+      - name: Start the stack
+        run: |
+          docker compose up -d
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:8000/health >/dev/null; then
+              echo "backend healthy"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::backend did not become healthy"
+          docker compose logs backend
+          exit 1
+
+      - name: Smoke test the running API
+        run: BASE_URL=http://localhost:8000 ./backend/smoke_test.sh
+
+      - name: Backend logs on failure
+        if: failure()
+        run: docker compose logs backend
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/backend/smoke_test.sh
+++ b/backend/smoke_test.sh
@@ -80,11 +80,28 @@ comment_resp=$(curl -sf -X POST "$BASE_URL/issues/$ISSUE_ID/comments" \
 
 echo "== list issues (filtered by status) =="
 list_resp=$(curl -sf "$BASE_URL/teams/$TEAM_ID/issues?status=in_progress" -H "$AUTH_HEADER")
-[ "$(echo "$list_resp" | jq 'length')" = "1" ] && pass "GET issues filtered by status returns 1 issue" || fail "status filter returned wrong count"
+# Collections are paginated: {"items": [...], "total": n, "limit": n, "offset": n}
+[ "$(echo "$list_resp" | jq '.items | length')" = "1" ] && pass "GET issues filtered by status returns 1 issue" || fail "status filter returned wrong count"
+[ "$(echo "$list_resp" | jq -r '.total')" = "1" ] && pass "the page reports total=1 for the filter" || fail "total did not match the filter"
+
+echo "== pagination =="
+page_resp=$(curl -sf "$BASE_URL/teams/$TEAM_ID/issues?limit=1&offset=0" -H "$AUTH_HEADER")
+[ "$(echo "$page_resp" | jq -r '.limit')" = "1" ] && pass "limit is echoed in the envelope" || fail "limit not echoed"
+capped=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/teams/$TEAM_ID/issues?limit=201" -H "$AUTH_HEADER")
+[ "$capped" = "422" ] && pass "a limit above the maximum is rejected" || fail "limit cap not enforced (got $capped)"
+
+echo "== comments are paginated too =="
+comments_resp=$(curl -sf "$BASE_URL/issues/$ISSUE_ID/comments" -H "$AUTH_HEADER")
+[ "$(echo "$comments_resp" | jq '.items | length')" = "1" ] && pass "GET comments returns the comment" || fail "comment list wrong"
 
 echo "== get single issue =="
 get_resp=$(curl -sf "$BASE_URL/issues/$ISSUE_ID" -H "$AUTH_HEADER")
 [ "$(echo "$get_resp" | jq -r .title)" = "Smoke issue" ] && pass "GET /issues/$ISSUE_ID returns correct title" || fail "get issue mismatch"
+
+echo "== deleting an issue that has a label and a comment =="
+del_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BASE_URL/issues/$ISSUE_ID" -H "$AUTH_HEADER")
+[ "$del_code" = "204" ] && pass "DELETE removes the issue and its dependent rows" || fail "delete returned $del_code"
+
 
 echo ""
 echo "All smoke tests passed."


### PR DESCRIPTION
Found by running the product, not by a test — which is the point.

`smoke_test.sh` has been **failing on `main`** since #35 merged. That PR moved the issue and comment collections to a `Page` envelope and updated the frontend and the pytest suite, but not the smoke test, which still asserted on a bare array.

**CI didn't catch it because nothing ran the script.** The unit suite exercises the app in-process against SQLite; a response-shape change only shows up when a real client talks to the real API over HTTP.

### Two changes
- `smoke_test.sh` reads `.items` / `.total`, and gained checks for the echoed `limit`, the 422 above the maximum, paginated comments, and **deleting an issue that has both a label and a comment** — the #1 regression, previously never covered end to end
- The `docker` CI job now starts the stack, waits for health, runs the smoke test against it, dumps backend logs on failure, and tears down after

### Verified locally as a CI-equivalent run
Separate compose project on its own ports and volume, since the job ends in `docker compose down -v`:

| Step | Result |
|---|---|
| `docker compose build --no-cache` | both images, 51s |
| health wait | healthy on attempt 1 |
| fresh Postgres from migrations | **9 tables**, revision `e2b56dbe1777` |
| smoke test | **all passed** |
| `down -v` | clean |

That fresh-database run is worth noting on its own: the schema was built by Alembic from nothing, which is the path a brand-new user gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)