### PR TITLE
Render descriptions and comments as markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           if-no-files-found: warn
 
   frontend:
-    name: Frontend · lint + typecheck + build
+    name: Frontend · lint + typecheck + test + build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -84,6 +84,9 @@ jobs:
 
       - name: Typecheck
         run: npx tsc -b --noEmit
+
+      - name: Test
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,10 +17,14 @@
         "date-fns": "^4.4.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^7.18.3"
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.18.3",
+        "remark-gfm": "^4.0.1",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
@@ -29,7 +33,8 @@
         "oxlint": "^1.79.0",
         "tailwindcss": "^4.3.3",
         "typescript": "~6.0.2",
-        "vite": "^8.2.2"
+        "vite": "^8.2.2",
+        "vitest": "^5.0.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -2097,15 +2102,71 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
@@ -2121,7 +2182,6 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2141,8 +2201,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.1.1",
@@ -2172,6 +2237,54 @@
         "oxc-transform-react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -2256,6 +2369,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2272,6 +2395,16 @@
         "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -2310,6 +2443,66 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -2345,6 +2538,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2396,7 +2599,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -2426,6 +2628,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2433,6 +2648,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -2443,6 +2667,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dunder-proto": {
@@ -2503,6 +2740,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -2573,6 +2817,38 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2609,6 +2885,22 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2885,6 +3177,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -2908,11 +3250,60 @@
         "node": ">=18.18.0"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3340,6 +3731,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -3385,6 +3786,16 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3394,11 +3805,844 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
       "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/mime-db": {
@@ -3491,6 +4735,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/orval": {
@@ -3626,6 +4884,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -3721,6 +5004,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3759,6 +5052,33 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/react-router": {
@@ -3811,6 +5131,72 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remeda": {
@@ -3915,6 +5301,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3938,6 +5331,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -3946,6 +5363,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-final-newline": {
@@ -3959,6 +5390,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/tailwindcss": {
@@ -3982,6 +5431,26 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3997,6 +5466,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {
@@ -4096,6 +5585,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4104,6 +5680,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -4184,6 +5788,99 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4198,6 +5895,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yaml": {
@@ -4240,6 +5954,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "oxlint",
     "preview": "vite preview",
     "generate:api": "orval",
-    "export:openapi": "cd ../backend && . venv/bin/activate && python export_openapi.py"
+    "export:openapi": "cd ../backend && . venv/bin/activate && python export_openapi.py",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -21,10 +22,14 @@
     "date-fns": "^4.4.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router-dom": "^7.18.3"
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.18.3",
+    "remark-gfm": "^4.0.1",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
@@ -33,6 +38,7 @@
     "oxlint": "^1.79.0",
     "tailwindcss": "^4.3.3",
     "typescript": "~6.0.2",
-    "vite": "^8.2.2"
+    "vite": "^8.2.2",
+    "vitest": "^5.0.0"
   }
 }

--- a/frontend/src/components/IssueDetailPanel.tsx
+++ b/frontend/src/components/IssueDetailPanel.tsx
@@ -6,6 +6,8 @@ import { useCreateCommentIssuesIssueIdCommentsPost, useListCommentsIssuesIssueId
 import { useGetIssueIssuesIssueIdGet, useUpdateIssueIssuesIssueIdPatch } from '../api/generated/endpoints/issues/issues'
 import { IssuePriority, IssueStatus } from '../api/generated/models'
 import { PRIORITY_META, PRIORITY_ORDER, STATUS_META, STATUS_ORDER } from '../lib/issueMeta'
+import { Markdown, MarkdownEditor } from '../markdown/lazy'
+import { taskProgress, toggleTaskAtOffset } from '../markdown/tasks'
 import { useTeamContext } from '../team/TeamContext'
 import { Avatar } from './Avatar'
 import { PriorityIcon } from './PriorityIcon'
@@ -30,6 +32,7 @@ export function IssueDetailPanel({
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [commentBody, setCommentBody] = useState('')
+  const [editingDescription, setEditingDescription] = useState(false)
 
   useEffect(() => {
     if (issue) {
@@ -54,6 +57,21 @@ export function IssueDetailPanel({
   const patch = async (data: Parameters<typeof updateIssue.mutateAsync>[0]['data']) => {
     await updateIssue.mutateAsync({ issueId, data })
     invalidateIssue()
+  }
+
+  const people = members.map((m) => m.user)
+
+  /**
+   * Toggling a checkbox in the rendered description edits the stored markdown
+   * and saves it. The offset comes from the source position of the list item,
+   * so nothing else in the description is touched -- see markdown/tasks.ts.
+   */
+  const onToggleTask = async (offset: number) => {
+    const source = issue?.description ?? ''
+    const next = toggleTaskAtOffset(source, offset)
+    if (next === null) return
+    setDescription(next)
+    await patch({ description: next })
   }
 
   const onSubmitComment = async (event: FormEvent) => {
@@ -100,14 +118,66 @@ export function IssueDetailPanel({
                 onBlur={() => title.trim() && title !== issue.title && patch({ title: title.trim() })}
                 className="w-full border-none p-0 text-lg font-semibold text-neutral-900 focus:outline-none focus:ring-0"
               />
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                onBlur={() => description !== (issue.description ?? '') && patch({ description })}
-                placeholder="Add a description…"
-                rows={5}
-                className="mt-3 w-full resize-none border-none p-0 text-sm text-neutral-600 placeholder-neutral-300 focus:outline-none focus:ring-0"
-              />
+              <div className="mt-3">
+                {editingDescription ? (
+                  <>
+                    <MarkdownEditor
+                      value={description}
+                      onChange={setDescription}
+                      people={people}
+                      placeholder="Add a description… Markdown works here."
+                      rows={8}
+                      autoFocus
+                    />
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          if (description !== (issue.description ?? '')) await patch({ description })
+                          setEditingDescription(false)
+                        }}
+                        className="rounded-md bg-brand-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-700"
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setDescription(issue.description ?? '')
+                          setEditingDescription(false)
+                        }}
+                        className="rounded-md px-2.5 py-1 text-xs font-medium text-neutral-500 hover:text-neutral-700"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </>
+                ) : issue.description?.trim() ? (
+                  <>
+                    <Markdown people={people} onToggleTask={onToggleTask}>
+                      {issue.description}
+                    </Markdown>
+                    <div className="mt-2 flex items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setEditingDescription(true)}
+                        className="text-xs font-medium text-neutral-400 hover:text-neutral-700"
+                      >
+                        Edit description
+                      </button>
+                      <TaskProgress source={issue.description} />
+                    </div>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setEditingDescription(true)}
+                    className="text-sm text-neutral-300 hover:text-neutral-500"
+                  >
+                    Add a description…
+                  </button>
+                )}
+              </div>
 
               <div className="mt-4 space-y-3 rounded-lg border border-neutral-100 bg-neutral-50 p-3">
                 <div className="flex items-center justify-between">
@@ -214,7 +284,9 @@ export function IssueDetailPanel({
                           })}
                         </span>
                       </div>
-                      <p className="whitespace-pre-wrap text-sm text-neutral-700">{comment.body}</p>
+                      {/* Read-only checkboxes: there is no endpoint to edit
+                          a comment yet, so a toggle here could not be saved. */}
+                      <Markdown people={people}>{comment.body}</Markdown>
                     </div>
                   </div>
                 ))}
@@ -223,25 +295,51 @@ export function IssueDetailPanel({
                 )}
               </div>
 
-              <form onSubmit={onSubmitComment} className="flex gap-2">
-                <input
+              <form onSubmit={onSubmitComment}>
+                <MarkdownEditor
                   value={commentBody}
-                  onChange={(e) => setCommentBody(e.target.value)}
+                  onChange={setCommentBody}
+                  people={people}
                   placeholder="Leave a comment…"
-                  className="flex-1 rounded-md border border-neutral-200 px-2.5 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+                  rows={3}
+                  onSubmit={() => void onSubmitComment(new Event('submit') as unknown as FormEvent)}
                 />
-                <button
-                  type="submit"
-                  disabled={!commentBody.trim() || createComment.isPending}
-                  className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
-                >
-                  Send
-                </button>
+                <div className="mt-2 flex items-center justify-end gap-3">
+                  <span className="text-[11px] text-neutral-400">
+                    <span className="identifier">⌘↵</span> to send
+                  </span>
+                  <button
+                    type="submit"
+                    disabled={!commentBody.trim() || createComment.isPending}
+                    className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+                  >
+                    Send
+                  </button>
+                </div>
               </form>
             </div>
           </>
         )}
       </div>
     </div>
+  )
+}
+
+
+/** "3 of 7 tasks" plus a thin bar, shown only when there are tasks. */
+function TaskProgress({ source }: { source: string }) {
+  const { done, total } = taskProgress(source)
+  if (total === 0) return null
+
+  return (
+    <span className="flex items-center gap-2 text-xs text-neutral-400">
+      <span className="h-1 w-16 overflow-hidden rounded-full bg-neutral-100">
+        <span
+          className="block h-full rounded-full bg-brand-500 transition-all"
+          style={{ width: `${(done / total) * 100}%` }}
+        />
+      </span>
+      {done} of {total} tasks
+    </span>
   )
 }

