### PR TITLE
Rate-limit sign-in and registration, and close the timing oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,40 @@ is at the default path.)
 - CORS origins for local dev are set in `backend/web.py`
   (`cors_origins`) — add your deployed frontend's origin there for production.
 
+## Sign-in rate limiting
+
+`/auth/login` and `/auth/register` are throttled, so credential guessing costs
+an attacker time. The budgets live in `backend/lib_utils/rate_limit.py`:
+
+| Bucket | Free attempts | Backoff | Cap |
+|---|---|---|---|
+| Failed sign-ins per address | 10 | doubles from 1s | 15 min |
+| Failed sign-ins per account | 5 | doubles from 1s | 1 min |
+| Registrations per address | 10 | doubles from 15s | 1 hour |
+
+A successful sign-in clears the counters, and any key that goes quiet for the
+forget window is dropped entirely, so a bad afternoon never follows you into
+the next day. Refusals return **429** with a `Retry-After` header.
+
+The per-account cap is deliberately the short one. A per-account lockout is
+itself an attack — without a cap, anyone who knows your address could keep you
+out of your own account — so it is set to slow a password spray to roughly one
+guess a minute rather than to lock anybody out.
+
+Two things worth knowing before you deploy:
+
+- **The counters are per process.** They live in memory, which covers the
+  single-worker container this repo ships. Run several workers or replicas and
+  each keeps its own counters, so the real budget is multiplied by the process
+  count. `Throttle` is the one class to reimplement against a shared cache if
+  you outgrow that.
+- **Behind a proxy, everyone shares one bucket.** The limiter uses the address
+  the server actually sees, and deliberately ignores `X-Forwarded-For`, since
+  any client can set that header and mint a fresh identity per request. If you
+  terminate TLS at nginx or a load balancer, run uvicorn with
+  `--proxy-headers --forwarded-allow-ips=<your proxy's address>`; Starlette
+  will then rewrite the client address from the header it can trust.
+
 ## Database migrations
 
 The schema is managed by **Alembic**. The URL comes from `DATABASE_URL`, the same

--- a/backend/app_identity/identity.py
+++ b/backend/app_identity/identity.py
@@ -1,17 +1,31 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlmodel import Session
 
 from lib_identity.identity import get_current_user, login_user, register_user
 from lib_identity.models.identity import Token, UserCreate, UserPublic
 from lib_softtrack.tables import User
