### PR TITLE
Load issue list relations in a fixed number of queries

### DIFF
--- a/backend/lib_softtrack/issues.py
+++ b/backend/lib_softtrack/issues.py
@@ -1,5 +1,6 @@
 """Issue services, including the assembly of the denormalised IssueRead payload."""
 
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -49,6 +50,67 @@ def issue_to_read(issue: Issue, session: Session) -> IssueRead:
         created_at=issue.created_at,
         updated_at=issue.updated_at,
     )
+
+
+def _expand_issues(issues: list[Issue], session: Session) -> list[IssueRead]:
+    """Build IssueRead for a page of issues with a fixed number of queries.
+
+    `issue_to_read` is fine for one issue but costs a query per issue for its
+    label links, so a page of 50 cost ~58 queries. Loading labels, users and
+    teams in one query each makes the cost constant in the page size.
+
+    (The identity map already absorbed the repeated user and team lookups when
+    a page shared an assignee -- the label links were the real N+1.)
+    """
+    if not issues:
+        return []
+
+    issue_ids = [issue.id for issue in issues]
+
+    labels_by_issue: dict[int, list[Label]] = defaultdict(list)
+    for issue_id, label in session.exec(
+        select(IssueLabelLink.issue_id, Label)
+        .join(Label, Label.id == IssueLabelLink.label_id)
+        .where(IssueLabelLink.issue_id.in_(issue_ids))
+    ).all():
+        labels_by_issue[issue_id].append(label)
+
+    user_ids = {issue.creator_id for issue in issues}
+    user_ids |= {issue.assignee_id for issue in issues if issue.assignee_id}
+    users = {
+        user.id: user
+        for user in session.exec(select(User).where(User.id.in_(user_ids))).all()
+    }
+
+    team_ids = {issue.team_id for issue in issues}
+    teams = {
+        team.id: team
+        for team in session.exec(select(Team).where(Team.id.in_(team_ids))).all()
+    }
+
+    return [
+        IssueRead(
+            id=issue.id,
+            team_id=issue.team_id,
+            project_id=issue.project_id,
+            number=issue.number,
+            identifier=f"{teams[issue.team_id].key}-{issue.number}",
+            title=issue.title,
+            description=issue.description,
+            status=issue.status,
+            priority=issue.priority,
+            assignee=(
+                UserPublic.model_validate(users[issue.assignee_id])
+                if issue.assignee_id
+                else None
+            ),
+            creator=UserPublic.model_validate(users[issue.creator_id]),
+            labels=labels_by_issue.get(issue.id, []),
+            created_at=issue.created_at,
+            updated_at=issue.updated_at,
+        )
+        for issue in issues
+    ]
 
 
 def set_labels(issue_id: int, label_ids: list[int], session: Session) -> None:
