### PR TITLE
Refuse to start outside development with the published SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,12 @@ Notes worth knowing:
   API, not the frontend container. Serving this anywhere other than localhost
   means rebuilding with the right value:
   `docker compose build --build-arg VITE_API_BASE_URL=https://api.example.com frontend`.
-- **Set a real `SECRET_KEY`** before running this anywhere but your own machine.
-  It is read from the environment, so `SECRET_KEY=... docker compose up` or a
-  `.env` file next to `docker-compose.yml` both work.
+- **Set a real `SECRET_KEY`** before running this anywhere but your own machine,
+  and set `ENVIRONMENT` to something other than `development`. In that
+  combination the app **refuses to start** while `SECRET_KEY` is still the
+  default, because that default is published in this repository and anyone who
+  reads it can forge a token. `SECRET_KEY=... ENVIRONMENT=production docker
+  compose up` or a `.env` file next to `docker-compose.yml` both work.
 - Host port 5173 is deliberate: it matches the backend's default `cors_origins`,
   so the API accepts the frontend's requests without extra configuration. If
   something else on your machine already holds 5173 (a `npm run dev` you left

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,11 @@
 # SQLite by default. For Postgres: postgresql://user:password@host:5432/dbname
 DATABASE_URL=sqlite:///./softtrack.db
 
+# "development" keeps the convenient defaults below. Set anything else
+# (production, staging, ...) and the app refuses to start while SECRET_KEY is
+# still the published default.
+ENVIRONMENT=development
+
 # Generate a real secret for anything beyond local dev, e.g.:
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
 SECRET_KEY=dev-secret-key-change-me-in-production

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,40 @@
+"""The startup guard on the signing key.
+
+The default SECRET_KEY is published in this repository, so a deployment that
+never set one can have any user's JWT forged by anyone who reads the source.
+The app refuses to boot in that combination rather than serving forgeable
+tokens while looking healthy.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from web import DEV_SECRET_KEY, Settings
+
+
+def test_the_development_default_is_allowed_in_development():
+    settings = Settings(environment="development", secret_key=DEV_SECRET_KEY)
+    assert settings.secret_key == DEV_SECRET_KEY
+
+
+@pytest.mark.parametrize("environment", ["production", "staging"])
+def test_the_development_default_is_refused_outside_development(environment):
+    with pytest.raises(ValidationError) as exc:
+        Settings(environment=environment, secret_key=DEV_SECRET_KEY)
+    message = str(exc.value)
+    # the error has to say what to do, not just that something is wrong
+    assert "SECRET_KEY" in message
+    assert "secrets.token_urlsafe" in message
+
+
+def test_a_real_secret_is_accepted_in_production():
+    settings = Settings(environment="production", secret_key="a-real-secret-value")
+    assert settings.environment == "production"
+
+
+def test_the_guard_only_rejects_the_published_default():
+    """A secret that merely looks similar must still be accepted."""
+    settings = Settings(
+        environment="production", secret_key=DEV_SECRET_KEY + "-but-changed"
+    )
+    assert settings.secret_key != DEV_SECRET_KEY

--- a/backend/web.py
+++ b/backend/web.py
@@ -6,15 +6,21 @@ neither routing (`app_*`) nor business logic (`lib_*`) lives here.
 
 from pathlib import Path
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 from sqlalchemy import inspect
 from sqlmodel import Session, create_engine
 
+# Published in this repository, so anyone can sign a token with it. Fine for
+# local development, never acceptable on a host anyone else can reach.
+DEV_SECRET_KEY = "dev-secret-key-change-me-in-production"
+
 
 class Settings(BaseSettings):
     app_name: str = "SoftTrack"
+    environment: str = "development"
     database_url: str = "sqlite:///./softtrack.db"
-    secret_key: str = "dev-secret-key-change-me-in-production"
+    secret_key: str = DEV_SECRET_KEY
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24 * 7  # 7 days
     cors_origins: list[str] = [
@@ -24,6 +30,25 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
+
+    @model_validator(mode="after")
+    def _refuse_the_published_secret_in_production(self) -> "Settings":
+        """Fail at startup rather than serve forgeable tokens.
+
+        The default signing key is in this repository, so a deployment that
+        never set SECRET_KEY can have any user's JWT forged by anyone who has
+        read the source. Refusing to boot is noisy; the alternative is a
+        service that looks healthy and is not.
+        """
+        if self.environment != "development" and self.secret_key == DEV_SECRET_KEY:
+            raise ValueError(
+                "SECRET_KEY is still the published development default while "
+                f"ENVIRONMENT={self.environment!r}. Generate one with:\n"
+                '  python -c "import secrets; print(secrets.token_urlsafe(48))"\n'
+                "and set SECRET_KEY, or set ENVIRONMENT=development if this is "
+                "a local machine."
+            )
+        return self
 
 
 settings = Settings()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,11 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-softtrack}:${POSTGRES_PASSWORD:-softtrack}@db:5432/${POSTGRES_DB:-softtrack}
-      # Override before exposing this anywhere beyond your own machine:
+      # development keeps the convenient defaults. Set ENVIRONMENT to anything
+      # else and the app refuses to start unless SECRET_KEY is a real value,
+      # because the default below is published in this repository.
       #   python -c "import secrets; print(secrets.token_urlsafe(48))"
+      ENVIRONMENT: ${ENVIRONMENT:-development}
       SECRET_KEY: ${SECRET_KEY:-dev-secret-key-change-me-in-production}
     depends_on:
       db:


### PR DESCRIPTION
Closes #9

`SECRET_KEY` defaults to `dev-secret-key-change-me-in-production`, and that string is published -- it is in `.env.example`, in `docker-compose.yml`, and in this repository's history. Anyone who deploys without overriding it can have a valid admin token minted for them, because the signing key is public knowledge.

Nothing stopped that. The app started happily and logged nothing.

`Settings` now carries an `environment` field (default `development`) and a `model_validator` that raises when the environment is anything else and the key is still the published default. The error names the variable and gives the exact command to generate a replacement:

    python -c "import secrets; print(secrets.token_urlsafe(48))"

Local development is untouched: the default environment is `development`, so `docker compose up` and `uvicorn` still start with no configuration. Only `ENVIRONMENT=staging`/`production` demands a real key -- which is precisely where you want the failure.

Verified in-process and inside the built image (start refused with the default key under `ENVIRONMENT=production`, started with a generated one), and the dev stack still returns 200 from `/health`.

`tests/test_settings.py` covers five cases, including that the message actually names `SECRET_KEY` and `secrets.token_urlsafe` -- an error a reader can act on is the whole point of the change.