--- a/frontend/src/components/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useState } from 'react'
 import { useCreateIssueTeamsTeamIdIssuesPost } from '../api/generated/endpoints/issues/issues'
 import { IssuePriority, IssueStatus } from '../api/generated/models'
 import { PRIORITY_ORDER, STATUS_ORDER, PRIORITY_META, STATUS_META } from '../lib/issueMeta'
+import { MarkdownEditor } from '../markdown/lazy'
 import { useTeamContext } from '../team/TeamContext'
 
 export function NewIssueModal({ onClose }: { onClose: () => void }) {
@@ -68,12 +69,13 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
               placeholder="Issue title"
               className="w-full border-none p-0 text-base font-medium text-neutral-900 placeholder-neutral-300 focus:outline-none focus:ring-0"
             />
-            <textarea
+            <MarkdownEditor
               value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Add a description…"
-              rows={3}
-              className="mt-2 w-full resize-none border-none p-0 text-sm text-neutral-600 placeholder-neutral-300 focus:outline-none focus:ring-0"
+              onChange={setDescription}
+              people={members.map((m) => m.user)}
+              placeholder="Add a description… Markdown works here."
+              rows={4}
+              className="mt-2"
             />
           </div>
 

--- a/frontend/src/markdown/Markdown.tsx
+++ b/frontend/src/markdown/Markdown.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from 'react'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import type { PluggableList } from 'unified'
+import remarkGfm from 'remark-gfm'
+
+import type { Mentionable } from './mentions'
+import { remarkMentions } from './remarkMentions'
+
+/**
+ * Rendered markdown.
+ *
+ * Safety: react-markdown does not render raw HTML unless `rehype-raw` is added
+ * to the pipeline, and it is deliberately not added here -- a `<script>` or an
+ * `onerror` attribute in a description is text, not markup. Link URLs go
+ * through react-markdown's default transform, which drops `javascript:` and
+ * other non-http protocols, so `[click](javascript:...)` renders inert.
+ */
+export function Markdown({
+  children,
+  people = [],
+  onToggleTask,
+  className = '',
+}: {
+  children: string
+  people?: Mentionable[]
+  /**
+   * Called with the source offset of the task item that was clicked. Omit to
+   * render checkboxes read-only -- which is right anywhere the viewer has no
+   * way to save the change back, such as someone else's comment.
+   */
+  onToggleTask?: (offset: number) => void
+  className?: string
+}) {
+  const plugins = useMemo(
+    () => [remarkGfm, [remarkMentions, { people }]] as PluggableList,
+    [people],
+  )
+
+  const components: Components = {
+    a: ({ node, className: linkClass, children: linkChildren, ...props }) => {
+      void node
+      if (linkClass === 'mention') {
+        return (
+          <span
+            className="rounded bg-brand-50 px-1 font-medium text-brand-700"
+            title={props.title}
+          >
+            {linkChildren}
+          </span>
+        )
+      }
+      return (
+        <a
+          {...props}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          className="text-brand-600 underline underline-offset-2 hover:text-brand-700"
+        >
+          {linkChildren}
+        </a>
+      )
+    },
+
+    li: ({ node, children, className: liClass, ...props }) => {
+      const offset = node?.position?.start?.offset
+      const isTask = typeof liClass === 'string' && liClass.includes('task-list-item')
+
+      if (!isTask || offset === undefined) {
+        return (
+          <li {...props} className="my-0.5">
+            {children}
+          </li>
+        )
+      }
+
+      // remark-gfm renders the checkbox as a disabled <input>; replace it with
+      // one wired to the toggle so the state can be written back to the source.
+      const [checkbox, ...rest] = Array.isArray(children) ? children : [children]
+      const checked = isCheckedInput(checkbox)
+
+      return (
+        <li {...props} className="my-0.5 flex list-none items-start gap-2 -ml-5">
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled={!onToggleTask}
+            onChange={() => onToggleTask?.(offset)}
+            className="mt-1 h-3.5 w-3.5 shrink-0 rounded border-neutral-300 accent-brand-600 disabled:opacity-60"
+            aria-label={checked ? 'Mark task as not done' : 'Mark task as done'}
+          />
+          <span className={checked ? 'text-neutral-400 line-through' : undefined}>{rest}</span>
+        </li>
+      )
+    },
+
+    // remark-gfm's own checkbox never reaches the DOM -- `li` above replaces it.
+    input: () => null,
+
+    h1: ({ children }) => <h1 className="mt-4 mb-2 text-base font-semibold first:mt-0">{children}</h1>,
+    h2: ({ children }) => <h2 className="mt-4 mb-2 text-sm font-semibold first:mt-0">{children}</h2>,
+    h3: ({ children }) => <h3 className="mt-3 mb-1.5 text-sm font-semibold first:mt-0">{children}</h3>,
+    p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0">{children}</p>,
+    ul: ({ children }) => <ul className="my-2 list-disc pl-5">{children}</ul>,
+    ol: ({ children }) => <ol className="my-2 list-decimal pl-5">{children}</ol>,
+    blockquote: ({ children }) => (
+      <blockquote className="my-2 border-l-2 border-neutral-200 pl-3 text-neutral-500">
+        {children}
+      </blockquote>
+    ),
+    code: ({ className: codeClass, children }) => {
+      // A fenced block gets a language class; inline code does not.
+      const fenced = typeof codeClass === 'string' && codeClass.startsWith('language-')
+      if (!fenced) {
+        return (
+          <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-[0.85em] text-neutral-800">
+            {children}
+          </code>
+        )
+      }
+      return <code className="font-mono text-xs leading-relaxed">{children}</code>
+    },
+    pre: ({ children }) => (
+      <pre className="my-2 overflow-x-auto rounded-md bg-neutral-50 p-3 ring-1 ring-neutral-100">
+        {children}
+      </pre>
+    ),
+    table: ({ children }) => (
+      <div className="my-2 overflow-x-auto">
+        <table className="w-full border-collapse text-left">{children}</table>
+      </div>
+    ),
+    th: ({ children }) => (
+      <th className="border-b border-neutral-200 px-2 py-1 font-medium">{children}</th>
+    ),
+    td: ({ children }) => <td className="border-b border-neutral-100 px-2 py-1">{children}</td>,
+    hr: () => <hr className="my-3 border-neutral-100" />,
+    img: ({ src, alt }) => (
+      <img src={src} alt={alt} className="my-2 max-w-full rounded-md" loading="lazy" />
+    ),
+  }
+
+  return (
+    <div className={`text-sm leading-relaxed text-neutral-700 ${className}`}>
+      <ReactMarkdown remarkPlugins={plugins} components={components}>
+        {children}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+/** Read the checked state off the `<input>` react-markdown handed us. */
+function isCheckedInput(node: unknown): boolean {
+  const props = (node as { props?: { checked?: boolean } })?.props
+  return props?.checked === true
+}

--- a/frontend/src/markdown/MarkdownEditor.tsx
+++ b/frontend/src/markdown/MarkdownEditor.tsx
@@ -1,0 +1,195 @@
+import { type KeyboardEvent, useRef, useState } from 'react'
+
+import { Markdown } from './Markdown'
+import { type Mentionable, matchMentions, mentionHandles } from './mentions'
+import { mentionQueryAt } from './mentionQuery'
+
+type Mode = 'write' | 'preview'
+
+export function MarkdownEditor({
+  value,
+  onChange,
+  people = [],
+  placeholder,
+  rows = 5,
+  autoFocus = false,
+  onSubmit,
+  onBlur,
+  className = '',
+}: {
+  value: string
+  onChange: (next: string) => void
+  people?: Mentionable[]
+  placeholder?: string
+  rows?: number
+  autoFocus?: boolean
+  /** Called on Cmd/Ctrl+Enter. */
+  onSubmit?: () => void
+  onBlur?: () => void
+  className?: string
+}) {
+  const [mode, setMode] = useState<Mode>('write')
+  const [mention, setMention] = useState<{ query: string; start: number } | null>(null)
+  // Carrying the query alongside the index means a new query resets the
+  // selection during render, with no effect and no intermediate frame showing
+  // the old row highlighted.
+  const [selection, setSelection] = useState({ query: '', index: 0 })
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const suggestions = mention ? matchMentions(people, mention.query) : []
+  const highlighted = selection.query === (mention?.query ?? '') ? selection.index : 0
+  const setHighlighted = (next: number | ((i: number) => number)) =>
+    setSelection({
+      query: mention?.query ?? '',
+      index: typeof next === 'function' ? next(highlighted) : next,
+    })
+
+  const syncMention = () => {
+    const el = textareaRef.current
+    if (!el) return
+    setMention(mentionQueryAt(el.value, el.selectionStart))
+  }
+
+  const insertMention = (person: Mentionable) => {
+    const el = textareaRef.current
+    if (!el || !mention) return
+
+    const handle = mentionHandles(people).get(person.id)
+    if (!handle) return
+
+    const before = value.slice(0, mention.start)
+    const after = value.slice(el.selectionStart)
+    const inserted = `@${handle} `
+
+    onChange(before + inserted + after)
+    setMention(null)
+
+    // Put the caret after what we inserted, once React has re-rendered.
+    const caret = before.length + inserted.length
+    requestAnimationFrame(() => {
+      el.focus()
+      el.setSelectionRange(caret, caret)
+    })
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mention && suggestions.length > 0) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setHighlighted((i) => (i + 1) % suggestions.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setHighlighted((i) => (i - 1 + suggestions.length) % suggestions.length)
+        return
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault()
+        insertMention(suggestions[highlighted])
+        return
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setMention(null)
+        return
+      }
+    }
+
+    if (onSubmit && event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault()
+      onSubmit()
+    }
+  }
+
+  const tabClass = (active: boolean) =>
+    `rounded-md px-2 py-1 text-xs font-medium transition ${
+      active ? 'bg-white text-neutral-800 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'
+    }`
+
+  return (
+    <div className={className}>
+      <div className="mb-1.5 flex items-center justify-between">
+        <div className="inline-flex gap-0.5 rounded-lg bg-neutral-100 p-0.5">
+          <button type="button" onClick={() => setMode('write')} className={tabClass(mode === 'write')}>
+            Write
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('preview')}
+            className={tabClass(mode === 'preview')}
+          >
+            Preview
+          </button>
+        </div>
+        {mode === 'write' && (
+          <span className="text-[11px] text-neutral-400">
+            Markdown supported · <span className="identifier">@</span> to mention
+          </span>
+        )}
+      </div>
+
+      {mode === 'write' ? (
+        <div className="relative">
+          <textarea
+            ref={textareaRef}
+            value={value}
+            autoFocus={autoFocus}
+            onChange={(e) => {
+              onChange(e.target.value)
+              syncMention()
+            }}
+            onKeyUp={syncMention}
+            onClick={syncMention}
+            onKeyDown={onKeyDown}
+            onBlur={() => {
+              // Let a click on a suggestion land before the menu closes.
+              setTimeout(() => setMention(null), 120)
+              onBlur?.()
+            }}
+            placeholder={placeholder}
+            rows={rows}
+            className="w-full resize-y rounded-md border border-neutral-200 px-2.5 py-2 text-sm text-neutral-700 placeholder-neutral-300 focus:border-brand-400 focus:outline-none"
+          />
+
+          {mention && suggestions.length > 0 && (
+            <ul
+              role="listbox"
+              aria-label="Team members"
+              className="absolute left-2 top-full z-30 mt-1 w-64 overflow-hidden rounded-lg border border-neutral-200 bg-white py-1 shadow-lg"
+            >
+              {suggestions.map((person, index) => (
+                <li key={person.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={index === highlighted}
+                    onMouseEnter={() => setHighlighted(index)}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => insertMention(person)}
+                    className={`flex w-full items-baseline gap-2 px-2.5 py-1.5 text-left text-sm ${
+                      index === highlighted ? 'bg-brand-50' : ''
+                    }`}
+                  >
+                    <span className="font-medium text-neutral-800">{person.full_name}</span>
+                    <span className="identifier truncate text-xs text-neutral-400">
+                      @{mentionHandles(people).get(person.id)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : (
+        <div className="min-h-[5rem] rounded-md border border-neutral-200 px-2.5 py-2">
+          {value.trim() ? (
+            <Markdown people={people}>{value}</Markdown>
+          ) : (
+            <p className="text-sm text-neutral-300">Nothing to preview yet.</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/markdown/__tests__/mentionQuery.test.ts
+++ b/frontend/src/markdown/__tests__/mentionQuery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { mentionQueryAt } from '../mentionQuery'
+
+/** Caret position is marked with | in these fixtures. */
+function at(withCaret: string) {
+  const caret = withCaret.indexOf('|')
+  return mentionQueryAt(withCaret.replace('|', ''), caret)
+}
+
+describe('mentionQueryAt', () => {
+  it('opens on a bare @', () => {
+    expect(at('@|')).toEqual({ query: '', start: 0 })
+  })
+
+  it('captures what has been typed so far', () => {
+    expect(at('ping @ad|')).toEqual({ query: 'ad', start: 5 })
+  })
+
+  it('closes once a space is typed', () => {
+    expect(at('@ada |')).toBeNull()
+  })
+
+  it('does not open inside an email address being typed', () => {
+    expect(at('write to demo@|')).toBeNull()
+  })
+
+  it('does not open on an @ in a path', () => {
+    expect(at('/users/@de|')).toBeNull()
+  })
+
+  it('ignores text after the caret', () => {
+    expect(at('@ad| and the rest')).toEqual({ query: 'ad', start: 0 })
+  })
+
+  it('reports a start offset that points at the @', () => {
+    const result = at('hello @world|')
+    expect('hello @world'[result!.start]).toBe('@')
+  })
+})

--- a/frontend/src/markdown/__tests__/mentions.test.ts
+++ b/frontend/src/markdown/__tests__/mentions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MENTION_PATTERN,
+  type Mentionable,
+  matchMentions,
+  mentionHandles,
+  peopleByHandle,
+} from '../mentions'
+
+const people: Mentionable[] = [
+  { id: 1, full_name: 'Demo User', email: 'demo@softtrack.dev' },
+  { id: 2, full_name: 'Ada Lovelace', email: 'ada.lovelace@softtrack.dev' },
+  { id: 3, full_name: 'Grace Hopper', email: 'Grace+work@softtrack.dev' },
+]
+
+function matches(text: string): string[] {
+  return [...text.matchAll(MENTION_PATTERN)].map((m) => m[2])
+}
+
+describe('mentionHandles', () => {
+  it('uses the local part of the address', () => {
+    const handles = mentionHandles(people)
+    expect(handles.get(1)).toBe('demo')
+    expect(handles.get(2)).toBe('ada.lovelace')
+  })
+
+  it('lowercases and replaces characters a handle cannot contain', () => {
+    expect(mentionHandles(people).get(3)).toBe('grace-work')
+  })
+
+  it('falls back to the full address when local parts collide', () => {
+    const colliding: Mentionable[] = [
+      { id: 1, full_name: 'Sam A', email: 'sam@a.example' },
+      { id: 2, full_name: 'Sam B', email: 'sam@b.example' },
+      { id: 3, full_name: 'Ada', email: 'ada@a.example' },
+    ]
+    const handles = mentionHandles(colliding)
+
+    expect(handles.get(1)).toBe('sam@a.example')
+    expect(handles.get(2)).toBe('sam@b.example')
+    // A handle that does not collide is left alone.
+    expect(handles.get(3)).toBe('ada')
+  })
+
+  it('does not depend on the order people arrive in', () => {
+    const colliding: Mentionable[] = [
+      { id: 1, full_name: 'Sam A', email: 'sam@a.example' },
+      { id: 2, full_name: 'Sam B', email: 'sam@b.example' },
+    ]
+    const forwards = mentionHandles(colliding)
+    const backwards = mentionHandles([...colliding].reverse())
+
+    expect([...forwards.entries()].sort()).toEqual([...backwards.entries()].sort())
+  })
+
+  it('round-trips through peopleByHandle', () => {
+    const byHandle = peopleByHandle(people)
+    expect(byHandle.get('demo')?.id).toBe(1)
+    expect(byHandle.get('ada.lovelace')?.full_name).toBe('Ada Lovelace')
+    expect(byHandle.get('nobody')).toBeUndefined()
+  })
+})
+
+describe('MENTION_PATTERN', () => {
+  it('finds a mention at the start of a line and mid-sentence', () => {
+    expect(matches('@demo can you look at this')).toEqual(['demo'])
+    expect(matches('ping @ada.lovelace about it')).toEqual(['ada.lovelace'])
+  })
+
+  it('finds several in one line', () => {
+    expect(matches('@demo and @ada.lovelace')).toEqual(['demo', 'ada.lovelace'])
+  })
+
+  it('does not read a plain email address as a mention of its domain', () => {
+    expect(matches('write to demo@softtrack.dev instead')).toEqual([])
+  })
+
+  it('matches a full address when that is the handle', () => {
+    expect(matches('@sam@a.example please review')).toEqual(['sam@a.example'])
+  })
+
+  it('ignores an @ inside a path', () => {
+    expect(matches('see /users/@demo')).toEqual([])
+  })
+})
+
+describe('matchMentions', () => {
+  it('matches on handle and on name', () => {
+    expect(matchMentions(people, 'ada').map((p) => p.id)).toEqual([2])
+    expect(matchMentions(people, 'hopper').map((p) => p.id)).toEqual([3])
+  })
+
+  it('is case insensitive', () => {
+    expect(matchMentions(people, 'ADA').map((p) => p.id)).toEqual([2])
+  })
+
+  it('returns everyone for an empty query, capped at the limit', () => {
+    expect(matchMentions(people, '')).toHaveLength(3)
+    expect(matchMentions(people, '', 2)).toHaveLength(2)
+  })
+
+  it('returns nothing when there is no match', () => {
+    expect(matchMentions(people, 'zzz')).toEqual([])
+  })
+})

--- a/frontend/src/markdown/__tests__/render.test.tsx
+++ b/frontend/src/markdown/__tests__/render.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Renders the real component through the real unified pipeline.
+ *
+ * The unit tests around it cover pure functions, and they all passed while the
+ * renderer threw on every document: `remarkMentions` was being passed to
+ * unified as a transformer where unified wants an attacher, which only shows
+ * up when something actually parses a document. Hence this file.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { Markdown } from '../Markdown'
+import type { Mentionable } from '../mentions'
+
+const people: Mentionable[] = [
+  { id: 7, full_name: 'Demo User', email: 'demo@softtrack.dev' },
+  { id: 8, full_name: 'Ada Lovelace', email: 'ada@softtrack.dev' },
+]
+
+const render = (source: string) =>
+  renderToStaticMarkup(<Markdown people={people}>{source}</Markdown>)
+
+/** The first checkbox tag in `html`, so attribute assertions cannot be
+ *  satisfied by a class name somewhere else on the page. */
+function checkboxIn(html: string): string {
+  const match = /<input[^>]*type="checkbox"[^>]*>/.exec(html)
+  if (!match) throw new Error('no checkbox rendered')
+  return match[0]
+}
+
+describe('Markdown', () => {
+  it('renders headings, emphasis and lists', () => {
+    const html = render('## Title\n\nSome **bold** text.\n\n- one\n- two\n')
+    expect(html).toContain('<h2')
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).toContain('<li')
+  })
+
+  it('renders fenced code without executing the markdown inside it', () => {
+    const html = render('```bash\ncurl -sf http://localhost:8000/health\n```')
+    expect(html).toContain('<pre')
+    expect(html).toContain('curl -sf http://localhost:8000/health')
+  })
+
+  it('opens external links safely', () => {
+    const html = render('[roadmap](https://example.com/x)')
+    expect(html).toContain('href="https://example.com/x"')
+    expect(html).toContain('rel="noopener noreferrer nofollow"')
+    expect(html).toContain('target="_blank"')
+  })
+
+  // --- safety ---------------------------------------------------------
+
+  it('escapes raw HTML instead of rendering it', () => {
+    const html = render('<img src=x onerror="alert(1)">\n\n<b>bold?</b>')
+
+    // No element is created -- the markup arrives as visible, escaped text.
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('<b>')
+    expect(html).toContain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;')
+    expect(html).toContain('&lt;b&gt;bold?&lt;/b&gt;')
+  })
+
+  it('escapes a script tag', () => {
+    const html = render('<script>alert(document.cookie)</script>')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('neutralises a javascript: link', () => {
+    const html = render('[click me](javascript:alert(1))')
+    expect(html).not.toContain('javascript:alert')
+  })
+
+  // --- mentions -------------------------------------------------------
+
+  it('renders a known mention with the person’s name', () => {
+    const html = render('ping @demo about it')
+    expect(html).toContain('@Demo User')
+    expect(html).toContain('demo@softtrack.dev')
+  })
+
+  it('leaves an unknown handle as plain text', () => {
+    const html = render('ping @nobody about it')
+    expect(html).toContain('@nobody')
+    expect(html).not.toContain('mention')
+  })
+
+  it('leaves a mention inside inline code alone', () => {
+    const html = render('use `@demo` as the handle')
+    expect(html).toContain('<code')
+    expect(html).toContain('@demo')
+    expect(html).not.toContain('@Demo User')
+  })
+
+  it('leaves a mention inside a fenced block alone', () => {
+    const html = render('```\ngreet @demo\n```')
+    expect(html).not.toContain('@Demo User')
+  })
+
+  it('does not turn a plain email address into a mention', () => {
+    const html = render('write to demo@softtrack.dev instead')
+    expect(html).not.toContain('@Demo User')
+  })
+
+  it('renders several mentions in one paragraph', () => {
+    const html = render('@demo and @ada should both see this')
+    expect(html).toContain('@Demo User')
+    expect(html).toContain('@Ada Lovelace')
+  })
+
+  // --- task lists -----------------------------------------------------
+
+  it('renders task list checkboxes with the right checked state', () => {
+    const html = render('- [ ] not done\n- [x] done\n')
+    const checkboxes = html.match(/<input[^>]*type="checkbox"[^>]*>/g) ?? []
+    expect(checkboxes).toHaveLength(2)
+    expect(checkboxes[0]).not.toContain('checked')
+    expect(checkboxes[1]).toContain('checked')
+  })
+
+  it('disables the checkboxes when there is no way to save a change', () => {
+    // The `disabled` *attribute*, not the `disabled:` Tailwind variant that
+    // also appears in the class list.
+    expect(checkboxIn(render('- [ ] not done\n'))).toContain('disabled=""')
+  })
+
+  it('enables them when a handler is given', () => {
+    const html = renderToStaticMarkup(
+      <Markdown people={people} onToggleTask={() => {}}>
+        {'- [ ] not done\n'}
+      </Markdown>,
+    )
+    expect(checkboxIn(html)).not.toContain('disabled=""')
+  })
+
+  it('renders a GFM table', () => {
+    const html = render('| a | b |\n|---|---|\n| 1 | 2 |\n')
+    expect(html).toContain('<table')
+    expect(html).toContain('<th')
+  })
+})

--- a/frontend/src/markdown/__tests__/tasks.test.ts
+++ b/frontend/src/markdown/__tests__/tasks.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasTaskList, taskProgress, toggleTaskAtOffset } from '../tasks'
+
+const DOC = `# Release checklist
+
+Some prose that mentions [x] in passing.
+
+- [ ] Write the migration
+- [x] Update the changelog
+- [ ] Tag the release
+
+1. [ ] An ordered task
+`
+
+/** The offset of the list item that starts with `text`, as hast reports it. */
+function offsetOfItem(source: string, text: string): number {
+  const line = source.split('\n').find((l) => l.includes(text))
+  if (!line) throw new Error(`no line containing ${text}`)
+  return source.indexOf(line)
+}
+
+describe('toggleTaskAtOffset', () => {
+  it('checks an unchecked box', () => {
+    const next = toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'Write the migration'))
+    expect(next).toContain('- [x] Write the migration')
+  })
+
+  it('unchecks a checked box', () => {
+    const next = toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'Update the changelog'))
+    expect(next).toContain('- [ ] Update the changelog')
+  })
+
+  it('changes exactly one character', () => {
+    const next = toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'Tag the release'))!
+    expect(next).toHaveLength(DOC.length)
+
+    const differing = [...next].filter((char, i) => char !== DOC[i])
+    expect(differing).toEqual(['x'])
+  })
+
+  it('leaves every other line untouched', () => {
+    const next = toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'Write the migration'))!
+    const before = DOC.split('\n')
+    const after = next.split('\n')
+
+    for (let i = 0; i < before.length; i++) {
+      if (before[i].includes('Write the migration')) continue
+      expect(after[i]).toBe(before[i])
+    }
+  })
+
+  it('handles ordered task lists', () => {
+    const next = toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'An ordered task'))
+    expect(next).toContain('1. [x] An ordered task')
+  })
+
+  it('accepts an uppercase [X] as checked', () => {
+    const source = '- [X] Already done'
+    expect(toggleTaskAtOffset(source, 0)).toBe('- [ ] Already done')
+  })
+
+  it('refuses an offset with no checkbox rather than guessing', () => {
+    // Pointing at the prose line that happens to contain "[x]".
+    expect(toggleTaskAtOffset(DOC, offsetOfItem(DOC, 'in passing'))).toBeNull()
+    expect(toggleTaskAtOffset(DOC, -1)).toBeNull()
+    expect(toggleTaskAtOffset(DOC, DOC.length + 10)).toBeNull()
+  })
+
+  it('does not treat a bracketed word in a list as a task', () => {
+    const source = '- [see the docs](https://example.com)'
+    expect(toggleTaskAtOffset(source, 0)).toBeNull()
+  })
+})
+
+describe('taskProgress', () => {
+  it('counts done and total', () => {
+    expect(taskProgress(DOC)).toEqual({ done: 1, total: 4 })
+  })
+
+  it('reports zero total for a document with no tasks', () => {
+    expect(taskProgress('Just some prose.')).toEqual({ done: 0, total: 0 })
+    expect(hasTaskList('Just some prose.')).toBe(false)
+  })
+
+  it('does not count the prose mention of [x]', () => {
+    expect(taskProgress('Some prose that mentions [x] in passing.')).toEqual({
+      done: 0,
+      total: 0,
+    })
+  })
+})

--- a/frontend/src/markdown/lazy.tsx
+++ b/frontend/src/markdown/lazy.tsx
@@ -1,0 +1,54 @@
+import { type ComponentProps, Suspense, lazy } from 'react'
+
+import type { Markdown as MarkdownComponent } from './Markdown'
+import type { MarkdownEditor as MarkdownEditorComponent } from './MarkdownEditor'
+
+/**
+ * The markdown renderer and its editor, split out of the initial bundle.
+ *
+ * react-markdown and remark-gfm are about 160 kB raw, and nothing on the board
+ * needs them until someone opens an issue or starts writing one. Loading them
+ * on that interaction keeps the first paint the size it was before markdown
+ * existed.
+ *
+ * The fallback for the renderer is the raw source as preformatted text, which
+ * is what descriptions looked like before this feature: readable, correctly
+ * sized, and no layout jump when the real renderer replaces it.
+ */
+
+const MarkdownImpl = lazy(() => import('./Markdown').then((m) => ({ default: m.Markdown })))
+const MarkdownEditorImpl = lazy(() =>
+  import('./MarkdownEditor').then((m) => ({ default: m.MarkdownEditor })),
+)
+
+export function Markdown(props: ComponentProps<typeof MarkdownComponent>) {
+  return (
+    <Suspense
+      fallback={
+        <div className={`text-sm leading-relaxed text-neutral-700 ${props.className ?? ''}`}>
+          <p className="whitespace-pre-wrap">{props.children}</p>
+        </div>
+      }
+    >
+      <MarkdownImpl {...props} />
+    </Suspense>
+  )
+}
+
+export function MarkdownEditor(props: ComponentProps<typeof MarkdownEditorComponent>) {
+  return (
+    <Suspense
+      fallback={
+        <div className={props.className}>
+          <div className="mb-1.5 h-6 w-32 rounded-lg bg-neutral-100" />
+          <div
+            className="w-full rounded-md border border-neutral-200 bg-neutral-50"
+            style={{ height: `${(props.rows ?? 5) * 1.5 + 1}rem` }}
+          />
+        </div>
+      }
+    >
+      <MarkdownEditorImpl {...props} />
+    </Suspense>
+  )
+}

--- a/frontend/src/markdown/mentionQuery.ts
+++ b/frontend/src/markdown/mentionQuery.ts
@@ -1,0 +1,13 @@
+/** The `@query` being typed immediately before the caret, if any. */
+export function mentionQueryAt(
+  value: string,
+  caret: number,
+): { query: string; start: number } | null {
+  const upToCaret = value.slice(0, caret)
+  // An `@` that starts a word, followed by no whitespace. Bailing out on the
+  // second `@` of an email address keeps the menu closed while someone is
+  // simply typing an address into a comment.
+  const match = /(^|[^\w@/])@([a-z0-9._@-]*)$/i.exec(upToCaret)
+  if (!match) return null
+  return { query: match[2], start: caret - match[2].length - 1 }
+}

--- a/frontend/src/markdown/mentions.ts
+++ b/frontend/src/markdown/mentions.ts
@@ -1,0 +1,83 @@
+/**
+ * `@` mentions of team members.
+ *
+ * Handles are derived from the email's local part rather than stored, because
+ * users have no username column yet. That has one consequence worth knowing:
+ * a mention is resolved against the team roster at render time, so it follows
+ * whoever holds the address today rather than whoever was meant when it was
+ * written. Stable mentions need a real `username` on User -- that is a schema
+ * change and its own issue. Everything that depends on the shape of a handle
+ * lives in this file, so swapping the derivation is a one-file change.
+ */
+
+export type Mentionable = {
+  id: number
+  full_name: string
+  email: string
+}
+
+const HANDLE_UNSAFE = /[^a-z0-9._-]+/g
+
+function localPart(email: string): string {
+  return email.split('@')[0].toLowerCase().replace(HANDLE_UNSAFE, '-')
+}
+
+/**
+ * A handle for each person, unique within the list.
+ *
+ * Two people can share a local part across domains (`sam@a.com`,
+ * `sam@b.com`). Numbering them would be unstable -- the suffix would depend on
+ * roster order -- so everyone in a colliding group falls back to their full
+ * address, which is unique by definition.
+ */
+export function mentionHandles(people: Mentionable[]): Map<number, string> {
+  const byLocal = new Map<string, Mentionable[]>()
+  for (const person of people) {
+    const local = localPart(person.email)
+    byLocal.set(local, [...(byLocal.get(local) ?? []), person])
+  }
+
+  const handles = new Map<number, string>()
+  for (const [local, group] of byLocal) {
+    for (const person of group) {
+      handles.set(person.id, group.length === 1 ? local : person.email.toLowerCase())
+    }
+  }
+  return handles
+}
+
+/** Reverse of `mentionHandles`, for the renderer. */
+export function peopleByHandle(people: Mentionable[]): Map<string, Mentionable> {
+  const handles = mentionHandles(people)
+  const byHandle = new Map<string, Mentionable>()
+  for (const person of people) {
+    const handle = handles.get(person.id)
+    if (handle) byHandle.set(handle, person)
+  }
+  return byHandle
+}
+
+/**
+ * Matches `@handle` where a mention can plausibly start.
+ *
+ * The leading boundary stops `user@example.com` in prose from being read as a
+ * mention of `@example.com`, and the alternation lets a handle be a full
+ * address for the collision case above.
+ */
+export const MENTION_PATTERN =
+  /(^|[^\w@/])@([a-z0-9][a-z0-9._-]*(?:@[a-z0-9-]+(?:\.[a-z0-9-]+)+)?)/gi
+
+/** People whose handle or name matches what has been typed after the `@`. */
+export function matchMentions(people: Mentionable[], query: string, limit = 6): Mentionable[] {
+  const handles = mentionHandles(people)
+  const needle = query.toLowerCase()
+  return people
+    .filter((person) => {
+      if (!needle) return true
+      return (
+        (handles.get(person.id) ?? '').includes(needle) ||
+        person.full_name.toLowerCase().includes(needle)
+      )
+    })
+    .slice(0, limit)
+}

--- a/frontend/src/markdown/remarkMentions.ts
+++ b/frontend/src/markdown/remarkMentions.ts
@@ -1,0 +1,70 @@
+import type { Root, Text } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+import { MENTION_PATTERN, type Mentionable, peopleByHandle } from './mentions'
+
+/**
+ * Turn `@handle` into a link node for each member of the team.
+ *
+ * Done as a remark plugin rather than a string replacement on the source so
+ * that mentions inside code stay literal: the visitor only sees `text` nodes,
+ * and `` `@demo` `` or a fenced block parses to `inlineCode` / `code`. A
+ * regex over the raw markdown would rewrite those too, which is exactly the
+ * wrong behaviour in an issue tracker full of shell snippets.
+ *
+ * An `@handle` that matches nobody on the team is left as plain text.
+ *
+ * This is a unified *attacher*: unified calls it once with the options at
+ * `freeze()` time, and it returns the transformer that runs per document. Use
+ * it as `remarkPlugins={[[remarkMentions, { people }]]}` -- passing
+ * `remarkMentions(people)` instead hands unified a transformer where it
+ * expects an attacher, and it invokes it with no tree.
+ */
+export function remarkMentions({ people }: { people: Mentionable[] }) {
+  const byHandle = peopleByHandle(people)
+
+  return (tree: Root) => {
+    visit(tree, 'text', (node: Text, index, parent) => {
+      if (!parent || index === undefined) return
+
+      const children: Array<Text | Record<string, unknown>> = []
+      let lastEnd = 0
+      MENTION_PATTERN.lastIndex = 0
+
+      for (const match of node.value.matchAll(MENTION_PATTERN)) {
+        const [whole, boundary, handle] = match
+        const person = byHandle.get(handle.toLowerCase())
+        if (!person) continue
+
+        const start = (match.index ?? 0) + boundary.length
+        if (start > lastEnd) {
+          children.push({ type: 'text', value: node.value.slice(lastEnd, start) })
+        }
+
+        children.push({
+          type: 'link',
+          url: `#user-${person.id}`,
+          title: person.email,
+          children: [{ type: 'text', value: `@${person.full_name}` }],
+          data: {
+            hProperties: {
+              className: 'mention',
+              'data-user-id': String(person.id),
+            },
+          },
+        })
+
+        lastEnd = (match.index ?? 0) + whole.length
+      }
+
+      if (children.length === 0) return
+      if (lastEnd < node.value.length) {
+        children.push({ type: 'text', value: node.value.slice(lastEnd) })
+      }
+
+      parent.children.splice(index, 1, ...(children as Text[]))
+      // Skip the nodes just inserted; they contain no further mentions.
+      return index + children.length
+    })
+  }
+}

--- a/frontend/src/markdown/tasks.ts
+++ b/frontend/src/markdown/tasks.ts
@@ -1,0 +1,54 @@
+/**
+ * Toggling a task-list checkbox writes back to the markdown source.
+ *
+ * The rendered checkbox knows where its list item started in the source (hast
+ * carries positions), so flipping is a surgical edit at that offset rather
+ * than a re-serialisation of the parsed tree. That matters: round-tripping
+ * markdown through a parser normalises things the author chose on purpose --
+ * bullet characters, indentation, hard line breaks, trailing spaces. Editing
+ * the source in place leaves every byte the user typed exactly where it was
+ * except the one character being toggled.
+ */
+
+/** The `[ ]` / `[x]` marker at or just after `offset`, if it is on that line. */
+function findMarker(source: string, offset: number): { index: number; checked: boolean } | null {
+  if (offset < 0 || offset >= source.length) return null
+
+  const lineEnd = source.indexOf('\n', offset)
+  const line = source.slice(offset, lineEnd === -1 ? source.length : lineEnd)
+
+  // A task marker follows the list bullet: "- [ ] text". Anchor on that shape
+  // so a literal "[x]" elsewhere in the line is never mistaken for one.
+  const match = /^(\s*[-*+]\s+|\s*\d+[.)]\s+)?\[([ xX])\]/.exec(line)
+  if (!match) return null
+
+  const markerIndex = offset + match[0].length - 3
+  return { index: markerIndex, checked: match[2] !== ' ' }
+}
+
+/**
+ * Return `source` with the task checkbox at `offset` flipped, or `null` if
+ * there is no checkbox there -- in which case the caller should do nothing
+ * rather than write a guess back to the server.
+ */
+export function toggleTaskAtOffset(source: string, offset: number): string | null {
+  const marker = findMarker(source, offset)
+  if (!marker) return null
+
+  const next = marker.checked ? ' ' : 'x'
+  return source.slice(0, marker.index + 1) + next + source.slice(marker.index + 2)
+}
+
+/** Whether `source` contains at least one task-list item. */
+export function hasTaskList(source: string): boolean {
+  return /^\s*(?:[-*+]|\d+[.)])\s+\[[ xX]\]/m.test(source)
+}
+
+/** `{done, total}` for the task lists in `source`, for a progress summary. */
+export function taskProgress(source: string): { done: number; total: number } {
+  const items = source.match(/^\s*(?:[-*+]|\d+[.)])\s+\[[ xX]\]/gm) ?? []
+  return {
+    done: items.filter((item) => !item.endsWith('[ ]')).length,
+    total: items.length,
+  }
+}