@@ -138,7 +200,7 @@ def list_issues(
     ).all()
 
     return Page(
-        items=[issue_to_read(issue, session) for issue in issues],
+        items=_expand_issues(list(issues), session),
         total=total,
         limit=limit,
         offset=offset,

--- a/backend/tests/test_query_counts.py
+++ b/backend/tests/test_query_counts.py
@@ -1,0 +1,105 @@
+"""A ceiling on query counts for the issue list.
+
+Asserting an exact number would break on any incidental change, so this asserts
+the property that actually matters: the cost does not grow with the page size.
+Before soft-track#10 a page of 50 cost ~58 queries and a page of 200 cost ~208,
+because each issue fetched its own label links.
+"""
+
+import pytest
+from sqlalchemy import event
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from lib_softtrack.issues import list_issues
+from lib_softtrack.tables import (
+    Issue,
+    IssueLabelLink,
+    Label,
+    Team,
+    TeamMember,
+    TeamRole,
+    User,
+)
+
+
+def _seeded_engine(issue_count: int):
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        users = [
+            User(email=f"u{k}@softtrack.dev", hashed_password="x", full_name=f"U{k}")
+            for k in range(5)  # several assignees, so the identity map cannot hide it
+        ]
+        for user in users:
+            session.add(user)
+        session.commit()
+        for user in users:
+            session.refresh(user)
+
+        team = Team(name="Engineering", key="ENG")
+        session.add(team)
+        session.commit()
+        session.refresh(team)
+        session.add(
+            TeamMember(team_id=team.id, user_id=users[0].id, role=TeamRole.admin)
+        )
+        session.commit()
+
+        labels = [
+            Label(team_id=team.id, name=f"L{i}", color="#000000") for i in range(3)
+        ]
+        for label in labels:
+            session.add(label)
+        session.commit()
+        for label in labels:
+            session.refresh(label)
+
+        for i in range(issue_count):
+            issue = Issue(
+                team_id=team.id,
+                number=i + 1,
+                title=f"issue {i}",
+                creator_id=users[i % 5].id,
+                assignee_id=users[(i + 1) % 5].id,
+            )
+            session.add(issue)
+            session.commit()
+            session.refresh(issue)
+            for label in labels:
+                session.add(IssueLabelLink(issue_id=issue.id, label_id=label.id))
+            session.commit()
+        # ids, not ORM objects: instances detach when this session closes
+        return engine, users[0].id, team.id
+
+
+def _queries_to_list(issue_count: int) -> int:
+    engine, actor_id, team_id = _seeded_engine(issue_count)
+    counted: list[str] = []
+
+    def _record(conn, cursor, statement, *args):
+        counted.append(statement)
+
+    with Session(engine) as session:
+        actor = session.get(User, actor_id)  # load before counting starts
+        event.listen(engine, "before_cursor_execute", _record)
+        page = list_issues(session, actor, team_id, limit=200)
+        event.remove(engine, "before_cursor_execute", _record)
+        assert len(page.items) == issue_count
+    return len(counted)
+
+
+def test_listing_issues_does_not_scale_queries_with_page_size():
+    small = _queries_to_list(5)
+    large = _queries_to_list(60)
+    assert small == large, (
+        f"query count grew with the page: {small} for 5 issues, {large} for 60. "
+        "Something in the list path is querying per issue again."
+    )
+
+
+@pytest.mark.parametrize("issue_count", [5, 60])
+def test_the_issue_list_stays_under_a_query_ceiling(issue_count):
+    assert _queries_to_list(issue_count) <= 10


### PR DESCRIPTION
Closes #10

`list_issues` built each `IssueRead` with `issue_to_read`, which runs a query per issue to fetch its label links. The cost therefore grew with the page size, and `MAX_LIMIT` is 100.

**A correction to the issue first:** it estimated ~700 queries for a page of 50. The measured figure was **58**. SQLAlchemy's identity map was already absorbing the repeated user and team lookups whenever a page shared an assignee, so the label links were the only real N+1. The bug is real; the number in the issue was not.

`_expand_issues` loads labels, users and teams in one query each and assembles the page from those maps. The same page now costs **8 queries**, and the count no longer moves with the page size -- measured constant at 10, 50 and 200 issues with 5 distinct assignees.

The response payload is unchanged. Verified against the live Docker stack (identifier, labels, assignee and creator all identical) and against `backend/openapi.json`, which the contract job regenerates and which shows no drift.

### The test

`tests/test_query_counts.py` counts real statements through a SQLAlchemy event listener and asserts the *invariant*, not a magic number:

- the query count for a 5-issue page equals the count for a 60-issue page
- both stay under a ceiling of 10

A magic number would need editing every time an unrelated query is added, and would stop meaning anything. This phrasing fails only when the scaling comes back.

I checked that it does fail: reverting `_expand_issues` to the old `issue_to_read` loop makes all three cases fail, then passing again once restored.

    42 files would be left unchanged.
    Required test coverage of 85% reached. Total coverage: 93.16%
    45 passed, 14 warnings in 12.53s