### PR TITLE
Rejoin the two Alembic heads so main can boot again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,16 @@ jobs:
             echo "Expected exactly one Alembic head, found $count:"
             printf '%s\n' "$heads"
             echo
-            echo "Another branch added a migration from the same parent."
-            echo "Rebase onto main, then point this branch's migration at the"
-            echo "other head by editing its down_revision."
+            echo "Two migrations share a parent, so 'alembic upgrade head'"
+            echo "fails and the app cannot boot on a fresh database."
+            echo
+            echo "If the other migration is not merged yet: rebase onto main"
+            echo "and point this branch's migration at the other head by"
+            echo "editing its down_revision."
+            echo
+            echo "If both are already on main: add a merge revision instead,"
+            echo "so neither published revision id has to be rewritten --"
+            echo "  alembic merge -m 'merge <a> and <b>' <head1> <head2>"
             exit 1
           fi
           printf 'Single head: %s\n' "$heads"

--- a/backend/alembic/versions/09d941255b48_merge_issue_links_and_search_heads.py
+++ b/backend/alembic/versions/09d941255b48_merge_issue_links_and_search_heads.py
@@ -1,0 +1,37 @@
+"""merge issue links and search heads
+
+Revision ID: 09d941255b48
+Revises: 55613c0f041c, a3f1c9d24e70
+Create Date: 2026-09-07
+
+Issue links (#43) and full-text search (#44) each added a migration from the
+same parent, and both were merged. That left two Alembic heads, and since the
+app runs `alembic upgrade head` on startup, it meant a fresh database could
+not be created at all:
+
+    CommandError: Multiple head revisions are present for given argument
+    'head'; please specify a specific target revision...
+
+This revision does nothing except join the two branches back into one head.
+No schema change -- the two migrations touch different tables and neither
+needs the other.
+
+A merge revision rather than repointing one migration's down_revision at the
+other: both revision ids are already on main, and rewriting a published
+migration's parent would strand anyone who had stamped one of them.
+"""
+
+from typing import Sequence, Union
+
+revision: str = "09d941255b48"
+down_revision: Union[str, Sequence[str], None] = ("55613c0f041c", "a3f1c9d24e70")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Nothing to do -- this revision exists only to rejoin the two branches."""
+
+
+def downgrade() -> None:
+    """Nothing to undo."""


### PR DESCRIPTION
## main is currently broken

Issue links (#43) and full-text search (#44) each added a migration from the same parent. Both merged, leaving **two Alembic heads** — and the app runs `alembic upgrade head` on startup, so `main` cannot create a fresh database at all:

    CommandError: Multiple head revisions are present for given argument 'head';
    please specify a specific target revision, '<branchname>@head' to narrow to a
    specific head, or 'heads' for all heads

Reproduced against `origin/main` before writing this. An existing database keeps working — nothing is corrupted — but any fresh deploy, any new contributor running `docker compose up`, and the Docker CI job on a clean volume all fail to start.

## The fix

A merge revision that joins the two branches and changes no schema. The two migrations touch different tables and neither needs the other, so there is genuinely nothing to do beyond rejoining the history.

**A merge revision rather than repointing one migration's `down_revision` at the other**, because both revision ids are already on `main`; rewriting a published migration's parent would strand anyone who had stamped one of them.

Verified that every state an existing database could be in upgrades cleanly:

    from e2b56dbe1777 (baseline) -> 09d941255b48   3 steps
    from 55613c0f041c (links)    -> 09d941255b48   2 steps
    from a3f1c9d24e70 (search)   -> 09d941255b48   2 steps

and that a fresh database now boots.

## Why the check in #43 did not catch it

It is per-branch, and #44 was cut before #43 merged — so #44's own branch contained exactly one head and passed honestly. The check is doing its job; what let this through is that **the branch was not required to be up to date with `main` before merging**.

Two follow-ups, one in this PR and one for you:

- **Here:** the failure message now also covers the case where both migrations are *already* merged, where "rebase and repoint `down_revision`" is no longer the right advice — `alembic merge` is.
- **For you:** turning on **Require branches to be up to date before merging** in the ruleset is what actually prevents this class of problem. It would have re-run CI on #44 against the updated `main`, and the single-head check would have failed there instead of on `main`. #45 and #46 are both still open with migrations off the same parent, so this will happen again otherwise.