### PR DESCRIPTION
Closes #12

Descriptions and comments were plain text, so anyone arriving from another tracker lost headings, lists, code blocks and checklists.

### Safety

Rendering goes through react-markdown with remark-gfm, and deliberately **without** `rehype-raw`. A `<script>` or an `onerror` attribute in a description is escaped and shown as text rather than turned into markup, and link URLs go through react-markdown's transform, so `[click](javascript:alert(1))` renders inert. There are tests for each of those, asserting on the escaped output rather than just the absence of a substring -- `not.toContain('onerror')` passes for the escaped text too, which would have made the test meaningless.

### Task checkboxes

They toggle, and the toggle saves.

The rendered checkbox knows where its list item began in the source, so a toggle edits that one character in place rather than re-serialising the parsed tree. That distinction matters: a round trip through a parser normalises bullet characters, indentation, hard line breaks and trailing spaces that the author chose on purpose. Verified against the live stack -- toggling one box in a description containing a fenced block, a GFM table and a mention left every other byte identical:

    - [x] Write the migration     <- toggled
    - [x] Update the changelog
    - [ ] Tag the release

Comments render markdown too, but their checkboxes are **read-only**: there is no endpoint to edit a comment yet, so a toggle there could not be saved, and a checkbox that silently forgets is worse than one that does not move.

