### PR TITLE
Add issue forms, a PR template, CONTRIBUTING.md and a code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something in SoftTrack does not work the way it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this. The more precisely you can
+        pin down what you did and what happened, the faster it gets fixed.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+      placeholder: |
+        Deleting an issue that has labels returns 500 instead of 204.
+        I expected the issue and its label links to be removed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How to reproduce it
+      description: >
+        Numbered steps from a clean start. A curl command or a failing test is
+        even better than prose -- if you can express the bug as a test that
+        fails, paste it here and the fix comes with its own proof.
+      placeholder: |
+        1. docker compose up --build
+        2. Sign in as demo@softtrack.dev
+        3. Create an issue and attach a label
+        4. DELETE /issues/{id}
+    validations:
+      required: true
+
+  - type: dropdown
+    id: how-running
+    attributes:
+      label: How are you running it?
+      options:
+        - Docker Compose (the default)
+        - Backend and frontend started by hand
+        - Something else (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: database
+    attributes:
+      label: Database
+      description: Postgres (the Docker default) or SQLite, and the version if you know it.
+      placeholder: Postgres 16 via docker compose
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: >
+        The commit you are on -- `git rev-parse --short HEAD`. This matters more
+        than it looks: half of "cannot reproduce" turns out to be a stale branch.
+      placeholder: 8d835b6
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: >
+        Relevant output from `docker compose logs backend`, and the browser
+        console if the problem is in the UI. Pasted text beats a screenshot --
+        it is searchable.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+# Discussions is not enabled on this repository, so there is nowhere else to
+# send people. Blank issues stay on: a question that does not fit either
+# template is still worth having.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Something SoftTrack should be able to do and cannot.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a look at the [Roadmap](https://github.com/soft-track/soft-track#roadmap)
+        first -- it may already be there, in which case a comment on the
+        existing issue is more useful than a new one.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: >
+        The problem, not the solution. "I cannot tell which issues are blocked
+        on someone else" leads somewhere better than "add a Blocked column",
+        because it leaves room for a better answer than the one you had in mind.
+      placeholder: |
+        When I open the board on Monday I cannot tell which of my issues moved
+        over the weekend, so I re-read all of them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What do you think should happen?
+      description: If you already have a shape in mind, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What are you doing instead today?
+      description: >
+        The workaround, if you have one. How annoying the workaround is tells us
+        how much the feature is worth.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Would you like to build it?
+      options:
+        - label: I would be willing to open a pull request for this
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What this changes
+
+<!-- One or two sentences. If it closes an issue, say "Closes #123" and the
+     issue will close when this merges. -->
+
+## Why
+
+<!-- The problem this solves. If the reasoning is already in the issue, a link
+     is enough -- but say what changed your mind if you took a different
+     approach than the issue proposed. -->
+
+## How it was verified
+
+<!-- Not "tests pass" -- what did you actually run, and what did you see?
+     Paste the output if it is short. For a bug fix, the most useful thing you
+     can show is that the new test fails without your change. -->
+
+## Checklist
+
+- [ ] `cd backend && black . && pytest` passes
+- [ ] If backend routes or schemas changed, the API client was regenerated and committed (`npm run export:openapi && npm run generate:api` in `frontend/`)
+- [ ] If the schema changed, there is an Alembic migration and I have read what autogenerate wrote
+- [ ] New behaviour has a test, and I checked that the test fails without the change
+- [ ] Business logic went in `lib_softtrack/`, not in a route handler
+
+<!-- Not every box applies to every PR. Say so rather than ticking one that
+     does not -- "no schema change" is a perfectly good answer. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,87 @@
+# Code of Conduct
+
+## The short version
+
+Be someone people want to work with. Assume the other person is acting in good
+faith, especially when you disagree with them.
+
+## What this asks of you
+
+SoftTrack is worked on by people in different countries, timezones, jobs and
+levels of experience, most of them doing it in time they could be spending
+elsewhere. That only holds together if participating here is pleasant.
+
+So, when you take part in this project — issues, pull requests, reviews,
+commit messages, anywhere the project's name is on it:
+
+- **Critique the work, not the person.** "This query runs once per row" is a
+  review. "Did you even test this?" is not, and it gets you a worse answer.
+- **Assume competence.** Someone who did something you find strange usually had
+  a reason. Ask what it was before explaining why they were wrong.
+- **Be patient with beginners.** Everyone writes their first pull request
+  once. A project that is unpleasant to a newcomer stops getting newcomers.
+- **Take the correction.** If you got something wrong, say so and move on. If
+  someone tells you their name or pronouns, use them.
+- **Respect the maintainers' time.** "Any update on this?" once is fine.
+  Weekly is not. Nobody here owes you a review on a schedule.
+
+## What is not acceptable
+
+- Harassment of any kind, public or private
+- Insults, or attacks based on who someone is — their gender, gender identity,
+  sexual orientation, disability, appearance, body size, race, ethnicity, age,
+  religion, nationality, or first language
+- Sexual language or imagery, and unwelcome sexual attention
+- Publishing someone's private information without their explicit permission
+- Sustained disruption: derailing threads, reopening settled arguments,
+  brigading a decision you lost
+- Deliberately introducing malicious code, or misrepresenting what a change
+  does
+
+Contributing in a language that is not your first is *not* a conduct problem,
+and neither is bluntness that comes from writing in one. Read generously.
+
+## Where this applies
+
+Anywhere the project happens: this repository, and any space where you are
+representing SoftTrack. Behaviour outside these spaces can be grounds for
+action here if it makes someone unsafe participating in the project.
+
+## Reporting
+
+If someone's behaviour is a problem, tell the maintainers. Do not open a public
+issue — that puts the person reporting in the worst position in the thread.
+
+Use GitHub's private reporting form:
+**[Report privately](https://github.com/soft-track/soft-track/security/advisories/new)**.
+It is meant for security reports, but it is the private channel this repository
+has, and it reaches the maintainers and nobody else. Say up front that it is a
+conduct report.
+
+Reports are read by the maintainers, kept confidential, and answered. You will
+not be asked to justify feeling uncomfortable, and reporting something in good
+faith will never be held against you — including when the answer turns out to
+be that no action is warranted.
+
+## What happens next
+
+Depending on what happened, and taking a first offence differently from a
+pattern:
+
+1. **A private word.** What was wrong and what to do instead. Most things end
+   here.
+2. **A warning.** Formal, and on the record.
+3. **A temporary ban** from participating in the project.
+4. **A permanent ban.**
+
+Maintainers who break these rules are held to them more strictly than anyone
+else, not less. Maintainers will also remove comments, commits, issues and
+pull requests that are not in keeping with this document, and will say when
+they have.
+
+---
+
+This code of conduct was written for SoftTrack. If you are looking for a
+standard one for your own project, the
+[Contributor Covenant](https://www.contributor-covenant.org/) is the one most
+projects use, and it has been translated into many languages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to SoftTrack
+
+Thanks for being here. SoftTrack is a small project, so this document is short
+and describes what actually happens rather than what a bigger process would
+look like.
+
+## Getting it running
+
+You need Docker. That is the whole list.
+
+```bash
+git clone https://github.com/soft-track/soft-track.git
+cd soft-track
+docker compose up --build
+```
+
+The frontend is on <http://localhost:5173>, the API on
+<http://localhost:8000>, and interactive API docs on
+<http://localhost:8000/docs>. Postgres runs in the stack too, so there is
+nothing to install locally. The database is seeded with a demo account:
+`demo@softtrack.dev` / `password123`.
+
+Confirm the whole thing works end to end before you change anything, so you
+know whether a later failure is yours:
+
+```bash
+cd backend && ./smoke_test.sh
+```
+
+If you would rather run the backend and frontend directly, the README's
+[Quickstart](README.md#quickstart-without-docker) covers it.
+
+## Running the checks
+
+CI runs four jobs on every pull request, and all four run locally. Run them
+before you push -- it is faster than waiting for a red build.
+
+```bash
+cd backend
+black .                                    # formatting; CI runs --check
+pytest --cov --cov-fail-under=85           # tests and the coverage floor
+```
+
+```bash
+cd frontend
+npx oxlint src/                            # lint
+npx tsc -b --noEmit                        # typecheck
+npm run build                              # the build must succeed
+```
+
+The fourth job regenerates `backend/openapi.json` and fails if it differs from
+what is committed. See below.
+
+## Three things worth knowing before you open a PR
+
+**The API client is generated, and it is committed.** Everything under
+`frontend/src/api/generated/` comes from the backend's OpenAPI schema via
+Orval. If you change a route, a request body or a response model, regenerate it
+and commit the result:
+
+```bash
+cd frontend
+npm run export:openapi     # writes backend/openapi.json from the live schema
+npm run generate:api       # regenerates the client from it
+```
+
+This is the one task Docker alone does not cover: `export:openapi` imports the
+app, so it needs the backend's virtualenv at `backend/venv` (the
+[Quickstart](README.md#1-backend) sets one up). CI fails if you forget. That check exists because a frontend and backend that
+disagree about a payload fail confusingly at runtime rather than loudly at
+build time.
+
+**Business logic goes in the service layer.** The backend is thin routers over
+services: `app_softtrack/issues.py` parses the request and calls
+`lib_softtrack/issues.py`, which does the work. A route handler should be
+short enough to read in one go. Logic in a handler is hard to test without
+HTTP and tends to get copied the next time a second route needs it.
+
+**Schema changes need a migration.** The schema is managed by Alembic and
+applied on startup, so `docker compose up` is enough for a contributor. When
+you change a table:
+
+```bash
+cd backend
+alembic revision --autogenerate -m "add x to y"
+alembic upgrade head
+```
+
+Then *read the generated file*. Autogenerate is reliable for added tables,
+columns and indexes, and unreliable for server defaults, constraint renames,
+and anything that has to move data. It also does not import `sqlmodel` on its
+own for `AutoString` columns -- check the imports at the top.
+
+## Tests
+
+Every behaviour change should come with a test, and the test should fail
+without your change. That second half is the part people skip, and it is the
+part that matters: a test that passes either way proves nothing. Run it against
+the unfixed code once, watch it fail, then fix the code.
+
+Tests run against in-memory SQLite with foreign keys switched on, so they
+behave like the Postgres the stack actually uses. `backend/tests/conftest.py`
+explains why, and which bug got through when they did not.
+
+## Opening the pull request
+
+Small and focused beats large and complete. One issue per PR is ideal; if you
+find a second problem on the way, an issue for it is more useful than a bigger
+diff.
+
+Say how you verified the change, not just that you did. "The sixth wrong
+password returns 429 with `Retry-After: 1`" tells a reviewer something;
+"tested" does not.
+
+If you are picking up an open issue, a comment saying so avoids two people
+doing the same work. Issues labelled `good first issue` are the ones with the
+clearest boundaries.
+
+## Reporting a security problem
+
+Please do not open a public issue. Use GitHub's private reporting instead:
+**[Report a vulnerability](https://github.com/soft-track/soft-track/security/advisories/new)**.
+It reaches the maintainers and nobody else.
+
+## Code of conduct
+
+By taking part you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -254,20 +254,17 @@ generated from, so drift there means the client and the API disagree.
 
 ## Contributing
 
-Issues and pull requests are welcome. A good first step is `docker compose up
---build` to get the stack running, then `backend/smoke_test.sh` to confirm the
-API works end to end.
+Issues and pull requests are welcome, and there are
+[good first issues](https://github.com/soft-track/soft-track/labels/good%20first%20issue)
+open. **[CONTRIBUTING.md](CONTRIBUTING.md)** covers setup, the checks CI runs,
+and the three project conventions worth knowing before you open a PR: the API
+client is generated *and committed*, business logic belongs in `lib_softtrack/`
+rather than in a route handler, and schema changes need an Alembic migration.
 
-Two things worth knowing before you open a PR:
-
-- The frontend's API client under `frontend/src/api/generated/` is generated
-  from the backend's OpenAPI schema and **is committed**. If you change backend
-  routes or schemas, regenerate it (see
-  [Regenerating the API client](#regenerating-the-api-client)) and commit the
-  result, or the frontend and backend will drift apart.
-- The backend is organised as thin routers (`app_*`) over a service layer
-  (`lib_*`). Business logic belongs in `lib_softtrack/`, not in the route
-  handler.
+Everyone taking part is asked to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md). Security problems should go through
+[private reporting](https://github.com/soft-track/soft-track/security/advisories/new),
+not a public issue.
 
 ## License
 


### PR DESCRIPTION
Closes #28

The repository has been public with nothing telling people how to take part, so every issue and PR arrives in a different shape.

### Issue forms

Two of them, using GitHub's YAML forms rather than markdown templates so the fields are actually required.

The bug form asks for **the commit** (`git rev-parse --short HEAD`), because a stale branch accounts for a good share of "cannot reproduce", and asks for logs **as text** rather than a screenshot, because text is searchable. It also nudges toward a failing test as the reproduction, since that makes the fix come with its own proof.

The feature form asks for the **problem before the proposed solution** -- "I cannot tell which issues moved over the weekend" leads somewhere better than "add a column", because it leaves room for a better answer than the reporter had in mind.

Discussions is not enabled on this repository, so `config.yml` links nowhere else; blank issues stay on so a question that fits neither form still has a home.

### PR template

It asks **how** a change was verified, not whether it was -- "the sixth wrong password returns 429 with `Retry-After: 1`" tells a reviewer something that "tested" does not. The checklist covers the three things this codebase actually bites people on: the generated API client is committed, schema changes need a migration, and business logic goes in the service layer. It also says explicitly that not every box applies, so nobody ticks one that does not.

### CONTRIBUTING.md

The long form, with one honest caveat: regenerating the API client is the single task `docker compose` does not cover, because `export:openapi` imports the app and needs the backend virtualenv. Better to say so than to let someone find out.

Every command in it was run before it was written down -- including `npm run export:openapi`, which is how I caught that the script is called `generate:api` and not `codegen`.

### CODE_OF_CONDUCT.md

Written for this project rather than adapted from a template, and it points people at the [Contributor Covenant](https://www.contributor-covenant.org/) if that is what they came looking for. It says plainly that bluntness from writing in a second language is not a conduct problem, and that maintainers are held to the rules more strictly than anyone else rather than less.

### README

The Contributing section now points at CONTRIBUTING.md instead of restating a shorter version of it, so the two cannot drift apart.

---

**One thing to do after merging:** both this PR's docs and the code of conduct send private reports to `/security/advisories/new`, and **private vulnerability reporting is currently disabled** on this repository (`{"enabled": false}` from the API), so that link will not work for anyone outside the org. It is one checkbox in **Settings -> Code security -> Private vulnerability reporting**. I have not flipped it -- it is a repository setting and yours to make.

All three issue YAML files parse, and the labels they apply (`bug`, `enhancement`) both exist on the repository.