+from lib_utils.rate_limit import (
+    address_of,
+    login_by_account,
+    login_by_address,
+    registration_by_address,
+)
 from web import get_session
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.post("/register", response_model=Token)
-def register(payload: UserCreate, session: Session = Depends(get_session)):
+def register(
+    request: Request, payload: UserCreate, session: Session = Depends(get_session)
+):
+    address = address_of(request)
+    registration_by_address.raise_if_locked(address)
+    # Charged before the attempt, and never forgiven: a successful signup
+    # spends budget too, because bulk registration is the thing being limited.
+    registration_by_address.record_attempt(address)
+
     return register_user(
         session=session,
         email=payload.email,
@@ -22,12 +36,31 @@ def register(payload: UserCreate, session: Session = Depends(get_session)):
 
 @router.post("/login", response_model=Token)
 def login(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     session: Session = Depends(get_session),
 ):
-    return login_user(
-        session=session, email=form_data.username, password=form_data.password
-    )
+    # The throttle lives here rather than in the service because it needs the
+    # request to know who is asking, and it needs the outcome to know whether
+    # to charge for it -- a dependency can see the first but not the second.
+    address = address_of(request)
+    account = form_data.username.strip().lower()
+
+    login_by_address.raise_if_locked(address)
+    login_by_account.raise_if_locked(account)
+
+    try:
+        token = login_user(
+            session=session, email=form_data.username, password=form_data.password
+        )
+    except HTTPException:
+        login_by_address.record_attempt(address)
+        login_by_account.record_attempt(account)
+        raise
+
+    login_by_address.forgive(address)
+    login_by_account.forgive(account)
+    return token
 
 
 @router.get("/me", response_model=UserPublic)

--- a/backend/lib_identity/identity.py
+++ b/backend/lib_identity/identity.py
@@ -1,6 +1,8 @@
 """Identity services: registration, login, and resolving the current user."""
 
 import hashlib
+import secrets
+from functools import lru_cache
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -75,9 +77,33 @@ def register_user(session: Session, email: str, password: str, full_name: str) -
     return Token(access_token=token, user=UserPublic.model_validate(user))
 
 
+@lru_cache(maxsize=1)
+def _unmatchable_hash() -> str:
+    """A bcrypt hash of a random string, so no password can ever match it.
+
+    Computed once, lazily, because bcrypt at the default cost takes a
+    noticeable fraction of a second and importing this module should not.
+    """
+    return hash_password(secrets.token_urlsafe(32))
+
+
+def warm_password_hasher() -> None:
+    """Fill the decoy-hash cache at startup. See `_unmatchable_hash`."""
+    _unmatchable_hash()
+
+
 def login_user(session: Session, email: str, password: str) -> Token:
     user = session.exec(select(User).where(User.email == email)).first()
-    if not user or not verify_password(password, user.hashed_password):
+
+    # Verify against a hash that cannot match rather than returning early, so
+    # an unknown address costs the same ~100ms of bcrypt as a known one with
+    # the wrong password. The early return was a clean timing oracle: the two
+    # answers are worded identically, but one came back in microseconds, which
+    # told an attacker exactly which addresses have accounts here.
+    hashed = user.hashed_password if user else _unmatchable_hash()
+    password_matches = verify_password(password, hashed)
+
+    if not user or not password_matches:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",

--- a/backend/lib_utils/rate_limit.py
+++ b/backend/lib_utils/rate_limit.py
@@ -1,0 +1,179 @@
+"""A small in-process throttle, used to slow down credential guessing.
+
+Scope, stated up front: the counters live in this process's memory. One
+container running one worker -- what `docker compose up` gives you -- is
+exactly covered. Run several workers or replicas and each keeps its own
+counters, so the effective budget multiplies by the number of processes.
+That is still far better than the unlimited attempts we had, and it needs no
+Redis to deploy. When SoftTrack grows a shared cache, `Throttle` is the one
+class to reimplement against it; nothing else has to change.
+"""
+
+import threading
+from dataclasses import dataclass, field
+from math import ceil
+from typing import Callable
+
+from fastapi import HTTPException, Request, status
+
+# Sweeping every write would be O(n) on a dict that is usually tiny, so only
+# bother once it has grown enough to be worth the walk. This is the bound on
+# how much memory a flood of distinct addresses can cost us.
+_PRUNE_ABOVE = 10_000
+
+
+@dataclass
+class _Record:
+    attempts: int = 0
+    last_attempt: float = 0.0
+    locked_until: float = 0.0
+
+
+@dataclass
+class Throttle:
+    """Counts attempts against a key and locks it out for a growing delay.
+
+    `free_attempts` attempts get through untouched -- people mistype
+    passwords. The next one is refused, and every further attempt doubles the
+    wait, from `base_delay` up to `max_delay`. A key that goes quiet for
+    `forget_after` seconds is forgotten entirely, so an honest user is never
+    carrying yesterday's typos.
+    """
+
+    name: str
+    free_attempts: int
+    base_delay: float
+    max_delay: float
+    forget_after: float
+    clock: Callable[[], float] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.clock is None:
+            # Monotonic, not wall time: the lockout has to survive an NTP step
+            # or a daylight-saving jump without either expiring early or
+            # stranding someone for an hour.
+            import time
+
+            self.clock = time.monotonic
+        self._lock = threading.Lock()
+        self._records: dict[str, _Record] = {}
+
+    def raise_if_locked(self, key: str) -> None:
+        """Reject the request with 429 while `key` is serving a lockout."""
+        with self._lock:
+            record = self._records.get(key)
+            if record is None:
+                return
+            remaining = record.locked_until - self.clock()
+            if remaining <= 0:
+                return
+        retry_after = max(1, ceil(remaining))
+        unit = "second" if retry_after == 1 else "seconds"
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Too many {self.name}. Try again in {retry_after} {unit}.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    def record_attempt(self, key: str) -> None:
+        """Spend one attempt from `key`'s budget, extending the lockout."""
+        now = self.clock()
+        with self._lock:
+            record = self._records.get(key)
+            if record is None or self._is_expired(record, now):
+                record = _Record()
+                self._records[key] = record
+
+            record.attempts += 1
+            record.last_attempt = now
+
+            # The lockout starts once the budget is spent, so the attempt
+            # after the last free one is the first to be refused.
+            over = record.attempts - self.free_attempts
+            if over >= 0:
+                delay = min(self.base_delay * 2**over, self.max_delay)
+                record.locked_until = now + delay
+
+            if len(self._records) > _PRUNE_ABOVE:
+                self._prune(now)
+
+    def forgive(self, key: str) -> None:
+        """Clear `key`'s record. Called when the attempt succeeded."""
+        with self._lock:
+            self._records.pop(key, None)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._records.clear()
+
+    def _is_expired(self, record: _Record, now: float) -> bool:
+        # Never forget a key that is still locked out, however long the
+        # lockout ran -- otherwise a long enough backoff would erase itself.
+        return (
+            now > record.last_attempt + self.forget_after and now > record.locked_until
+        )
+
+    def _prune(self, now: float) -> None:
+        for key in [k for k, r in self._records.items() if self._is_expired(r, now)]:
+            del self._records[key]
+
+
+# Per address, login. Generous, because a whole office can share one address
+# through NAT and one person's bad afternoon should not lock out the floor.
+login_by_address = Throttle(
+    name="failed sign-in attempts from this address",
+    free_attempts=10,
+    base_delay=1.0,
+    max_delay=15 * 60.0,
+    forget_after=15 * 60.0,
+)
+
+# Per account, login. This one catches a password spray spread across many
+# addresses, which the limiter above cannot see.
+#
+# The short cap is deliberate. A per-account lockout is itself an attack: if
+# it grew without bound, anyone who knows your address could lock you out of
+# your own account by failing five sign-ins. Capping the delay at a minute
+# still costs an attacker everything -- roughly one guess a minute against a
+# given account -- while the worst a griefer can do to you is make you wait.
+login_by_account = Throttle(
+    name="failed sign-in attempts for this account",
+    free_attempts=5,
+    base_delay=1.0,
+    max_delay=60.0,
+    forget_after=15 * 60.0,
+)
+
+# Per address, registration. Every attempt counts here, successes included:
+# the thing being limited is bulk signup and address enumeration through the
+# "Email already registered" response, and both look like success.
+registration_by_address = Throttle(
+    name="registrations from this address",
+    free_attempts=10,
+    base_delay=15.0,
+    max_delay=60 * 60.0,
+    forget_after=60 * 60.0,
+)
+
+_ALL = (login_by_address, login_by_account, registration_by_address)
+
+
+def reset_all() -> None:
+    """Drop every counter. For tests, which must not inherit each other's."""
+    for throttle in _ALL:
+        throttle.reset()
+
+
+def address_of(request: Request) -> str:
+    """The client address to charge this request to.
+
+    Deliberately `request.client`, never the `X-Forwarded-For` header: any
+    client can send that header, so trusting it here would let an attacker
+    pick a fresh identity per request and walk straight past the limiter.
+
+    Behind a real proxy, `request.client` is the proxy and every user shares
+    one bucket. The fix belongs in the deployment, not here -- run uvicorn
+    with `--proxy-headers --forwarded-allow-ips=<your proxy>` and Starlette
+    rewrites `request.client` from the header it can now trust.
+    """
+    return request.client.host if request.client else "unknown"

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app_identity.identity import router as identity_router
+from lib_identity.identity import warm_password_hasher
 from app_softtrack.comments import router as comments_router
 from app_softtrack.issues import router as issues_router
 from app_softtrack.labels import router as labels_router
@@ -16,6 +17,10 @@ from web import init_db, settings
 async def lifespan(app: FastAPI):
     """Startup and shutdown. Replaces the deprecated @app.on_event hooks."""
     init_db()
+    # Pay for the decoy hash now rather than on the first sign-in attempt at
+    # an unknown address, which would otherwise be measurably slower than
+    # every one after it -- a one-shot version of the oracle we just closed.
+    warm_password_hasher()
     yield
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,6 +36,21 @@ def _enforce_sqlite_foreign_keys(dbapi_connection, _record):
     cursor.close()
 
 
+@pytest.fixture(autouse=True)
+def _reset_auth_throttles():
+    """Keep the login/registration counters from leaking between tests.
+
+    They are module-level singletons, so without this a test that exhausts a
+    budget would 429 the next test that happens to register a user -- and
+    which test that is would depend on collection order.
+    """
+    from lib_utils.rate_limit import reset_all
+
+    reset_all()
+    yield
+    reset_all()
+
+
 @pytest.fixture(name="session")
 def session_fixture():
     engine = create_engine(

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,288 @@
+"""Tests for the authentication throttle (issue #8).
+
+The `Throttle` unit tests drive a fake clock rather than sleeping, so the
+backoff schedule is checked exactly and the suite stays instant.
+"""
+
+import pytest
+
+from lib_utils.rate_limit import (
+    Throttle,
+    login_by_account,
+    login_by_address,
+    registration_by_address,
+)
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_throttle(clock, **overrides) -> Throttle:
+    kwargs = dict(
+        name="attempts",
+        free_attempts=3,
+        base_delay=2.0,
+        max_delay=16.0,
+        forget_after=100.0,
+        clock=clock,
+    )
+    kwargs.update(overrides)
+    return Throttle(**kwargs)
+
+
+def lockout_seconds(throttle, key) -> float:
+    """How long `key` is locked out for, or 0 if it is not."""
+    try:
+        throttle.raise_if_locked(key)
+    except Exception as exc:  # HTTPException
+        return float(exc.headers["Retry-After"])
+    return 0.0
+
+
+def test_the_free_attempts_cost_nothing():
+    """Three attempts get through; the fourth is the one that is refused."""
+    throttle = make_throttle(FakeClock())
+    for _ in range(2):
+        throttle.record_attempt("k")
+    assert lockout_seconds(throttle, "k") == 0
+
+    throttle.record_attempt("k")
+    assert lockout_seconds(throttle, "k") > 0
+
+
+def test_the_delay_doubles_and_then_stops_at_the_cap():
+    clock = FakeClock()
+    throttle = make_throttle(clock)
+    for _ in range(2):
+        throttle.record_attempt("k")
+
+    # base_delay 2s, doubling from the third attempt, capped at 16s.
+    for expected in [2, 4, 8, 16, 16, 16]:
+        throttle.record_attempt("k")
+        assert lockout_seconds(throttle, "k") == expected
+        clock.advance(expected)
+
+
+def test_the_lockout_ends_when_it_says_it_will():
+    clock = FakeClock()
+    throttle = make_throttle(clock)
+    for _ in range(3):
+        throttle.record_attempt("k")
+
+    assert lockout_seconds(throttle, "k") == 2
+    clock.advance(2)
+    assert lockout_seconds(throttle, "k") == 0
+
+
+def test_a_key_that_goes_quiet_is_forgotten():
+    clock = FakeClock()
+    throttle = make_throttle(clock)
+    for _ in range(5):
+        throttle.record_attempt("k")
+
+    clock.advance(200)  # past forget_after, and past the 4s lockout
+    throttle.record_attempt("k")
+    assert lockout_seconds(throttle, "k") == 0, "yesterday's typos should not count"
+
+
+def test_a_long_lockout_does_not_erase_itself():
+    """`forget_after` must never expire a key that is still serving time."""
+    clock = FakeClock()
+    throttle = make_throttle(clock, max_delay=500.0, forget_after=10.0)
+    for _ in range(8):
+        throttle.record_attempt("k")
+
+    clock.advance(50)  # well past forget_after, well inside the lockout
+    assert lockout_seconds(throttle, "k") > 0
+
+
+def test_keys_do_not_share_a_budget():
+    throttle = make_throttle(FakeClock())
+    for _ in range(6):
+        throttle.record_attempt("noisy")
+    assert lockout_seconds(throttle, "noisy") > 0
+    assert lockout_seconds(throttle, "quiet") == 0
+
+
+def test_success_clears_the_record():
+    throttle = make_throttle(FakeClock())
+    for _ in range(6):
+        throttle.record_attempt("k")
+    assert lockout_seconds(throttle, "k") > 0
+
+    throttle.forgive("k")
+    assert lockout_seconds(throttle, "k") == 0
+
+
+def test_the_wait_is_worded_for_a_human_to_read():
+    clock = FakeClock()
+    throttle = make_throttle(clock, base_delay=1.0, max_delay=60.0)
+    for _ in range(3):
+        throttle.record_attempt("k")
+
+    with pytest.raises(Exception) as one:
+        throttle.raise_if_locked("k")
+    assert "in 1 second." in one.value.detail
+
+    throttle.record_attempt("k")
+    with pytest.raises(Exception) as two:
+        throttle.raise_if_locked("k")
+    assert "in 2 seconds." in two.value.detail
+
+
+def test_a_griefer_cannot_lock_someone_out_for_long():
+    """The per-account cap bounds the damage a third party can do.
+
+    Anyone who knows your address can fail sign-ins as you. That must cost
+    them a brute-force budget without handing them a way to keep you out of
+    your own account, so this delay is capped where the per-address one is not.
+    """
+    assert login_by_account.max_delay <= 60
+    assert login_by_account.max_delay < login_by_address.max_delay
+
+
+# --- through the API ---------------------------------------------------
+
+
+def failed_login(client, email="demo@softtrack.dev", password="wrong"):
+    return client.post("/auth/login", data={"username": email, "password": password})
+
+
+def test_repeated_wrong_passwords_start_getting_429(client, auth):
+    auth()
+
+    # login_by_account allows five, so the sixth is the first refusal.
+    for _ in range(5):
+        assert failed_login(client).status_code == 401
+
+    response = failed_login(client)
+    assert response.status_code == 429
+    assert int(response.headers["Retry-After"]) >= 1
+    assert "sign-in" in response.json()["detail"]
+
+
+def test_the_right_password_still_works_before_the_budget_runs_out(client, auth):
+    auth()
+    for _ in range(3):
+        assert failed_login(client).status_code == 401
+
+    response = client.post(
+        "/auth/login",
+        data={"username": "demo@softtrack.dev", "password": "password123"},
+    )
+    assert response.status_code == 200
+
+
+def test_signing_in_clears_the_counter(client, auth):
+    auth()
+    for _ in range(4):
+        failed_login(client)
+
+    client.post(
+        "/auth/login",
+        data={"username": "demo@softtrack.dev", "password": "password123"},
+    )
+
+    # Back to a full budget: four more failures must not trip the limit.
+    for _ in range(4):
+        assert failed_login(client).status_code == 401
+
+
+def test_spraying_many_addresses_still_trips_the_per_address_limit(client):
+    """This is what the per-address throttle is for.
+
+    One guess each against ten different addresses never spends any single
+    account's budget, so the account throttle cannot see it. Enumerating who
+    has an account here is exactly that shape of traffic.
+    """
+    for i in range(10):
+        response = failed_login(client, email=f"nobody{i}@example.com")
+        assert response.status_code == 401, f"attempt {i} should not be limited yet"
+
+    assert failed_login(client, email="nobody10@example.com").status_code == 429
+
+
+def test_registration_is_capped_per_address(client):
+    for i in range(10):
+        response = client.post(
+            "/auth/register",
+            json={
+                "email": f"user{i}@example.com",
+                "password": "password123",
+                "full_name": "User",
+            },
+        )
+        assert response.status_code == 200, response.text
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "one-too-many@example.com",
+            "password": "password123",
+            "full_name": "User",
+        },
+    )
+    assert response.status_code == 429
+    assert "registrations" in response.json()["detail"]
+
+
+def test_an_unknown_address_costs_the_same_work_as_a_wrong_password(
+    client, auth, monkeypatch
+):
+    """Guard the timing oracle by counting the bcrypt calls, not the clock.
+
+    Timing assertions are flaky on shared CI runners. The invariant that
+    actually matters is that both paths run one password verification, and
+    that is exact.
+    """
+    import lib_identity.identity as identity
+
+    calls = []
+    real = identity.verify_password
+    monkeypatch.setattr(
+        identity,
+        "verify_password",
+        lambda plain, hashed: calls.append(hashed) or real(plain, hashed),
+    )
+
+    auth()
+
+    failed_login(client, email="demo@softtrack.dev")
+    known_user_calls = len(calls)
+    calls.clear()
+
+    failed_login(client, email="nobody@example.com")
+    unknown_user_calls = len(calls)
+
+    assert known_user_calls == 1
+    assert (
+        unknown_user_calls == 1
+    ), "an unknown address must still pay for a bcrypt verify"
+
+
+def test_the_two_failures_are_worded_identically(client, auth):
+    auth()
+    known = failed_login(client, email="demo@softtrack.dev")
+    unknown = failed_login(client, email="nobody@example.com")
+
+    assert known.status_code == unknown.status_code == 401
+    assert known.json() == unknown.json()
+
+
+@pytest.mark.parametrize(
+    "throttle",
+    [login_by_address, login_by_account, registration_by_address],
+    ids=["login_by_address", "login_by_account", "registration_by_address"],
+)
+def test_every_throttle_forgets_eventually(throttle):
+    """No throttle may lock a key out permanently."""
+    assert throttle.max_delay < float("inf")
+    assert throttle.forget_after > 0

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,5 @@
+/** Pull the API's `detail` string out of an axios error. */
+export function errorDetail(err: unknown, fallback: string): string {
+  const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+  return typeof detail === 'string' && detail.length > 0 ? detail : fallback
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../auth/AuthContext'
 import { Logo } from '../components/Logo'
+import { errorDetail } from '../api/errors'
 
 export default function LoginPage() {
   const { login } = useAuth()
@@ -23,8 +24,13 @@ export default function LoginPage() {
     try {
       await login(email, password)
       navigate(from, { replace: true })
-    } catch {
-      setError('Incorrect email or password.')
+    } catch (err: unknown) {
+      // Surface what the API said rather than always blaming the password.
+      // Sign-in is rate limited, and a throttled person told "incorrect
+      // password" just retries -- straight into a longer backoff. The 401 text
+      // is identical for a wrong password and an unknown address, so showing
+      // it leaks nothing.
+      setError(errorDetail(err, 'Incorrect email or password.'))
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../auth/AuthContext'
 import { Logo } from '../components/Logo'
+import { errorDetail } from '../api/errors'
 
 export default function RegisterPage() {
   const { register } = useAuth()
@@ -22,9 +23,7 @@ export default function RegisterPage() {
       await register(email, password, fullName)
       navigate('/', { replace: true })
     } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
-        ?.detail
-      setError(detail ?? 'Could not create your account.')
+      setError(errorDetail(err, 'Could not create your account.'))
     } finally {
       setSubmitting(false)
     }


### PR DESCRIPTION
Closes #8

`/auth/login` and `/auth/register` accepted unlimited attempts. Login was a password oracle an attacker could work through as fast as the server answered.

## The throttle

`lib_utils/rate_limit.py` adds one small class. A key gets `free_attempts` for nothing -- people mistype passwords -- and then each further attempt doubles the lockout, up to a cap. A key that goes quiet is forgotten, so an honest user is never carrying yesterday's typos. Refusals are **429** with `Retry-After`; a successful sign-in clears the counters.

| Bucket | Free | Backoff | Cap |
|---|---|---|---|
| Failed sign-ins per address | 10 | doubles from 1s | 15 min |
| Failed sign-ins per account | 5 | doubles from 1s | 1 min |
| Registrations per address | 10 | doubles from 15s | 1 hour |

Registration charges **every** attempt, successes included: the things being limited are bulk signup and address enumeration through "Email already registered", and both of those look like success.

**Why the per-account cap is the short one.** A per-account lockout is itself an attack. Uncapped, anyone who knows your address could keep you out of your own account by failing five sign-ins. A minute still costs an attacker essentially everything -- about one guess per account per minute, which kills a password spray -- while the worst a griefer can do to you is make you wait. The per-address bucket is the one that gets the long lockout, and it is generous because a whole office can share one address through NAT.

## The timing oracle

Fixing the rate limit alone would have left the enumeration channel open. `login_user` verified the password only when the user existed, so the two identically worded failures came back about 250ms apart -- which told an attacker precisely which addresses have accounts here.

Both paths now run exactly one bcrypt verify; the unknown-address path checks against a hash of a random string that nothing can match. Measured on the running stack, six samples each, staying inside the budget so no 429 could shortcut a reading:

    known address   median 247.5 ms
    unknown address median 248.9 ms
    gap 1.4 ms

The decoy hash is computed at startup, so the first unknown-address sign-in after a boot is not the odd one out either -- that was a one-shot version of the same leak, 462ms against 248ms before the warm-up.

## The login page

It hard-coded `Incorrect email or password.` for every failure. A throttled person would have been told their password was wrong and gone right on retrying, into a longer backoff each time. It now shows what the API actually said, sharing one `errorDetail` helper with the registration page, which already did this. The 401 text is identical for a wrong password and an unknown address, so surfacing it leaks nothing.

## Two limits, documented rather than papered over

Both are in the README:

- **The counters are per process.** They cover the single-worker container this repo ships. Replicas each keep their own, so the real budget multiplies by the process count. `Throttle` is the one class to reimplement against a shared cache if you outgrow that.
- **`X-Forwarded-For` is deliberately ignored.** Any client can set it, so trusting it here would let an attacker mint a fresh identity per request and walk straight past the limiter. Behind a proxy the right fix is `--proxy-headers --forwarded-allow-ips=<proxy>`, which lets Starlette rewrite the client address from a header it can trust.

## Verification

- 18 new tests. The `Throttle` unit tests drive an injected fake clock, so the backoff schedule is checked exactly and nothing sleeps.
- The timing test counts bcrypt calls rather than milliseconds -- timing assertions are flaky on shared runners, and "both paths run one verify" is the invariant that actually matters.
- An autouse fixture resets the throttles between tests; they are module singletons, and without it a test that spent a budget would 429 whichever test happened to run next.
- End to end on the Docker stack: the sixth wrong password returns 429 with `Retry-After`, the right password still signs in and clears the counter, `smoke_test.sh` passes, and the browser shows *"Too many failed sign-in attempts for this account. Try again in 1 second."*

```
43 files would be left unchanged.
Required test coverage of 85% reached. Total coverage: 93.67%
61 passed
```

`openapi.json` is unchanged -- `Request` is not part of the schema.