### Mentions

`@` opens a member picker; arrow keys and Enter/Tab select. Mentions inside inline code and fenced blocks stay literal, which is why this is a remark plugin over `text` nodes rather than a regex over the source -- an issue tracker is full of shell snippets, and rewriting `@demo` inside one would be exactly wrong. A plain `demo@softtrack.dev` in prose is not read as a mention either.

**One tradeoff to know about.** Handles are derived from the email local part (colliding handles fall back to the full address), and resolved against the roster at render time -- so a mention follows whoever holds an address today, not whoever was meant when it was written. Stable mentions need a `username` column on User; that is a schema change and its own issue. The derivation lives entirely in `markdown/mentions.ts`, so swapping it later is a one-file change.

### Bundle

react-markdown and remark-gfm are ~160 kB, and nothing on the board needs them until an issue is opened. Both entry points load the renderer lazily, and the renderer's Suspense fallback is the raw source as preformatted text -- which is what descriptions looked like before this feature, so there is no layout jump.

| | before | after |
|---|---|---|
| initial chunk | 392 kB | **395 kB** |
| markdown chunk | -- | 154 kB, on first use |

### Tests

Adds vitest and 48 tests, and a `Test` step to the frontend CI job.

Most are unit tests over pure functions. `render.test.tsx` drives the real component through the real unified pipeline, and it had to exist: **every pure test passed while the renderer threw on every single document.** `remarkMentions` was being handed to unified as a transformer where unified wants an attacher, so unified called it with no tree at `freeze()` time. Nothing short of parsing a real document would have caught it, and I only found it by opening the panel in a browser.

### Verified in the browser

Against the Docker stack, on a description with a heading, bold text, a link, a three-item task list, a mention, an email address, inline code, a fenced bash block and a table: everything renders, the mention resolves to *@Demo User*, the inline `@demo` stays literal, no console errors, and the task counter reads *1 of 3 tasks* then *2 of 3* after a toggle.

### Note on the CI job name

The frontend job is now `Frontend · lint + typecheck + test + build`. No required status checks are configured yet, so nothing breaks -- but if you add them, use the new name.