### PR TITLE
Redesign the frontend as liquid glass, and fix the cycles migration on SQLite

### DIFF
--- a/backend/alembic/versions/4522806f02f8_add_cycles.py
+++ b/backend/alembic/versions/4522806f02f8_add_cycles.py
@@ -55,13 +55,12 @@ def upgrade() -> None:
         )
         batch_op.create_foreign_key(_CYCLE_FK, "cycle", ["cycle_id"], ["id"])
 
+    # server_default, then dropped: the column is NOT NULL and existing teams
+    # have no value for it, so adding it bare would fail on any database that
+    # already has rows. Every existing team starts at 1, which is correct --
+    # none of them has a cycle yet. The default is then removed so the schema
+    # matches the model and autogenerate does not keep reporting a difference.
     with op.batch_alter_table("team", schema=None) as batch_op:
-        # server_default, then dropped: the column is NOT NULL and existing
-        # teams have no value for it, so adding it bare would fail on any
-        # database that already has rows. Every existing team starts at 1,
-        # which is correct -- none of them has a cycle yet. The default is
-        # then removed so the schema matches the model and autogenerate does
-        # not keep reporting a difference.
         batch_op.add_column(
             sa.Column(
                 "next_cycle_number",
@@ -70,7 +69,16 @@ def upgrade() -> None:
                 server_default="1",
             )
         )
-        batch_op.alter_column("next_cycle_number", server_default=None)
+
+    # A second batch on purpose. SQLite's batch mode rebuilds the table once,
+    # from the column's *final* definition, so doing both steps in one batch
+    # rebuilt it with no default and copying existing rows into a NOT NULL
+    # column failed -- which left every SQLite install with a team stuck on
+    # this migration. Two batches: the rows get their 1, then the default goes.
+    with op.batch_alter_table("team", schema=None) as batch_op:
+        batch_op.alter_column(
+            "next_cycle_number", existing_type=sa.Integer(), server_default=None
+        )
 
 
 def downgrade() -> None:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,26 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#eef0f8" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0c0b15" media="(prefers-color-scheme: dark)" />
     <title>SoftTrack</title>
+    <script>
+      // Stamp the theme before the first paint so a dark-mode user never
+      // sees a light flash. Mirrors src/ui/theme.ts.
+      ;(function () {
+        try {
+          var stored = localStorage.getItem('softtrack.theme')
+          var theme =
+            stored === 'light' || stored === 'dark'
+              ? stored
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+          document.documentElement.dataset.theme = theme
+        } catch (e) {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -9,18 +9,23 @@ import TeamsHome from '@/team/TeamsHome'
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
+    <>
+      {/* The aurora sits behind every route; the glass surfaces above it are
+          what give the interface its depth. */}
+      <div className="aurora" aria-hidden="true" />
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
 
-      <Route element={<RequireAuth />}>
-        <Route path="/" element={<TeamsHome />} />
-        <Route path="/new-team" element={<NewTeamPage />} />
-        <Route path="/:teamKey" element={<BoardPage />} />
-        <Route path="/:teamKey/issue/:issueNumber" element={<BoardPage />} />
-      </Route>
+        <Route element={<RequireAuth />}>
+          <Route path="/" element={<TeamsHome />} />
+          <Route path="/new-team" element={<NewTeamPage />} />
+          <Route path="/:teamKey" element={<BoardPage />} />
+          <Route path="/:teamKey/issue/:issueNumber" element={<BoardPage />} />
+        </Route>
 
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </>
   )
 }

--- a/frontend/src/attachments/AttachmentImage.tsx
+++ b/frontend/src/attachments/AttachmentImage.tsx
@@ -43,7 +43,7 @@ export function AttachmentImage({
 
   if (state.failed) {
     return (
-      <span className="my-2 inline-flex items-center gap-1.5 rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-400">
+      <span className="well my-2 inline-flex items-center gap-1.5 rounded-control px-2 py-1 text-xs text-neutral-500">
         <span aria-hidden>🖼</span>
         {alt || 'This image could not be loaded'}
       </span>
@@ -55,7 +55,7 @@ export function AttachmentImage({
       <span
         role="img"
         aria-label={alt ? `Loading ${alt}` : 'Loading image'}
-        className={`my-2 block h-32 w-full max-w-xs animate-pulse rounded-md bg-neutral-100 ${className}`}
+        className={`skeleton my-2 block h-32 w-full max-w-xs rounded-card ${className}`}
       />
     )
   }
@@ -64,7 +64,7 @@ export function AttachmentImage({
     <img
       src={state.url}
       alt={alt ?? ''}
-      className={`my-2 max-w-full rounded-md border border-neutral-100 ${className}`}
+      className={`my-2 max-w-full rounded-card border border-neutral-900/8 shadow-sm ${className}`}
     />
   )
 }

--- a/frontend/src/attachments/AttachmentList.tsx
+++ b/frontend/src/attachments/AttachmentList.tsx
@@ -1,6 +1,7 @@
 import type { AttachmentRead } from '@/api/generated/models'
 import { AttachmentImage } from '@/attachments/AttachmentImage'
 import { downloadAttachment, formatBytes } from '@/attachments/urls'
+import { Icon } from '@/ui/Icon'
 
 /**
  * The files on an issue or a comment.
@@ -23,14 +24,14 @@ export function AttachmentList({
   if (attachments.length === 0) return null
 
   return (
-    <ul className={`flex flex-wrap gap-2 ${compact ? '' : 'mt-2'}`}>
+    <ul className={`flex flex-wrap gap-2 ${compact ? 'mt-2' : 'mt-2'}`}>
       {attachments.map((attachment) => (
         <li key={attachment.id} className="group relative">
           <button
             type="button"
             onClick={() => downloadAttachment(attachment.url, attachment.filename)}
             title={`${attachment.filename} · ${formatBytes(attachment.size_bytes)}`}
-            className="block max-w-[12rem] overflow-hidden rounded-md border border-neutral-200 text-left transition hover:border-neutral-300"
+            className="glass-card block max-w-[12rem] overflow-hidden rounded-card text-left"
           >
             {attachment.is_image ? (
               <AttachmentImage
@@ -39,12 +40,12 @@ export function AttachmentList({
                 className="!my-0 !rounded-none !border-0 h-20 w-32 object-cover"
               />
             ) : (
-              <span className="flex items-center gap-2 px-2.5 py-2">
-                <span aria-hidden className="text-neutral-400">
-                  ⎘
+              <span className="flex items-center gap-2.5 px-3 py-2">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-900/6 text-neutral-500">
+                  <Icon name="paperclip" size={13} />
                 </span>
                 <span className="min-w-0">
-                  <span className="block truncate text-xs font-medium text-neutral-700">
+                  <span className="block truncate text-xs font-medium text-neutral-800">
                     {attachment.filename}
                   </span>
                   <span className="block text-[11px] text-neutral-400">
@@ -60,9 +61,9 @@ export function AttachmentList({
               type="button"
               onClick={() => onRemove(attachment)}
               aria-label={`Remove ${attachment.filename}`}
-              className="absolute -right-1.5 -top-1.5 hidden h-5 w-5 items-center justify-center rounded-full border border-neutral-200 bg-white text-xs text-neutral-500 shadow-sm hover:text-danger-600 group-hover:flex focus:flex"
+              className="glass-strong absolute -right-1.5 -top-1.5 hidden h-5 w-5 items-center justify-center rounded-full text-neutral-500 hover:text-danger-600 focus:flex group-hover:flex"
             >
-              ✕
+              <Icon name="close" size={11} strokeWidth={2.2} />
             </button>
           )}
         </li>

--- a/frontend/src/auth/LoginPage.tsx
+++ b/frontend/src/auth/LoginPage.tsx
@@ -1,9 +1,9 @@
 import { type FormEvent, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
+import { errorDetail } from '@/api/errors'
 import { useAuth } from '@/auth/AuthContext'
 import { Logo } from '@/ui/Logo'
-import { errorDetail } from '@/api/errors'
 
 export default function LoginPage() {
   const { login } = useAuth()
@@ -37,66 +37,72 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4">
-      <div className="w-full max-w-sm">
+    <div className="flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="pop-in w-full max-w-sm">
         <div className="mb-8 text-center">
-          <div className="mb-3 flex justify-center">
-            <Logo size={40} />
+          <div className="mb-4 flex justify-center">
+            <Logo size={52} />
           </div>
-          <h1 className="text-xl font-semibold text-neutral-900">Sign in to SoftTrack</h1>
-          <p className="mt-1 text-sm text-neutral-500">
+          <h1 className="text-2xl font-semibold tracking-tight text-neutral-900">
+            Sign in to <span className="text-gradient">SoftTrack</span>
+          </h1>
+          <p className="mt-1.5 text-sm text-neutral-500">
             An open-source issue tracker for small teams.
           </p>
         </div>
 
-        <form
-          onSubmit={onSubmit}
-          className="space-y-4 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm"
-        >
+        <form onSubmit={onSubmit} className="glass-strong sheen space-y-4 rounded-panel p-6">
           {error && (
-            <div className="rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-700">
+            <div
+              role="alert"
+              className="rounded-control bg-danger-50 px-3 py-2 text-sm text-danger-700"
+            >
               {error}
             </div>
           )}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Email</label>
+            <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Email
+            </label>
             <input
+              id="login-email"
               type="email"
               required
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="you@example.com"
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Password</label>
+            <label htmlFor="login-password" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Password
+            </label>
             <input
+              id="login-password"
               type="password"
               required
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="••••••••"
             />
           </div>
 
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full rounded-md bg-brand-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-700 disabled:opacity-60"
-          >
+          <button type="submit" disabled={submitting} className="btn btn-primary h-10 w-full text-sm">
             {submitting ? 'Signing in…' : 'Sign in'}
           </button>
 
           <p className="text-center text-xs text-neutral-400">
-            Demo login: demo@softtrack.dev / password123 (after running the seed script)
+            Demo login: demo@softtrack.dev / password123
           </p>
         </form>
 
-        <p className="mt-4 text-center text-sm text-neutral-500">
+        <p className="mt-5 text-center text-sm text-neutral-500">
           Don't have an account?{' '}
           <Link to="/register" className="font-medium text-brand-600 hover:text-brand-700">
             Create one

--- a/frontend/src/auth/RegisterPage.tsx
+++ b/frontend/src/auth/RegisterPage.tsx
@@ -1,9 +1,9 @@
 import { type FormEvent, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { errorDetail } from '@/api/errors'
 import { useAuth } from '@/auth/AuthContext'
 import { Logo } from '@/ui/Logo'
-import { errorDetail } from '@/api/errors'
 
 export default function RegisterPage() {
   const { register } = useAuth()
@@ -30,70 +30,82 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4">
-      <div className="w-full max-w-sm">
+    <div className="flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="pop-in w-full max-w-sm">
         <div className="mb-8 text-center">
-          <div className="mb-3 flex justify-center">
-            <Logo size={40} />
+          <div className="mb-4 flex justify-center">
+            <Logo size={52} />
           </div>
-          <h1 className="text-xl font-semibold text-neutral-900">Create your account</h1>
-          <p className="mt-1 text-sm text-neutral-500">Free, self-hosted, no credit card.</p>
+          <h1 className="text-2xl font-semibold tracking-tight text-neutral-900">
+            Create your <span className="text-gradient">account</span>
+          </h1>
+          <p className="mt-1.5 text-sm text-neutral-500">Free, self-hosted, no credit card.</p>
         </div>
 
-        <form
-          onSubmit={onSubmit}
-          className="space-y-4 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm"
-        >
+        <form onSubmit={onSubmit} className="glass-strong sheen space-y-4 rounded-panel p-6">
           {error && (
-            <div className="rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-700">{error}</div>
+            <div
+              role="alert"
+              className="rounded-control bg-danger-50 px-3 py-2 text-sm text-danger-700"
+            >
+              {error}
+            </div>
           )}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Full name</label>
+            <label htmlFor="register-name" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Full name
+            </label>
             <input
+              id="register-name"
               required
+              autoComplete="name"
               value={fullName}
               onChange={(e) => setFullName(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="Ada Lovelace"
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Email</label>
+            <label htmlFor="register-email" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Email
+            </label>
             <input
+              id="register-email"
               type="email"
               required
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="you@example.com"
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Password</label>
+            <label htmlFor="register-password" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Password
+            </label>
             <input
+              id="register-password"
               type="password"
               required
               minLength={8}
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="At least 8 characters"
             />
           </div>
 
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full rounded-md bg-brand-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-700 disabled:opacity-60"
-          >
+          <button type="submit" disabled={submitting} className="btn btn-primary h-10 w-full text-sm">
             {submitting ? 'Creating account…' : 'Create account'}
           </button>
         </form>
 
-        <p className="mt-4 text-center text-sm text-neutral-500">
+        <p className="mt-5 text-center text-sm text-neutral-500">
           Already have an account?{' '}
           <Link to="/login" className="font-medium text-brand-600 hover:text-brand-700">
             Sign in

--- a/frontend/src/auth/RequireAuth.tsx
+++ b/frontend/src/auth/RequireAuth.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
 import { useAuth } from '@/auth/AuthContext'
+import { Loading } from '@/ui/Loading'
 
 export function RequireAuth() {
   const { isAuthenticated, isLoading } = useAuth()
@@ -8,8 +9,8 @@ export function RequireAuth() {
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center text-sm text-neutral-400">
-        Loading…
+      <div className="h-screen">
+        <Loading />
       </div>
     )
   }

--- a/frontend/src/board/BoardPage.tsx
+++ b/frontend/src/board/BoardPage.tsx
@@ -26,6 +26,7 @@ import { useDebounced } from '@/search/useDebounced'
 import { TeamProvider } from '@/team/TeamContext'
 import { useTeamData } from '@/team/useTeamData'
 import { useTeamByKey } from '@/team/useTeams'
+import { Loading } from '@/ui/Loading'
 
 export default function BoardPage() {
   const { teamKey, issueNumber } = useParams<{ teamKey: string; issueNumber?: string }>()
@@ -36,6 +37,8 @@ export default function BoardPage() {
   const [activeProjectId, setActiveProjectId] = useState<number | 'all'>('all')
   const [filters, setFilters] = useState<IssueFilters>(NO_FILTERS)
   const [search, setSearch] = useState('')
+  // The sidebar is a drawer below the `lg` breakpoint.
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const overlays = useOverlays()
 
   const teamData = useTeamData(team)
@@ -78,8 +81,8 @@ export default function BoardPage() {
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center text-sm text-neutral-400">
-        Loading…
+      <div className="h-screen">
+        <Loading />
       </div>
     )
   }
@@ -94,22 +97,54 @@ export default function BoardPage() {
   const setFilter = <K extends keyof IssueFilters>(key: K, value: IssueFilters[K]) =>
     setFilters((current) => ({ ...current, [key]: value }))
 
+  const sidebar = (
+    <Sidebar
+      activeProjectId={activeProjectId}
+      onSelectProject={(id) => {
+        setActiveProjectId(id)
+        setSidebarOpen(false)
+      }}
+      activeCycleId={filters.cycleId}
+      onSelectCycle={(cycleId) => {
+        setFilter('cycleId', cycleId)
+        setSidebarOpen(false)
+      }}
+      onNewCycle={() => {
+        setSidebarOpen(false)
+        overlays.open('newCycle')
+      }}
+      onImport={() => {
+        setSidebarOpen(false)
+        overlays.open('import')
+      }}
+    />
+  )
+
   return (
     <TeamProvider value={{ team, teams, ...teamData }}>
-      <div className="flex h-screen bg-neutral-50">
-        <Sidebar
-          activeProjectId={activeProjectId}
-          onSelectProject={setActiveProjectId}
-          activeCycleId={filters.cycleId}
-          onSelectCycle={(cycleId) => setFilter('cycleId', cycleId)}
-          onNewCycle={() => overlays.open('newCycle')}
-          onImport={() => overlays.open('import')}
-        />
-        <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex h-screen gap-3 p-2 sm:p-3">
+        <div className="hidden h-full lg:block">{sidebar}</div>
+
+        {sidebarOpen && (
+          <div
+            className="scrim fixed inset-0 z-30 lg:hidden"
+            onClick={() => setSidebarOpen(false)}
+          >
+            <div
+              className="slide-in-left h-full w-72 max-w-[85vw] p-2 sm:p-3"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {sidebar}
+            </div>
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
           <TopBar
             view={view}
             onViewChange={setView}
             onNewIssue={openNewIssue}
+            onOpenSidebar={() => setSidebarOpen(true)}
             search={search}
             onSearchChange={setSearch}
             priorityFilter={filters.priority}
@@ -127,9 +162,7 @@ export default function BoardPage() {
                 isLoading={searchResults.isLoading}
               />
             ) : issuesQuery.isLoading ? (
-              <div className="flex h-full items-center justify-center text-sm text-neutral-400">
-                Loading issues…
-              </div>
+              <Loading label="Loading issues…" />
             ) : view === 'reports' ? (
               <ReportsView />
             ) : view === 'board' ? (

--- a/frontend/src/board/IssueListView.tsx
+++ b/frontend/src/board/IssueListView.tsx
@@ -1,10 +1,11 @@
 import { useNavigate } from 'react-router-dom'
 
 import type { IssueRead } from '@/api/generated/models'
+import { EstimateBadge } from '@/issues/EstimateBadge'
+import { PriorityIcon } from '@/issues/PriorityIcon'
 import { STATUS_META } from '@/issues/issueMeta'
 import { useTeamContext } from '@/team/TeamContext'
 import { Avatar } from '@/ui/Avatar'
-import { PriorityIcon } from '@/issues/PriorityIcon'
 
 export function IssueListView({ issues }: { issues: IssueRead[] }) {
   const navigate = useNavigate()
@@ -12,49 +13,58 @@ export function IssueListView({ issues }: { issues: IssueRead[] }) {
 
   if (issues.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center text-sm text-neutral-400">
+      <div className="glass flex h-full items-center justify-center rounded-panel text-sm text-neutral-400">
         No issues match the current filters.
       </div>
     )
   }
 
   return (
-    <div className="overflow-y-auto px-4 py-3">
-      <div className="divide-y divide-neutral-100 overflow-hidden rounded-lg border border-neutral-200 bg-white">
+    <div className="glass scroll-thin h-full overflow-y-auto rounded-panel">
+      <ul className="divide-y divide-neutral-900/8">
         {issues.map((issue) => {
           const status = STATUS_META[issue.status]
           return (
-            <button
-              key={issue.id}
-              onClick={() => navigate(`/${team.key}/issue/${issue.number}`)}
-              className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm hover:bg-neutral-50"
-            >
-              <PriorityIcon priority={issue.priority} />
-              <span className="identifier w-16 shrink-0 text-xs font-medium text-neutral-400">
-                {issue.identifier}
-              </span>
-              <span className={`h-2 w-2 shrink-0 rounded-full ${status.dot}`} title={status.label} />
-              <span className="min-w-0 flex-1 truncate text-neutral-900">{issue.title}</span>
-              <div className="flex shrink-0 gap-1">
-                {issue.labels?.map((label) => (
-                  <span
-                    key={label.id}
-                    className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-                    style={{ backgroundColor: `${label.color}20`, color: label.color }}
-                  >
-                    {label.name}
-                  </span>
-                ))}
-              </div>
-              {issue.assignee ? (
-                <Avatar user={issue.assignee} size={20} />
-              ) : (
-                <div className="h-5 w-5 shrink-0 rounded-full border border-dashed border-neutral-300" />
-              )}
-            </button>
+            <li key={issue.id}>
+              <button
+                type="button"
+                onClick={() => navigate(`/${team.key}/issue/${issue.number}`)}
+                className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors hover:bg-neutral-900/4 focus:outline-none focus-visible:bg-brand-500/10"
+              >
+                <PriorityIcon priority={issue.priority} />
+                <span className="identifier w-16 shrink-0 text-xs font-medium text-neutral-400">
+                  {issue.identifier}
+                </span>
+                <span
+                  className="dot"
+                  style={{ ['--dot' as string]: status.color }}
+                  title={status.label}
+                />
+                <span className="min-w-0 flex-1 truncate font-medium text-neutral-900">
+                  {issue.title}
+                </span>
+                <span className="hidden shrink-0 gap-1 sm:flex">
+                  {issue.labels?.map((label) => (
+                    <span
+                      key={label.id}
+                      className="chip"
+                      style={{ ['--chip' as string]: label.color }}
+                    >
+                      {label.name}
+                    </span>
+                  ))}
+                </span>
+                {issue.estimate != null && <EstimateBadge points={issue.estimate} />}
+                {issue.assignee ? (
+                  <Avatar user={issue.assignee} size={22} />
+                ) : (
+                  <span className="h-[22px] w-[22px] shrink-0 rounded-full border border-dashed border-neutral-900/20" />
+                )}
+              </button>
+            </li>
           )
         })}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/frontend/src/board/KanbanBoard.tsx
+++ b/frontend/src/board/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 
 import {
   DndContext,
@@ -10,36 +10,47 @@ import {
 } from '@dnd-kit/core'
 
 import type { EstimateSummary, IssueRead, IssueStatus } from '@/api/generated/models'
-import { STATUS_META, STATUS_ORDER } from '@/issues/issueMeta'
 import { IssueCard } from '@/issues/IssueCard'
+import { STATUS_META, STATUS_ORDER } from '@/issues/issueMeta'
+import { Icon } from '@/ui/Icon'
+
+type Load = EstimateSummary['by_status'][IssueStatus]
+
+/** Columns start folded to a rail. Cancelled work is rarely what a board is for. */
+const COLLAPSED_BY_DEFAULT: IssueStatus[] = ['cancelled']
 
 function Column({
   status,
   issues,
   load,
+  onCollapse,
 }: {
   status: IssueStatus
   issues: IssueRead[]
-  load?: EstimateSummary['by_status'][IssueStatus]
+  load?: Load
+  onCollapse: () => void
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status })
   const meta = STATUS_META[status]
 
   return (
-    <div
+    <section
       ref={setNodeRef}
       data-column={status}
-      className={`flex w-72 shrink-0 flex-col rounded-lg transition-colors ${
-        isOver ? 'bg-brand-100/70' : 'bg-neutral-100/70'
+      aria-label={meta.label}
+      className={`group/column glass-subtle flex w-[82vw] shrink-0 snap-center flex-col rounded-panel transition-[box-shadow,background-color] duration-150 sm:w-80 lg:w-auto lg:min-w-[208px] lg:max-w-[400px] lg:flex-1 lg:shrink lg:snap-none ${
+        isOver ? 'bg-brand-500/10 ring-2 ring-brand-400/60' : ''
       }`}
     >
-      <div className="flex items-center gap-2 px-3 pb-2 pt-3">
-        <span className={`h-2 w-2 rounded-full ${meta.dot}`} />
-        <span className="text-sm font-medium text-neutral-700">{meta.label}</span>
-        <span className="text-xs text-neutral-400">{issues.length}</span>
+      <header className="flex items-center gap-2 px-3 pb-2 pt-3">
+        <span className="dot" style={{ ['--dot' as string]: meta.color }} aria-hidden="true" />
+        <h2 className="text-[13px] font-semibold text-neutral-800">{meta.label}</h2>
+        <span className="identifier rounded-full bg-neutral-900/6 px-1.5 py-0.5 text-[11px] font-medium text-neutral-500">
+          {issues.length}
+        </span>
         {load && load.points > 0 && (
           <span
-            className="identifier ml-auto text-xs text-neutral-400"
+            className="identifier ml-auto text-[11px] text-neutral-400"
             title={
               load.unestimated_count > 0
                 ? `${load.points} points, with ${load.unestimated_count} issue${
@@ -54,16 +65,70 @@ function Column({
             {load.unestimated_count > 0 && <span className="text-neutral-300"> +?</span>}
           </span>
         )}
-      </div>
-      <div className="flex-1 space-y-2 overflow-y-auto px-2 pb-3">
+        <button
+          type="button"
+          onClick={onCollapse}
+          aria-label={`Collapse ${meta.label}`}
+          title="Collapse column"
+          className={`btn btn-ghost btn-icon btn-xs text-neutral-400 opacity-0 transition group-hover/column:opacity-100 focus-visible:opacity-100 ${
+            load && load.points > 0 ? '' : 'ml-auto'
+          }`}
+        >
+          <Icon name="chevron-left" size={13} />
+        </button>
+      </header>
+
+      <div className="scroll-thin flex-1 space-y-2 overflow-y-auto px-2 pb-2">
         {issues.map((issue) => (
           <IssueCard key={issue.id} issue={issue} />
         ))}
         {issues.length === 0 && (
-          <p className="px-2 py-4 text-center text-xs text-neutral-400">No issues</p>
+          <div className="flex h-24 items-center justify-center rounded-card border border-dashed border-neutral-900/10 text-xs text-neutral-400">
+            {isOver ? 'Drop here' : 'No issues'}
+          </div>
         )}
       </div>
-    </div>
+    </section>
+  )
+}
+
+/** A folded column: a thin rail that still accepts drops and shows its count. */
+function CollapsedColumn({
+  status,
+  count,
+  onExpand,
+}: {
+  status: IssueStatus
+  count: number
+  onExpand: () => void
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: status })
+  const meta = STATUS_META[status]
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      onClick={onExpand}
+      data-column={status}
+      data-collapsed="true"
+      aria-label={`Expand ${meta.label}, ${count} issues`}
+      title={`${meta.label} · ${count}`}
+      className={`glass-subtle flex w-11 shrink-0 flex-col items-center gap-3 rounded-panel py-3 transition-[box-shadow,background-color] hover:bg-neutral-900/5 ${
+        isOver ? 'bg-brand-500/10 ring-2 ring-brand-400/60' : ''
+      }`}
+    >
+      <span className="dot" style={{ ['--dot' as string]: meta.color }} aria-hidden="true" />
+      <span
+        className="text-[12px] font-semibold text-neutral-700"
+        style={{ writingMode: 'vertical-rl' }}
+      >
+        {meta.label}
+      </span>
+      <span className="identifier rounded-full bg-neutral-900/6 px-1.5 py-0.5 text-[11px] font-medium text-neutral-500">
+        {count}
+      </span>
+    </button>
   )
 }
 
@@ -80,6 +145,17 @@ export function KanbanBoard({
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   )
+  const [collapsed, setCollapsed] = useState<Set<IssueStatus>>(
+    () => new Set(COLLAPSED_BY_DEFAULT),
+  )
+
+  const setCollapsedFor = (status: IssueStatus, value: boolean) =>
+    setCollapsed((current) => {
+      const next = new Set(current)
+      if (value) next.add(status)
+      else next.delete(status)
+      return next
+    })
 
   /**
    * Arrow keys move focus between cards.
@@ -97,7 +173,9 @@ export function KanbanBoard({
     const active = document.activeElement
     if (!(active instanceof HTMLElement) || !active.hasAttribute('data-card')) return
 
-    const columns = [...board.querySelectorAll<HTMLElement>('[data-column]')]
+    const columns = [
+      ...board.querySelectorAll<HTMLElement>('[data-column]:not([data-collapsed])'),
+    ]
     const column = active.closest<HTMLElement>('[data-column]')
     if (!column) return
 
@@ -139,15 +217,29 @@ export function KanbanBoard({
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      <div className="flex h-full gap-3 overflow-x-auto p-4" onKeyDown={moveFocus}>
-        {STATUS_ORDER.map((status) => (
-          <Column
-            key={status}
-            status={status}
-            issues={issues.filter((issue) => issue.status === status)}
-            load={estimates?.by_status?.[status]}
-          />
-        ))}
+      <div
+        className="scroll-thin flex h-full snap-x snap-mandatory gap-3 overflow-x-auto pb-1 lg:snap-none"
+        onKeyDown={moveFocus}
+      >
+        {STATUS_ORDER.map((status) => {
+          const inColumn = issues.filter((issue) => issue.status === status)
+          return collapsed.has(status) ? (
+            <CollapsedColumn
+              key={status}
+              status={status}
+              count={inColumn.length}
+              onExpand={() => setCollapsedFor(status, false)}
+            />
+          ) : (
+            <Column
+              key={status}
+              status={status}
+              issues={inColumn}
+              load={estimates?.by_status?.[status]}
+              onCollapse={() => setCollapsedFor(status, true)}
+            />
+          )
+        })}
       </div>
     </DndContext>
   )

--- a/frontend/src/board/Sidebar.tsx
+++ b/frontend/src/board/Sidebar.tsx
@@ -1,10 +1,13 @@
 import { Link, useNavigate } from 'react-router-dom'
 
 import { useAuth } from '@/auth/AuthContext'
+import { CycleList } from '@/cycles/CycleList'
 import { useTeamContext } from '@/team/TeamContext'
 import { Avatar } from '@/ui/Avatar'
-import { CycleList } from '@/cycles/CycleList'
+import { Icon } from '@/ui/Icon'
 import { Logo } from '@/ui/Logo'
+import { Select } from '@/ui/Select'
+import { useTheme } from '@/ui/theme'
 
 export function Sidebar({
   activeProjectId,
@@ -24,84 +27,85 @@ export function Sidebar({
   const { user, logout } = useAuth()
   const { team, teams, projects, cycles } = useTeamContext()
   const navigate = useNavigate()
+  const { theme, toggle: toggleTheme } = useTheme()
 
   return (
-    <aside className="flex w-60 shrink-0 flex-col border-r border-neutral-200 bg-white">
-      <div className="flex items-center gap-2 px-3 pt-3 pb-1">
-        <Logo size={20} />
-        <span className="text-sm font-semibold tracking-tight text-neutral-900">SoftTrack</span>
+    <aside className="glass-strong flex h-full w-60 flex-col rounded-panel">
+      <div className="flex items-center justify-between px-3 pb-2 pt-3">
+        <Logo size={26} withWordmark />
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="btn btn-ghost btn-icon btn-sm"
+          aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+          title={theme === 'dark' ? 'Light theme' : 'Dark theme'}
+        >
+          <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={15} />
+        </button>
       </div>
-      <div className="border-b border-neutral-200 p-3">
-        <select
+
+      <div className="px-3 pb-3">
+        <Select
+          block
           value={team.key}
           onChange={(e) => navigate(`/${e.target.value}`)}
-          className="w-full rounded-md border border-neutral-200 bg-neutral-50 px-2 py-1.5 text-sm font-medium text-neutral-800 focus:outline-none"
+          aria-label="Team"
         >
           {teams.map((t) => (
             <option key={t.id} value={t.key}>
-              {t.name} ({t.key})
+              {t.name} · {t.key}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
 
-      <nav className="flex-1 space-y-4 overflow-y-auto p-3">
+      <nav className="scroll-thin flex-1 space-y-5 overflow-y-auto px-3 pb-3">
         <div>
-          <div className="mb-1 px-2 text-xs font-semibold uppercase tracking-wide text-neutral-400">
-            Views
-          </div>
+          <p className="eyebrow mb-1.5 px-2">Views</p>
           <button
+            type="button"
             onClick={() => onSelectProject('all')}
-            className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
-              activeProjectId === 'all'
-                ? 'bg-brand-50 font-medium text-brand-700'
-                : 'text-neutral-700 hover:bg-neutral-50'
-            }`}
+            className="nav-item"
+            data-active={activeProjectId === 'all'}
           >
+            <Icon name="board" size={15} className="opacity-70" />
             All issues
           </button>
         </div>
 
         <div>
-          <div className="mb-1 flex items-center justify-between px-2">
-            <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
-              Cycles
-            </span>
+          <div className="mb-1.5 flex items-center justify-between px-2">
+            <p className="eyebrow">Cycles</p>
             <button
+              type="button"
               onClick={onNewCycle}
               aria-label="New cycle"
-              className="text-neutral-400 hover:text-neutral-700"
+              title="New cycle"
+              className="btn btn-ghost btn-icon btn-xs"
             >
-              +
+              <Icon name="plus" size={13} />
             </button>
           </div>
-          <CycleList
-            cycles={cycles}
-            activeCycleId={activeCycleId}
-            onSelect={onSelectCycle}
-          />
+          <CycleList cycles={cycles} activeCycleId={activeCycleId} onSelect={onSelectCycle} />
         </div>
 
         <div>
-          <div className="mb-1 px-2 text-xs font-semibold uppercase tracking-wide text-neutral-400">
-            Projects
-          </div>
+          <p className="eyebrow mb-1.5 px-2">Projects</p>
           {projects.length === 0 && (
-            <p className="px-2 text-sm text-neutral-400">No projects yet.</p>
+            <p className="px-2 text-xs text-neutral-400">No projects yet.</p>
           )}
           {projects.map((project) => (
             <button
               key={project.id}
+              type="button"
               onClick={() => onSelectProject(project.id)}
-              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
-                activeProjectId === project.id
-                  ? 'bg-brand-50 font-medium text-brand-700'
-                  : 'text-neutral-700 hover:bg-neutral-50'
-              }`}
+              className="nav-item"
+              data-active={activeProjectId === project.id}
             >
               <span
-                className="h-2 w-2 shrink-0 rounded-full"
-                style={{ backgroundColor: project.color }}
+                className="dot"
+                style={{ ['--dot' as string]: project.color }}
+                aria-hidden="true"
               />
               <span className="truncate">{project.name}</span>
             </button>
@@ -109,38 +113,35 @@ export function Sidebar({
         </div>
       </nav>
 
-      <div className="px-3 pb-1">
-        <button
-          onClick={onImport}
-          className="w-full rounded-md px-2 py-1.5 text-left text-sm text-neutral-500 hover:bg-neutral-50 hover:text-neutral-700"
-        >
+      <div className="space-y-0.5 px-3 pb-2">
+        <button type="button" onClick={onImport} className="nav-item text-neutral-500">
+          <Icon name="upload" size={15} className="opacity-70" />
           Import from Jira
         </button>
+        <Link to="/new-team" className="nav-item text-neutral-500">
+          <Icon name="plus" size={15} className="opacity-70" />
+          New team
+        </Link>
       </div>
 
-      <div className="border-t border-neutral-200 p-3">
-        <Link
-          to="/new-team"
-          className="mb-2 block px-2 text-xs text-neutral-400 hover:text-neutral-600"
-        >
-          + New team
-        </Link>
-        {user && (
-          <div className="flex items-center gap-2 px-2">
-            <Avatar user={user} size={26} />
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-neutral-800">{user.full_name}</p>
-            </div>
-            <button
-              onClick={logout}
-              className="text-xs text-neutral-400 hover:text-neutral-600"
-              title="Sign out"
-            >
-              Sign out
-            </button>
+      {user && (
+        <div className="hairline flex items-center gap-2.5 border-t px-3 py-3">
+          <Avatar user={user} size={30} />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-neutral-900">{user.full_name}</p>
+            <p className="truncate text-[11px] text-neutral-400">{user.email}</p>
           </div>
-        )}
-      </div>
+          <button
+            type="button"
+            onClick={logout}
+            className="btn btn-ghost btn-icon btn-sm text-neutral-400"
+            title="Sign out"
+            aria-label="Sign out"
+          >
+            <Icon name="logout" size={15} />
+          </button>
+        </div>
+      )}
     </aside>
   )
 }

--- a/frontend/src/board/TopBar.tsx
+++ b/frontend/src/board/TopBar.tsx
@@ -1,13 +1,22 @@
 import type { IssuePriority } from '@/api/generated/models'
-import { PRIORITY_META, PRIORITY_ORDER } from '@/issues/issueMeta'
 import type { AssigneeFilter } from '@/board/filterIssues'
+import { PRIORITY_META, PRIORITY_ORDER } from '@/issues/issueMeta'
 import type { BoardView } from '@/keyboard/useCommands'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon, type IconName } from '@/ui/Icon'
+import { Select } from '@/ui/Select'
+
+const VIEWS: Array<{ id: BoardView; label: string; icon: IconName }> = [
+  { id: 'board', label: 'Board', icon: 'board' },
+  { id: 'list', label: 'List', icon: 'list' },
+  { id: 'reports', label: 'Reports', icon: 'chart' },
+]
 
 export function TopBar({
   view,
   onViewChange,
   onNewIssue,
+  onOpenSidebar,
   search,
   onSearchChange,
   priorityFilter,
@@ -18,6 +27,7 @@ export function TopBar({
   view: BoardView
   onViewChange: (view: BoardView) => void
   onNewIssue: () => void
+  onOpenSidebar: () => void
   search: string
   onSearchChange: (value: string) => void
   priorityFilter: IssuePriority | 'all'
@@ -28,42 +38,43 @@ export function TopBar({
   const { team, members } = useTeamContext()
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-neutral-200 bg-white px-4 py-2.5">
-      <div className="flex items-center gap-3">
-        <h1 className="text-sm font-semibold text-neutral-900">{team.name}</h1>
-        <div className="flex rounded-md border border-neutral-200 p-0.5 text-xs">
-          <button
-            onClick={() => onViewChange('board')}
-            className={`rounded px-2 py-1 font-medium ${
-              view === 'board' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:text-neutral-800'
-            }`}
-          >
-            Board
-          </button>
-          <button
-            onClick={() => onViewChange('list')}
-            className={`rounded px-2 py-1 font-medium ${
-              view === 'list' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:text-neutral-800'
-            }`}
-          >
-            List
-          </button>
-          <button
-            onClick={() => onViewChange('reports')}
-            className={`rounded px-2 py-1 font-medium ${
-              view === 'reports'
-                ? 'bg-neutral-900 text-white'
-                : 'text-neutral-500 hover:text-neutral-800'
-            }`}
-          >
-            Reports
-          </button>
-        </div>
+    <header className="glass flex flex-wrap items-center gap-2 rounded-panel px-3 py-2">
+      <button
+        type="button"
+        onClick={onOpenSidebar}
+        className="btn btn-ghost btn-icon btn-sm lg:hidden"
+        aria-label="Open navigation"
+      >
+        <Icon name="menu" size={16} />
+      </button>
 
-        <select
+      <h1 className="mr-1 truncate text-sm font-semibold tracking-tight text-neutral-900">
+        {team.name}
+      </h1>
+
+      <div className="segmented" role="tablist" aria-label="View">
+        {VIEWS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={view === item.id}
+            data-active={view === item.id}
+            onClick={() => onViewChange(item.id)}
+            className="segmented-item"
+          >
+            <Icon name={item.icon} size={13} />
+            <span className="hidden sm:inline">{item.label}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Select
+          dense
           value={priorityFilter}
           onChange={(e) => onPriorityFilterChange(e.target.value as IssuePriority | 'all')}
-          className="rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-600 focus:outline-none"
+          aria-label="Filter by priority"
         >
           <option value="all">All priorities</option>
           {PRIORITY_ORDER.map((p) => (
@@ -71,15 +82,16 @@ export function TopBar({
               {PRIORITY_META[p].label}
             </option>
           ))}
-        </select>
+        </Select>
 
-        <select
+        <Select
+          dense
           value={String(assigneeFilter)}
           onChange={(e) => {
             const v = e.target.value
             onAssigneeFilterChange(v === 'all' || v === 'unassigned' ? v : Number(v))
           }}
-          className="rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-600 focus:outline-none"
+          aria-label="Filter by assignee"
         >
           <option value="all">Everyone</option>
           <option value="unassigned">Unassigned</option>
@@ -88,23 +100,45 @@ export function TopBar({
               {m.user.full_name}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
 
-      <div className="flex items-center gap-2">
-        <input
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search issues…"
-          className="w-52 rounded-md border border-neutral-200 px-2.5 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
-        />
-        <button
-          onClick={onNewIssue}
-          className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700"
-        >
-          New issue
+      <div className="ml-auto flex items-center gap-2">
+        <label className="relative block">
+          <span className="sr-only">Search issues</span>
+          <Icon
+            name="search"
+            size={14}
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-400"
+          />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search issues…"
+            className="field field-sm w-40 rounded-full pl-8 pr-8 sm:w-56 [&::-webkit-search-cancel-button]:hidden"
+          />
+          {search ? (
+            <button
+              type="button"
+              onClick={() => onSearchChange('')}
+              aria-label="Clear search"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-neutral-400 hover:text-neutral-800"
+            >
+              <Icon name="close" size={13} />
+            </button>
+          ) : (
+            <kbd className="kbd pointer-events-none absolute right-2 top-1/2 hidden -translate-y-1/2 sm:inline-flex">
+              /
+            </kbd>
+          )}
+        </label>
+
+        <button type="button" onClick={onNewIssue} className="btn btn-primary">
+          <Icon name="plus" size={14} strokeWidth={2.2} />
+          <span className="hidden sm:inline">New issue</span>
         </button>
       </div>
-    </div>
+    </header>
   )
 }

--- a/frontend/src/board/overlays.ts
+++ b/frontend/src/board/overlays.ts
@@ -6,6 +6,11 @@
  * makes "close the shallowest thing" mean exactly that -- the most recently
  * opened -- with no chain to keep in sync when a sixth overlay arrives.
  *
+ * Every action that changes nothing returns the *same* array. That is not a
+ * micro-optimisation: a fresh empty array on Escape re-rendered the board
+ * between window listeners, which unregistered the issue panel's own Escape
+ * handler before it ran, so Escape silently did nothing on an open issue.
+ *
  * Pure so it can be tested without React.
  */
 export type Overlay = 'newIssue' | 'palette' | 'shortcuts' | 'newCycle' | 'import'
@@ -22,16 +27,19 @@ export type OverlayAction =
 export function overlayReducer(stack: OverlayStack, action: OverlayAction): OverlayStack {
   switch (action.type) {
     case 'open':
-      // Re-opening something already open brings it to the top rather than
-      // stacking a duplicate.
+      // Re-opening something already on top is a no-op; otherwise bring it
+      // to the top rather than stacking a duplicate.
+      if (stack[stack.length - 1] === action.overlay) return stack
       return [...stack.filter((o) => o !== action.overlay), action.overlay]
     case 'close':
+      if (!stack.includes(action.overlay)) return stack
       return stack.filter((o) => o !== action.overlay)
     case 'toggle':
       return stack.includes(action.overlay)
         ? overlayReducer(stack, { type: 'close', overlay: action.overlay })
         : overlayReducer(stack, { type: 'open', overlay: action.overlay })
     case 'closeTop':
+      if (stack.length === 0) return stack
       return stack.slice(0, -1)
   }
 }

--- a/frontend/src/board/useStatusChange.ts
+++ b/frontend/src/board/useStatusChange.ts
@@ -6,6 +6,9 @@ import {
 } from '@/api/generated/endpoints/issues/issues'
 import type { IssueRead, IssueStatus, TeamRead } from '@/api/generated/models'
 
+/** The shape the list endpoint caches: a page, not a bare array. */
+type IssuePage = { items: IssueRead[]; total: number; limit: number; offset: number }
+
 /**
  * Move an issue between columns, optimistically.
  *
@@ -23,10 +26,16 @@ export function useStatusChange(
   return async (issueId: number, status: IssueStatus) => {
     if (!team) return
     const queryKey = getListIssuesTeamsTeamIdIssuesGetQueryKey(team.id, issuesParams)
-    const previous = queryClient.getQueryData<IssueRead[]>(queryKey)
-    queryClient.setQueryData<IssueRead[]>(
-      queryKey,
-      (old) => old?.map((issue) => (issue.id === issueId ? { ...issue, status } : issue)) ?? old,
+    const previous = queryClient.getQueryData<IssuePage>(queryKey)
+    queryClient.setQueryData<IssuePage>(queryKey, (old) =>
+      old
+        ? {
+            ...old,
+            items: old.items.map((issue) =>
+              issue.id === issueId ? { ...issue, status } : issue,
+            ),
+          }
+        : old,
     )
     try {
       await updateIssue.mutateAsync({ issueId, data: { status } })

--- a/frontend/src/cycles/CycleBanner.tsx
+++ b/frontend/src/cycles/CycleBanner.tsx
@@ -7,7 +7,9 @@ import {
   useStartCycleCyclesCycleIdStartPost,
 } from '@/api/generated/endpoints/cycles/cycles'
 import type { CycleRead } from '@/api/generated/models'
+import { errorDetail } from '@/api/errors'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon } from '@/ui/Icon'
 
 /** Shown above the board while a cycle is selected. */
 export function CycleBanner({ cycle }: { cycle: CycleRead }) {
@@ -32,21 +34,21 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
       setMessage(describe(result as never))
       refresh()
     } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
-        ?.detail
-      setError(typeof detail === 'string' ? detail : 'That did not work.')
+      setError(errorDetail(err, 'That did not work.'))
     }
   }
 
   const { progress } = cycle
   const ends = new Date(cycle.ends_at)
   const overdue = cycle.state === 'active' && isPast(ends)
+  const done = progress.issues_total > 0 ? progress.issues_completed / progress.issues_total : 0
 
   return (
-    <div className="border-b border-neutral-200 bg-white px-4 py-2.5">
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <span className="text-sm font-medium text-neutral-900">{cycle.display_name}</span>
-        <span className="text-xs text-neutral-400">
+    <div className="glass rounded-panel px-4 py-2.5">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+        <Icon name="calendar" size={15} className="text-neutral-400" />
+        <span className="text-sm font-semibold text-neutral-900">{cycle.display_name}</span>
+        <span className="text-xs text-neutral-500">
           {format(new Date(cycle.starts_at), 'd MMM')} – {format(ends, 'd MMM')}
           {cycle.state !== 'completed' && (
             <span className={overdue ? 'text-danger-600' : undefined}>
@@ -57,9 +59,21 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
           )}
         </span>
 
-        <span className="text-xs text-neutral-500">
-          {progress.issues_completed}/{progress.issues_total} issues ·{' '}
-          {progress.points_completed}/{progress.points_total} pts
+        <span className="flex items-center gap-2 text-xs text-neutral-500">
+          <span className="hidden h-1.5 w-24 overflow-hidden rounded-full bg-neutral-900/8 sm:block">
+            <span
+              className="block h-full rounded-full bg-linear-to-r from-brand-500 to-accent-sky"
+              style={{ width: `${done * 100}%` }}
+            />
+          </span>
+          <span className="identifier">
+            {progress.issues_completed}/{progress.issues_total}
+          </span>{' '}
+          issues ·{' '}
+          <span className="identifier">
+            {progress.points_completed}/{progress.points_total}
+          </span>{' '}
+          pts
           {progress.issues_unestimated > 0 && (
             <span
               className="text-neutral-400"
@@ -82,7 +96,7 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
                   () => 'Cycle started.',
                 )
               }
-              className="rounded-md bg-brand-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+              className="btn btn-primary btn-sm"
             >
               Start cycle
             </button>
@@ -104,21 +118,26 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
                         }.`,
                 )
               }
-              className="rounded-md bg-brand-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+              className="btn btn-primary btn-sm"
             >
               Complete cycle
             </button>
           )}
           {cycle.state === 'completed' && (
-            <span className="text-xs text-neutral-400">Completed</span>
+            <span
+              className="chip"
+              style={{ ['--chip' as string]: 'var(--color-status-done)' }}
+            >
+              <Icon name="check" size={11} /> Completed
+            </span>
           )}
         </div>
       </div>
 
       {/* Say what happened to the carried-over work rather than leaving people
           to wonder where their issues went. */}
-      {message && <p className="mt-1 text-xs text-brand-700">{message}</p>}
-      {error && <p className="mt-1 text-xs text-danger-600">{error}</p>}
+      {message && <p className="mt-1.5 text-xs text-brand-700">{message}</p>}
+      {error && <p className="mt-1.5 text-xs text-danger-600">{error}</p>}
     </div>
   )
 }

--- a/frontend/src/cycles/CycleList.tsx
+++ b/frontend/src/cycles/CycleList.tsx
@@ -27,7 +27,7 @@ export function CycleList({
   )
 
   if (cycles.length === 0) {
-    return <p className="px-2 text-sm text-neutral-400">No cycles yet.</p>
+    return <p className="px-2 text-xs text-neutral-400">No cycles yet.</p>
   }
 
   return (
@@ -43,6 +43,12 @@ export function CycleList({
     </div>
   )
 }
+
+const STATE_COLOUR = {
+  active: 'var(--color-status-progress)',
+  upcoming: 'var(--color-status-todo)',
+  completed: 'var(--color-status-done)',
+} as const
 
 function CycleRow({
   cycle,
@@ -60,26 +66,22 @@ function CycleRow({
 
   return (
     <button
+      type="button"
       onClick={onSelect}
-      className={`w-full rounded-md px-2 py-1.5 text-left ${
-        selected ? 'bg-brand-50' : 'hover:bg-neutral-50'
-      }`}
+      data-active={selected}
+      aria-pressed={selected}
+      className="nav-item flex-col items-stretch gap-1"
     >
-      <div className="flex items-baseline gap-1.5">
+      <span className="flex items-center gap-2">
         <span
-          className={`h-1.5 w-1.5 shrink-0 rounded-full ${
-            cycle.state === 'active'
-              ? 'bg-status-in_progress'
-              : cycle.state === 'completed'
-                ? 'bg-neutral-300'
-                : 'bg-neutral-200 ring-1 ring-neutral-300'
-          }`}
+          className="dot"
+          style={{ ['--dot' as string]: STATE_COLOUR[cycle.state] }}
           title={cycle.state}
         />
         <span
-          className={`min-w-0 flex-1 truncate text-sm ${
-            selected ? 'font-medium text-brand-700' : 'text-neutral-700'
-          } ${cycle.state === 'completed' ? 'text-neutral-400' : ''}`}
+          className={`min-w-0 flex-1 truncate ${
+            cycle.state === 'completed' ? 'text-neutral-400' : ''
+          }`}
         >
           {cycle.display_name}
         </span>
@@ -88,17 +90,21 @@ function CycleRow({
             {progress.issues_completed}/{progress.issues_total}
           </span>
         )}
-      </div>
+      </span>
 
       {cycle.state !== 'completed' && (
         <>
-          <div className="mt-1 h-1 overflow-hidden rounded-full bg-neutral-100">
-            <div
-              className="h-full rounded-full bg-brand-500 transition-all"
+          <span className="block h-1 overflow-hidden rounded-full bg-neutral-900/8">
+            <span
+              className="block h-full rounded-full bg-linear-to-r from-brand-500 to-accent-sky transition-all"
               style={{ width: `${done * 100}%` }}
             />
-          </div>
-          <p className={`mt-0.5 text-[11px] ${overdue ? 'text-danger-600' : 'text-neutral-400'}`}>
+          </span>
+          <span
+            className={`block text-[11px] font-normal ${
+              overdue ? 'text-danger-600' : 'text-neutral-400'
+            }`}
+          >
             {/* Points, not just issues -- eight of ten issues done with two of
                 thirty points burned means the hard work is still ahead. */}
             {progress.points_total > 0 && (
@@ -108,7 +114,7 @@ function CycleRow({
             )}
             {overdue ? 'ended ' : 'ends '}
             {formatDistanceToNow(ends, { addSuffix: true })}
-          </p>
+          </span>
         </>
       )}
     </button>

--- a/frontend/src/cycles/NewCycleModal.tsx
+++ b/frontend/src/cycles/NewCycleModal.tsx
@@ -3,6 +3,7 @@ import { addDays, format } from 'date-fns'
 import { type FormEvent, useState } from 'react'
 
 import { useCreateCycleTeamsTeamIdCyclesPost } from '@/api/generated/endpoints/cycles/cycles'
+import { errorDetail } from '@/api/errors'
 import { useTeamContext } from '@/team/TeamContext'
 
 /** A day, as the value an <input type="date"> wants. */
@@ -34,74 +35,66 @@ export function NewCycleModal({ onClose }: { onClose: () => void }) {
       queryClient.invalidateQueries({ queryKey: [`/teams/${team.id}/cycles`] })
       onClose()
     } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data
-        ?.detail
-      setError(typeof detail === 'string' ? detail : 'Could not create that cycle.')
+      setError(errorDetail(err, 'Could not create that cycle.'))
     }
   }
 
   return (
     <div
-      className="fixed inset-0 z-30 flex items-start justify-center bg-black/20 pt-[15vh]"
+      className="scrim fixed inset-0 z-30 flex items-start justify-center px-4 pt-[15vh]"
       onClick={onClose}
     >
       <form
+        role="dialog"
+        aria-label="New cycle"
         onSubmit={onSubmit}
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-sm rounded-xl border border-neutral-200 bg-white p-4 shadow-2xl"
+        className="pop-in glass-strong w-full max-w-sm rounded-panel p-5"
       >
-        <h2 className="mb-3 text-sm font-semibold text-neutral-900">New cycle</h2>
+        <h2 className="mb-4 text-base font-semibold tracking-tight text-neutral-900">New cycle</h2>
 
-        <label className="mb-2 block">
-          <span className="mb-1 block text-xs text-neutral-500">Name (optional)</span>
+        <label className="mb-3 block">
+          <span className="mb-1.5 block text-xs font-medium text-neutral-500">Name (optional)</span>
           <input
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Left blank, it will be numbered"
-            className="w-full rounded-md border border-neutral-200 px-2.5 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+            className="field"
           />
         </label>
 
-        <div className="mb-3 flex gap-2">
+        <div className="mb-4 flex gap-3">
           <label className="flex-1">
-            <span className="mb-1 block text-xs text-neutral-500">Starts</span>
+            <span className="mb-1.5 block text-xs font-medium text-neutral-500">Starts</span>
             <input
               type="date"
               required
               value={startsAt}
               onChange={(e) => setStartsAt(e.target.value)}
-              className="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+              className="field"
             />
           </label>
           <label className="flex-1">
-            <span className="mb-1 block text-xs text-neutral-500">Ends</span>
+            <span className="mb-1.5 block text-xs font-medium text-neutral-500">Ends</span>
             <input
               type="date"
               required
               value={endsAt}
               onChange={(e) => setEndsAt(e.target.value)}
-              className="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+              className="field"
             />
           </label>
         </div>
 
-        {error && <p className="mb-2 text-xs text-danger-600">{error}</p>}
+        {error && <p className="mb-3 text-xs text-danger-600">{error}</p>}
 
         <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md px-2.5 py-1.5 text-sm text-neutral-500 hover:text-neutral-700"
-          >
+          <button type="button" onClick={onClose} className="btn btn-ghost">
             Cancel
           </button>
-          <button
-            type="submit"
-            disabled={createCycle.isPending}
-            className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
-          >
-            Create
+          <button type="submit" disabled={createCycle.isPending} className="btn btn-primary">
+            {createCycle.isPending ? 'Creating…' : 'Create cycle'}
           </button>
         </div>
       </form>

--- a/frontend/src/imports/ImportJiraModal.tsx
+++ b/frontend/src/imports/ImportJiraModal.tsx
@@ -2,8 +2,10 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 
 import { AXIOS_INSTANCE } from '@/api/client'
+import { errorDetail } from '@/api/errors'
 import type { ImportReport } from '@/api/generated/models'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon } from '@/ui/Icon'
 
 /**
  * Import a Jira export.
@@ -42,9 +44,7 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
         queryClient.invalidateQueries({ queryKey: [`/teams/${team.id}/projects`] })
       }
     } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data
-        ?.detail
-      setError(typeof detail === 'string' ? detail : 'That import could not be read.')
+      setError(errorDetail(err, 'That import could not be read.'))
       setReport(null)
     } finally {
       setBusy(false)
@@ -55,40 +55,56 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-30 flex items-start justify-center bg-black/20 p-4 pt-[8vh]"
+      className="scrim fixed inset-0 z-30 flex items-start justify-center p-4 pt-[8vh]"
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-label="Import from Jira"
         onClick={(e) => e.stopPropagation()}
-        className="flex max-h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-2xl"
+        className="pop-in glass-strong flex max-h-[80vh] w-full max-w-lg flex-col overflow-hidden rounded-panel"
       >
-        <div className="border-b border-neutral-100 px-4 py-3">
-          <h2 className="text-sm font-semibold text-neutral-900">Import from Jira</h2>
+        <div className="hairline border-b px-5 py-4">
+          <h2 className="text-base font-semibold tracking-tight text-neutral-900">Import from Jira</h2>
           <p className="mt-0.5 text-xs text-neutral-500">
             A Jira CSV or JSON export. Export with the <em>Issue key</em> column so the
             import can be re-run safely.
           </p>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-          <input
-            type="file"
-            accept=".csv,.json,text/csv,application/json"
-            onChange={(e) => {
-              setFile(e.target.files?.[0] ?? null)
-              setReport(null)
-              setDone(false)
-              setError(null)
-            }}
-            className="w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-neutral-100 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-neutral-700 hover:file:bg-neutral-200"
-          />
+        <div className="scroll-thin min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <label className="well flex cursor-pointer items-center gap-3 rounded-card border-dashed px-4 py-3 transition hover:border-brand-400/60">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-500/12 text-brand-700">
+              <Icon name="upload" size={16} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-neutral-800">
+                {file ? file.name : 'Choose a Jira export'}
+              </span>
+              <span className="block text-xs text-neutral-400">
+                {file ? `${Math.max(1, Math.round(file.size / 1024))} KB` : '.csv or .json, up to 20 MB'}
+              </span>
+            </span>
+            <span className="btn btn-secondary btn-sm">Browse</span>
+            <input
+              type="file"
+              accept=".csv,.json,text/csv,application/json"
+              className="sr-only"
+              onChange={(e) => {
+                setFile(e.target.files?.[0] ?? null)
+                setReport(null)
+                setDone(false)
+                setError(null)
+              }}
+            />
+          </label>
 
           {error && <p className="mt-3 text-sm text-danger-600">{error}</p>}
 
           {report && (
             <div className="mt-4 space-y-3">
-              <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3">
-                <p className="text-sm font-medium text-neutral-800">
+              <div className="well rounded-card p-3">
+                <p className="text-sm font-medium text-neutral-900">
                   {done ? 'Imported' : 'This import would create'}
                 </p>
                 <ul className="mt-1 space-y-0.5 text-sm text-neutral-600">
@@ -138,7 +154,8 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
                   {report.warnings.map((warning) => (
                     <li
                       key={warning}
-                      className="rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-900"
+                      className="chip h-auto whitespace-normal rounded-card px-3 py-2 text-xs font-normal"
+                      style={{ ['--chip' as string]: 'var(--color-accent-amber)' }}
                     >
                       {warning}
                     </li>
@@ -148,9 +165,7 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
 
               {unmatched.length > 0 && !done && (
                 <div>
-                  <p className="mb-1 text-xs font-medium text-neutral-500">
-                    Not members of this team
-                  </p>
+                  <p className="eyebrow mb-1">Not members of this team</p>
                   <ul className="space-y-0.5">
                     {unmatched.map((user) => (
                       <li key={user.source} className="text-xs text-neutral-600">
@@ -167,7 +182,7 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
 
               {report.preview.length > 0 && !done && (
                 <div>
-                  <p className="mb-1 text-xs font-medium text-neutral-500">
+                  <p className="eyebrow mb-1">
                     First {report.preview.length} of {report.issues_found}
                   </p>
                   <ul className="space-y-0.5">
@@ -192,18 +207,16 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
           )}
         </div>
 
-        <div className="flex items-center justify-end gap-2 border-t border-neutral-100 px-4 py-3">
-          <button
-            onClick={onClose}
-            className="rounded-md px-2.5 py-1.5 text-sm text-neutral-500 hover:text-neutral-700"
-          >
+        <div className="hairline flex items-center justify-end gap-2 border-t px-5 py-3">
+          <button type="button" onClick={onClose} className="btn btn-ghost">
             {done ? 'Close' : 'Cancel'}
           </button>
           {!done && (
             <button
+              type="button"
               onClick={() => send(report ? false : true)}
               disabled={!file || busy}
-              className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+              className="btn btn-primary"
             >
               {busy
                 ? 'Working…'
@@ -221,7 +234,7 @@ export function ImportJiraModal({ onClose }: { onClose: () => void }) {
 function Count({ n, one, many }: { n: number; one: string; many: string }) {
   return (
     <>
-      <span className="identifier font-medium text-neutral-800">{n}</span>{' '}
+      <span className="identifier font-medium text-neutral-900">{n}</span>{' '}
       {n === 1 ? one : many}
     </>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,119 +1,669 @@
 @import "tailwindcss";
 
 /* ---------------------------------------------------------------------------
-   SoftTrack design tokens
+   SoftTrack design tokens -- "liquid glass"
    ---------------------------------------------------------------------------
    Tailwind v4 is configured CSS-first: everything declared in `@theme` becomes
    both a utility class (`bg-brand-600`) and a CSS variable (`--color-brand-600`).
 
-   Three layers, in order of how often you should reach for them:
-     1. semantic  -- status.*, priority.*  : meaning, not appearance
-     2. brand     -- brand.*               : the product's identity
-     3. neutral   -- neutral.*             : surfaces, borders, text
+   The visual model is three layers:
+     1. the canvas: a soft aurora of brand colour behind everything
+     2. glass: translucent panels that blur and saturate what is behind them
+     3. ink: text and controls that sit on the glass
 
-   Prefer the semantic layer. `bg-status-progress` survives a palette change;
-   `bg-amber-500` does not.
+   Every neutral is theme-aware. The ramp is written for light and flipped for
+   dark under `[data-theme="dark"]`, so `text-neutral-700` reads correctly in
+   both without a second set of classes.
 --------------------------------------------------------------------------- */
 
 @theme {
   /* -- Brand -------------------------------------------------------------
-     A violet-leaning indigo. 600 is the primary: it is the fill of the logo
-     mark, the colour of every primary action, and the only saturated colour
-     allowed to carry brand meaning. */
-  --color-brand-50:  #f2f1fd;
-  --color-brand-100: #e6e4fb;
-  --color-brand-200: #cfcbf8;
-  --color-brand-300: #b0a8f3;
-  --color-brand-400: #8f80ec;
-  --color-brand-500: #7559e4;
+     A violet-leaning indigo, with three accents used only in the aurora and
+     in gradients. 600 remains the one saturated colour allowed to carry
+     brand meaning on its own. */
+  --color-brand-50:  #f3f1ff;
+  --color-brand-100: #e8e4ff;
+  --color-brand-200: #d3ccff;
+  --color-brand-300: #b4a6ff;
+  --color-brand-400: #937bff;
+  --color-brand-500: #7a5cf5;
   --color-brand-600: #6342db;
   --color-brand-700: #5433bd;
   --color-brand-800: #462c9a;
   --color-brand-900: #3b277b;
 
-  /* -- Neutrals ----------------------------------------------------------
-     Biased very slightly toward the brand hue rather than pure grey, so
-     surfaces sit with the accent instead of fighting it. */
-  --color-neutral-50:  #fafafb;
-  --color-neutral-100: #f4f4f7;
-  --color-neutral-200: #e9e9ef;
-  --color-neutral-300: #d8d8e1;
-  --color-neutral-400: #a9a9b8;
-  --color-neutral-500: #7d7d8d;
-  --color-neutral-600: #5b5b6a;
-  --color-neutral-700: #44444f;
-  --color-neutral-800: #2d2d36;
-  --color-neutral-900: #1a1a21;
+  --color-accent-sky:   #4f8cff;
+  --color-accent-pink:  #ff6fae;
+  --color-accent-mint:  #2fd4a7;
+  --color-accent-amber: #ffb648;
 
-  /* -- Status ------------------------------------------------------------
-     One colour per workflow state. The two unstarted states are deliberately
-     neutral so that colour on a board means "something is happening". */
-  --color-status-backlog:   #a9a9b8;
-  --color-status-todo:      #7d7d8d;
-  --color-status-progress:  #ef9d0b;
+  /* -- Neutrals (light) --------------------------------------------------
+     Tinted toward the brand hue. 400 is the lightest tone used for text
+     that has to be read; it clears 4.5:1 on white. 300 and below are for
+     placeholders, borders and fills only. */
+  --color-neutral-50:  #f7f6fb;
+  --color-neutral-100: #eeedf5;
+  --color-neutral-200: #dedcea;
+  --color-neutral-300: #b6b3c8;
+  --color-neutral-400: #7a7791;
+  --color-neutral-500: #66637c;
+  --color-neutral-600: #514e66;
+  --color-neutral-700: #3b3850;
+  --color-neutral-800: #26243a;
+  --color-neutral-900: #15131f;
+
+  /* -- Status ------------------------------------------------------------ */
+  --color-status-backlog:   #9b98b0;
+  --color-status-todo:      #6f6c86;
+  --color-status-progress:  #f29d0b;
   --color-status-review:    #8b5cf6;
   --color-status-done:      #12a474;
   --color-status-cancelled: #f2647d;
 
-  /* -- Priority ----------------------------------------------------------
-     A warm ramp: the hotter the hue, the more urgent. `none` drops out of the
-     ramp entirely so unprioritised work reads as absence, not as low. */
+  /* -- Priority ---------------------------------------------------------- */
   --color-priority-urgent: #e0424a;
   --color-priority-high:   #f2721c;
   --color-priority-medium: #ef9d0b;
   --color-priority-low:    #3f82f6;
-  --color-priority-none:   #a9a9b8;
+  --color-priority-none:   #a29fb5;
 
-  /* -- Feedback ----------------------------------------------------------
-     Danger is separate from priority.urgent on purpose: one is a destructive
-     or failed action, the other is how important a piece of work is. They
-     look similar today but must be free to diverge. */
+  /* -- Feedback ---------------------------------------------------------- */
   --color-danger-50:  #fef2f3;
   --color-danger-500: #e0424a;
   --color-danger-600: #cf3038;
   --color-danger-700: #a81d24;
 
-  /* -- Type --------------------------------------------------------------
-     System stacks on purpose: SoftTrack is self-hosted, and a webfont CDN
-     would add a third-party request to every install. Mono is not decorative
-     -- issue identifiers (ENG-42) are tabular data and must align. */
+  /* -- Type -------------------------------------------------------------- */
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, "Apple Color Emoji", sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
     "Liberation Mono", monospace;
 
-  /* -- Radii -------------------------------------------------------------
-     Cards and controls share a radius so the board reads as one material. */
-  --radius-control: 0.375rem;
-  --radius-card:    0.5rem;
-  --radius-panel:   0.75rem;
+  /* -- Radii ------------------------------------------------------------- */
+  --radius-control: 0.625rem;
+  --radius-card:    0.875rem;
+  --radius-panel:   1.25rem;
 }
 
-:root {
-  color-scheme: light;
+/* ---------------------------------------------------------------------------
+   Glass and canvas variables. Not Tailwind namespaces, so they live here.
+--------------------------------------------------------------------------- */
+@layer base {
+  :root {
+    color-scheme: light;
+
+    --canvas: #eef0f8;
+    --aurora-opacity: 1;
+
+    --glass-fill:        rgba(255, 255, 255, 0.55);
+    --glass-fill-strong: rgba(255, 255, 255, 0.78);
+    --glass-fill-subtle: rgba(255, 255, 255, 0.34);
+    --glass-fill-card:   rgba(255, 255, 255, 0.82);
+    --glass-border:      rgba(255, 255, 255, 0.72);
+    --glass-edge:        rgba(60, 50, 110, 0.10);
+    --glass-highlight:   rgba(255, 255, 255, 0.95);
+    --glass-shadow:      rgba(40, 30, 90, 0.22);
+    --glass-blur:        22px;
+
+    --ink-shadow: rgba(20, 18, 40, 0.06);
+    --ring: color-mix(in oklab, var(--color-brand-500) 45%, transparent);
+    --chevron: %237a7791;
+  }
+
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+
+    --canvas: #0c0b15;
+    --aurora-opacity: 0.6;
+
+    --color-neutral-50:  #1b1a27;
+    --color-neutral-100: #262433;
+    --color-neutral-200: #363448;
+    --color-neutral-300: #5b586f;
+    --color-neutral-400: #9491aa;
+    --color-neutral-500: #aaa7bd;
+    --color-neutral-600: #c3c0d2;
+    --color-neutral-700: #d9d7e5;
+    --color-neutral-800: #ebeaf3;
+    --color-neutral-900: #f6f5fb;
+
+    --color-brand-50:  #221d3d;
+    --color-brand-100: #2b2450;
+
+    --color-status-backlog: #6f6c86;
+    --color-status-todo:    #9b98b0;
+    --color-priority-none:  #6f6c86;
+
+    --color-danger-50: #3a1a1f;
+    --color-danger-700: #ff8a92;
+
+    --glass-fill:        rgba(28, 26, 44, 0.55);
+    --glass-fill-strong: rgba(24, 22, 38, 0.82);
+    --glass-fill-subtle: rgba(28, 26, 44, 0.36);
+    --glass-fill-card:   rgba(38, 35, 56, 0.86);
+    --glass-border:      rgba(255, 255, 255, 0.10);
+    --glass-edge:        rgba(0, 0, 0, 0.35);
+    --glass-highlight:   rgba(255, 255, 255, 0.14);
+    --glass-shadow:      rgba(0, 0, 0, 0.55);
+
+    --ink-shadow: rgba(0, 0, 0, 0.3);
+    --chevron: %239491aa;
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background-color: var(--canvas);
+    color: var(--color-neutral-900);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  ::selection {
+    background: color-mix(in oklab, var(--color-brand-500) 30%, transparent);
+  }
+
+  /* One focus treatment everywhere, only for keyboard focus. */
+  :where(button, a, input, select, textarea, [tabindex]):focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
 }
 
-html,
-body,
-#root {
-  height: 100%;
-}
+/* ---------------------------------------------------------------------------
+   Components
+--------------------------------------------------------------------------- */
+@layer components {
+  /* -- The aurora canvas ------------------------------------------------- */
+  .aurora {
+    position: fixed;
+    inset: -20%;
+    z-index: -1;
+    pointer-events: none;
+    opacity: var(--aurora-opacity);
+    background:
+      radial-gradient(38% 34% at 12% 18%, color-mix(in oklab, var(--color-brand-400) 60%, transparent) 0%, transparent 72%),
+      radial-gradient(34% 30% at 86% 12%, color-mix(in oklab, var(--color-accent-sky) 55%, transparent) 0%, transparent 72%),
+      radial-gradient(36% 36% at 78% 86%, color-mix(in oklab, var(--color-accent-pink) 48%, transparent) 0%, transparent 72%),
+      radial-gradient(30% 30% at 18% 84%, color-mix(in oklab, var(--color-accent-mint) 46%, transparent) 0%, transparent 72%),
+      radial-gradient(24% 24% at 52% 52%, color-mix(in oklab, var(--color-accent-amber) 26%, transparent) 0%, transparent 72%);
+    filter: blur(48px) saturate(125%);
+    animation: aurora-drift 48s ease-in-out infinite alternate;
+    will-change: transform;
+  }
 
-body {
-  margin: 0;
-  font-family: var(--font-sans);
-  background-color: var(--color-neutral-50);
-  color: var(--color-neutral-900);
-}
+  @keyframes aurora-drift {
+    0%   { transform: translate3d(0, 0, 0) scale(1); }
+    50%  { transform: translate3d(2%, -1.5%, 0) scale(1.04); }
+    100% { transform: translate3d(-1.5%, 2%, 0) scale(1.02); }
+  }
 
-* {
-  box-sizing: border-box;
-}
+  @media (prefers-reduced-motion: reduce) {
+    .aurora { animation: none; }
+  }
 
-/* Issue identifiers are data. Tabular figures keep ENG-9 and ENG-42 aligned
-   in a column, and the slight tracking stops the mono face from looking wide. */
-.identifier {
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
+  /* -- Glass surfaces ---------------------------------------------------- */
+  .glass,
+  .glass-strong,
+  .glass-subtle,
+  .glass-card {
+    border: 1px solid var(--glass-border);
+    box-shadow:
+      inset 0 1px 0 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge),
+      0 1px 2px var(--ink-shadow),
+      0 18px 48px -20px var(--glass-shadow);
+  }
+
+  .glass {
+    background: var(--glass-fill);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(170%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(170%);
+  }
+
+  .glass-strong {
+    background: var(--glass-fill-strong);
+    -webkit-backdrop-filter: blur(28px) saturate(180%);
+    backdrop-filter: blur(28px) saturate(180%);
+  }
+
+  /* Columns and insets: lighter, and no blur -- there can be many on screen. */
+  .glass-subtle {
+    background: var(--glass-fill-subtle);
+    box-shadow:
+      inset 0 1px 0 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge);
+  }
+
+  .glass-card {
+    background: var(--glass-fill-card);
+    box-shadow:
+      inset 0 1px 0 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge),
+      0 1px 2px var(--ink-shadow),
+      0 8px 20px -14px var(--glass-shadow);
+    transition:
+      transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+      box-shadow 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .glass-card:hover {
+    transform: translateY(-1px);
+    box-shadow:
+      inset 0 1px 0 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge),
+      0 2px 4px var(--ink-shadow),
+      0 16px 32px -14px var(--glass-shadow);
+  }
+
+  /* An inset well inside a glass panel: properties, previews, empty states. */
+  .well {
+    background: color-mix(in oklab, var(--color-neutral-900) 4%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-neutral-900) 6%, transparent);
+  }
+
+  .hairline { border-color: color-mix(in oklab, var(--color-neutral-900) 9%, transparent); }
+
+  /* A specular sweep across the top edge of a surface. Opt-in: it needs
+     overflow hidden, which would clip a dropdown. */
+  .sheen {
+    position: relative;
+    overflow: hidden;
+  }
+  .sheen::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 42%;
+    pointer-events: none;
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--glass-highlight) 55%, transparent),
+      transparent
+    );
+  }
+
+  /* -- Buttons ----------------------------------------------------------- */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    height: 2.125rem;
+    padding: 0 0.875rem;
+    border-radius: 999px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition:
+      background-color 140ms ease,
+      color 140ms ease,
+      box-shadow 140ms ease,
+      transform 120ms ease,
+      opacity 140ms ease;
+    user-select: none;
+  }
+  .btn:active { transform: translateY(0.5px) scale(0.99); }
+  .btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
+
+  .btn-sm { height: 1.75rem; padding: 0 0.7rem; font-size: 0.75rem; }
+  .btn-xs { height: 1.5rem; padding: 0 0.55rem; font-size: 0.7rem; }
+
+  .btn-primary {
+    color: #fff;
+    background: linear-gradient(135deg, var(--color-brand-500), var(--color-accent-sky));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.35),
+      0 1px 2px rgba(20, 18, 40, 0.2),
+      0 10px 24px -10px color-mix(in oklab, var(--color-brand-600) 80%, transparent);
+  }
+  .btn-primary:hover:not(:disabled) {
+    filter: brightness(1.06) saturate(1.05);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.4),
+      0 2px 4px rgba(20, 18, 40, 0.2),
+      0 14px 30px -10px color-mix(in oklab, var(--color-brand-600) 90%, transparent);
+  }
+
+  .btn-secondary {
+    color: var(--color-neutral-800);
+    background: var(--glass-fill-strong);
+    border-color: var(--glass-border);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge),
+      0 1px 2px var(--ink-shadow);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+  .btn-secondary:hover:not(:disabled) { background: var(--glass-fill-card); }
+
+  .btn-ghost {
+    color: var(--color-neutral-600);
+    background: transparent;
+  }
+  .btn-ghost:hover:not(:disabled) {
+    color: var(--color-neutral-900);
+    background: color-mix(in oklab, var(--color-neutral-900) 6%, transparent);
+  }
+
+  .btn-danger-ghost { color: var(--color-danger-600); background: transparent; }
+  .btn-danger-ghost:hover:not(:disabled) { background: var(--color-danger-50); }
+
+  .btn-icon {
+    width: 2.125rem;
+    padding: 0;
+  }
+  .btn-icon.btn-sm { width: 1.75rem; }
+  .btn-icon.btn-xs { width: 1.5rem; }
+
+  /* -- Fields ------------------------------------------------------------ */
+  .field {
+    width: 100%;
+    border-radius: var(--radius-control);
+    border: 1px solid color-mix(in oklab, var(--color-neutral-900) 12%, transparent);
+    background: color-mix(in oklab, var(--glass-fill-card) 85%, transparent);
+    color: var(--color-neutral-900);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.35;
+    box-shadow: inset 0 1px 0 var(--glass-highlight), 0 1px 2px var(--ink-shadow);
+    transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+  }
+  .field::placeholder { color: var(--color-neutral-400); opacity: 0.8; }
+  .field:focus {
+    outline: none;
+    border-color: color-mix(in oklab, var(--color-brand-500) 60%, transparent);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      0 0 0 3px color-mix(in oklab, var(--color-brand-500) 18%, transparent);
+  }
+  .field-sm { padding: 0.375rem 0.625rem; font-size: 0.8125rem; }
+
+  /* A native select dressed as a glass pill. The chevron is drawn by
+     `Select`, so the native arrow is hidden here. */
+  .select {
+    appearance: none;
+    -webkit-appearance: none;
+    height: 2rem;
+    padding: 0 1.75rem 0 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--glass-border);
+    background: var(--glass-fill-strong);
+    color: var(--color-neutral-800);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      0 0 0 1px var(--glass-edge),
+      0 1px 2px var(--ink-shadow);
+    cursor: pointer;
+    transition: background-color 140ms ease, box-shadow 140ms ease;
+    max-width: 100%;
+  }
+  .select:hover:not(:disabled) { background: var(--glass-fill-card); }
+  .select:disabled { opacity: 0.55; cursor: not-allowed; }
+  .select:focus {
+    outline: none;
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      0 0 0 3px color-mix(in oklab, var(--color-brand-500) 22%, transparent);
+  }
+  .select-sm { height: 1.75rem; font-size: 0.75rem; padding-left: 0.625rem; padding-right: 1.5rem; }
+  .select-block { width: 100%; }
+  .select-wrap { position: relative; display: inline-flex; max-width: 100%; }
+  .select-wrap > .select-chevron {
+    position: absolute;
+    right: 0.6rem;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    color: var(--color-neutral-400);
+  }
+
+  /* -- Segmented control ------------------------------------------------- */
+  .segmented {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--color-neutral-900) 7%, transparent);
+    box-shadow: inset 0 1px 1px color-mix(in oklab, var(--color-neutral-900) 6%, transparent);
+  }
+  .segmented-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    height: 1.625rem;
+    padding: 0 0.7rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-neutral-500);
+    transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
+  }
+  .segmented-item:hover { color: var(--color-neutral-800); }
+  .segmented-item[data-active="true"] {
+    color: var(--color-neutral-900);
+    background: var(--glass-fill-card);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      0 1px 2px var(--ink-shadow),
+      0 0 0 1px var(--glass-edge);
+  }
+
+  /* -- Navigation rows --------------------------------------------------- */
+  .nav-item {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: var(--radius-control);
+    padding: 0.4rem 0.6rem;
+    font-size: 0.8125rem;
+    color: var(--color-neutral-700);
+    text-align: left;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+  .nav-item:hover {
+    color: var(--color-neutral-900);
+    background: color-mix(in oklab, var(--color-neutral-900) 5%, transparent);
+  }
+  .nav-item[data-active="true"] {
+    color: var(--color-brand-700);
+    font-weight: 500;
+    background: color-mix(in oklab, var(--color-brand-500) 14%, transparent);
+    box-shadow: inset 0 1px 0 color-mix(in oklab, #fff 40%, transparent);
+  }
+  :root[data-theme="dark"] .nav-item[data-active="true"] {
+    color: var(--color-brand-300);
+  }
+
+  /* -- Small type -------------------------------------------------------- */
+  .eyebrow {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-neutral-400);
+  }
+
+  .identifier {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+  }
+
+  .kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.35rem;
+    height: 1.35rem;
+    padding: 0 0.35rem;
+    border-radius: 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    color: var(--color-neutral-500);
+    background: color-mix(in oklab, var(--color-neutral-900) 6%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-neutral-900) 10%, transparent);
+    box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--color-neutral-900) 8%, transparent);
+  }
+
+  /* A coloured label chip. `--chip` is the label's own colour. */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    height: 1.25rem;
+    padding: 0 0.5rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: color-mix(in oklab, var(--chip) 78%, var(--color-neutral-900));
+    background: color-mix(in oklab, var(--chip) 16%, transparent);
+    border: 1px solid color-mix(in oklab, var(--chip) 28%, transparent);
+  }
+  :root[data-theme="dark"] .chip {
+    color: color-mix(in oklab, var(--chip) 70%, #fff);
+    background: color-mix(in oklab, var(--chip) 22%, transparent);
+  }
+  .chip-toggle {
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+  }
+  .chip-toggle[data-active="false"] {
+    color: var(--color-neutral-500);
+    background: transparent;
+    border-color: color-mix(in oklab, var(--color-neutral-900) 14%, transparent);
+  }
+  .chip-toggle[data-active="false"]:hover {
+    border-color: color-mix(in oklab, var(--chip) 50%, transparent);
+    color: color-mix(in oklab, var(--chip) 70%, var(--color-neutral-900));
+  }
+
+  /* A status dot with a soft glow of its own colour. */
+  .dot {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+    background: var(--dot);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--dot) 22%, transparent);
+  }
+
+  /* -- Scrollbars -------------------------------------------------------- */
+  .scroll-thin {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--color-neutral-900) 22%, transparent) transparent;
+  }
+  .scroll-thin::-webkit-scrollbar { height: 8px; width: 8px; }
+  .scroll-thin::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--color-neutral-900) 22%, transparent);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+  .scroll-thin::-webkit-scrollbar-track { background: transparent; }
+
+  /* -- Overlays ---------------------------------------------------------- */
+  .scrim {
+    background: color-mix(in oklab, var(--color-neutral-900) 22%, transparent);
+    -webkit-backdrop-filter: blur(6px) saturate(120%);
+    backdrop-filter: blur(6px) saturate(120%);
+    animation: fade-in 140ms ease-out both;
+  }
+  :root[data-theme="dark"] .scrim {
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  .pop-in { animation: pop-in 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+  .slide-in-right { animation: slide-in-right 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+  .slide-in-left { animation: slide-in-left 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+
+  @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes pop-in {
+    from { opacity: 0; transform: translateY(6px) scale(0.985); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  @keyframes slide-in-right {
+    from { opacity: 0; transform: translateX(24px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+  @keyframes slide-in-left {
+    from { opacity: 0; transform: translateX(-24px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scrim, .pop-in, .slide-in-right, .slide-in-left { animation: none; }
+    .glass-card, .btn { transition: none; }
+  }
+
+  /* -- Inline brand text: links and @mentions, readable in both themes --- */
+  .link {
+    color: var(--color-brand-600);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in oklab, var(--color-brand-600) 40%, transparent);
+  }
+  .link:hover { color: var(--color-brand-700); text-decoration-color: currentColor; }
+  :root[data-theme="dark"] .link { color: var(--color-brand-300); }
+  :root[data-theme="dark"] .link:hover { color: var(--color-brand-200); }
+
+  .mention {
+    border-radius: 0.35rem;
+    padding: 0 0.3rem;
+    font-weight: 600;
+    color: var(--color-brand-700);
+    background: color-mix(in oklab, var(--color-brand-500) 14%, transparent);
+  }
+  :root[data-theme="dark"] .mention { color: var(--color-brand-300); }
+
+  /* -- Text with a brand gradient ---------------------------------------- */
+  .text-gradient {
+    background: linear-gradient(120deg, var(--color-brand-600), var(--color-accent-sky) 60%, var(--color-accent-pink));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  :root[data-theme="dark"] .text-gradient {
+    background: linear-gradient(120deg, var(--color-brand-300), var(--color-accent-sky) 60%, var(--color-accent-pink));
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+
+  /* -- Shimmer placeholder ----------------------------------------------- */
+  .skeleton {
+    border-radius: var(--radius-control);
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-neutral-900) 6%, transparent) 25%,
+      color-mix(in oklab, var(--color-neutral-900) 10%, transparent) 50%,
+      color-mix(in oklab, var(--color-neutral-900) 6%, transparent) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.4s linear infinite;
+  }
+  @keyframes shimmer {
+    from { background-position: 200% 0; }
+    to   { background-position: -200% 0; }
+  }
 }

--- a/frontend/src/issues/EstimateBadge.tsx
+++ b/frontend/src/issues/EstimateBadge.tsx
@@ -3,7 +3,7 @@ export function EstimateBadge({ points }: { points: number }) {
   return (
     <span
       title={`${points} ${points === 1 ? 'point' : 'points'}`}
-      className="identifier inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-neutral-100 px-1.5 text-[11px] font-medium text-neutral-600"
+      className="identifier inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-neutral-900/6 px-1.5 text-[11px] font-semibold text-neutral-600"
     >
       {points}
     </span>

--- a/frontend/src/issues/IssueCard.tsx
+++ b/frontend/src/issues/IssueCard.tsx
@@ -3,10 +3,10 @@ import { CSS } from '@dnd-kit/utilities'
 import { useNavigate } from 'react-router-dom'
 
 import type { IssueRead } from '@/api/generated/models'
-import { useTeamContext } from '@/team/TeamContext'
-import { Avatar } from '@/ui/Avatar'
 import { EstimateBadge } from '@/issues/EstimateBadge'
 import { PriorityIcon } from '@/issues/PriorityIcon'
+import { useTeamContext } from '@/team/TeamContext'
+import { Avatar } from '@/ui/Avatar'
 
 export function IssueCard({ issue }: { issue: IssueRead }) {
   const navigate = useNavigate()
@@ -15,13 +15,21 @@ export function IssueCard({ issue }: { issue: IssueRead }) {
     id: issue.id,
   })
 
+  // While dragging, the card follows the pointer with no easing and lifts
+  // off the column; the CSS hover transition would otherwise lag the drag.
   const style = transform
     ? {
-        transform: CSS.Translate.toString(transform),
-        opacity: isDragging ? 0.4 : 1,
-        zIndex: isDragging ? 10 : undefined,
+        transform: `${CSS.Translate.toString(transform)} ${isDragging ? 'rotate(1.5deg) scale(1.03)' : ''}`,
+        transition: 'none',
+        opacity: isDragging ? 0.92 : 1,
+        zIndex: isDragging ? 20 : undefined,
+        boxShadow: isDragging
+          ? '0 0 0 1px var(--glass-edge), 0 24px 48px -12px var(--glass-shadow)'
+          : undefined,
       }
     : undefined
+
+  const open = () => navigate(`/${team.key}/issue/${issue.number}`)
 
   return (
     <div
@@ -32,19 +40,21 @@ export function IssueCard({ issue }: { issue: IssueRead }) {
       role="button"
       tabIndex={0}
       data-card={issue.id}
-      onClick={() => navigate(`/${team.key}/issue/${issue.number}`)}
+      onClick={open}
       onKeyDown={(e) => {
         // The card is a div, so Enter and Space have to be wired by hand to
         // match what a real button would do.
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
-          navigate(`/${team.key}/issue/${issue.number}`)
+          open()
         }
       }}
-      className="w-full cursor-grab touch-none rounded-lg border border-neutral-200 bg-white p-3 text-left shadow-sm transition hover:border-neutral-300 hover:shadow focus:outline-none focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-200 active:cursor-grabbing"
+      className="glass-card relative w-full cursor-grab touch-none rounded-card p-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/70 active:cursor-grabbing"
     >
-      <div className="mb-1.5 flex items-center justify-between">
-        <span className="identifier text-xs font-medium text-neutral-400">{issue.identifier}</span>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <span className="identifier text-[11px] font-medium text-neutral-400">
+          {issue.identifier}
+        </span>
         <div className="flex items-center gap-1.5">
           {issue.blocked_by_count > 0 && <BlockedMarker count={issue.blocked_by_count} />}
           {issue.child_count > 0 && (
@@ -59,29 +69,35 @@ export function IssueCard({ issue }: { issue: IssueRead }) {
           <PriorityIcon priority={issue.priority} />
         </div>
       </div>
-      <p className="mb-2 text-sm font-medium leading-snug text-neutral-900">{issue.title}</p>
-      <div className="flex items-center justify-between">
-        <div className="flex flex-wrap gap-1">
+
+      <p className="mb-2.5 text-[13.5px] font-medium leading-snug text-neutral-900">
+        {issue.title}
+      </p>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-wrap gap-1">
           {issue.labels?.map((label) => (
             <span
               key={label.id}
-              className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-              style={{ backgroundColor: `${label.color}20`, color: label.color }}
+              className="chip"
+              style={{ ['--chip' as string]: label.color }}
             >
               {label.name}
             </span>
           ))}
         </div>
         {issue.assignee ? (
-          <Avatar user={issue.assignee} size={20} />
+          <Avatar user={issue.assignee} size={22} />
         ) : (
-          <div className="h-5 w-5 rounded-full border border-dashed border-neutral-300" />
+          <span
+            className="h-[22px] w-[22px] shrink-0 rounded-full border border-dashed border-neutral-900/20"
+            title="Unassigned"
+          />
         )}
       </div>
     </div>
   )
 }
-
 
 /**
  * Shown on a card that cannot be started yet.
@@ -94,7 +110,8 @@ function BlockedMarker({ count }: { count: number }) {
   return (
     <span
       title={`Blocked by ${count} unresolved ${count === 1 ? 'issue' : 'issues'}`}
-      className="inline-flex items-center gap-0.5 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700"
+      className="chip"
+      style={{ ['--chip' as string]: 'var(--color-accent-amber)' }}
     >
       <svg viewBox="0 0 16 16" className="h-3 w-3" fill="none" aria-hidden="true">
         <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.6" />

--- a/frontend/src/issues/IssueDetailPanel.tsx
+++ b/frontend/src/issues/IssueDetailPanel.tsx
@@ -1,7 +1,6 @@
 import { formatDistanceToNow } from 'date-fns'
 
 import { AttachmentList } from '@/attachments/AttachmentList'
-
 import { CommentsSection } from '@/issues/detail/CommentsSection'
 import { DescriptionEditor } from '@/issues/detail/DescriptionEditor'
 import { IssueLinksSection } from '@/issues/detail/IssueLinksSection'
@@ -11,6 +10,9 @@ import { useIssueAttachments } from '@/issues/detail/useIssueAttachments'
 import { useIssueEditor } from '@/issues/detail/useIssueEditor'
 import { usePanelShortcuts } from '@/issues/detail/usePanelShortcuts'
 import { PriorityIcon } from '@/issues/PriorityIcon'
+import { STATUS_META } from '@/issues/issueMeta'
+import { Avatar } from '@/ui/Avatar'
+import { Icon } from '@/ui/Icon'
 
 /** The slide-over for one issue. Composes the sections; owns none of them. */
 export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClose: () => void }) {
@@ -20,43 +22,62 @@ export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClos
   const { issue } = editor
 
   return (
-    <div className="fixed inset-0 z-20 flex justify-end bg-black/20" onClick={onClose}>
+    <div className="scrim fixed inset-0 z-20 flex justify-end" onClick={onClose}>
       <div
+        role="dialog"
+        aria-label={issue ? `${issue.identifier} ${issue.title}` : 'Issue'}
         onClick={(e) => e.stopPropagation()}
-        className="flex h-full w-full max-w-lg flex-col overflow-y-auto border-l border-neutral-200 bg-white shadow-xl"
+        className="slide-in-right glass-strong m-2 flex w-full max-w-xl flex-col overflow-hidden rounded-panel sm:m-3"
       >
-        <div className="flex items-center justify-between border-b border-neutral-100 px-4 py-3">
-          <span className="flex items-baseline gap-2">
-            <span className="identifier text-xs font-medium text-neutral-400">
+        <div className="hairline flex items-center justify-between gap-3 border-b px-4 py-3">
+          <span className="flex min-w-0 items-center gap-2">
+            {issue && (
+              <span
+                className="dot"
+                style={{ ['--dot' as string]: STATUS_META[issue.status].color }}
+                title={STATUS_META[issue.status].label}
+              />
+            )}
+            <span className="identifier text-xs font-semibold text-neutral-500">
               {issue ? issue.identifier : '…'}
             </span>
             {issue?.external_key && (
               <span
-                className="identifier rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] text-neutral-500"
+                className="identifier rounded-full bg-neutral-900/6 px-2 py-0.5 text-[10px] text-neutral-500"
                 title="This issue's key before it was imported"
               >
                 {issue.external_key}
               </span>
             )}
           </span>
-          <button onClick={onClose} className="text-neutral-400 hover:text-neutral-700" aria-label="Close">
-            ✕
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-ghost btn-icon btn-sm text-neutral-500"
+            aria-label="Close"
+            title="Close (Esc)"
+          >
+            <Icon name="close" size={15} />
           </button>
         </div>
 
         {!issue ? (
-          <div className="flex flex-1 items-center justify-center text-sm text-neutral-400">
-            Loading…
+          <div className="flex flex-1 flex-col gap-3 p-5">
+            <div className="skeleton h-7 w-3/4" />
+            <div className="skeleton h-4 w-full" />
+            <div className="skeleton h-4 w-5/6" />
+            <div className="skeleton mt-4 h-36 w-full" />
           </div>
         ) : (
-          <>
-            <div className="flex-1 px-4 py-4">
+          <div className="scroll-thin flex-1 overflow-y-auto">
+            <div className="px-5 pb-5 pt-4">
               {issue.parent && <SubIssuesSection issue={issue} />}
               <input
                 value={editor.title}
                 onChange={(e) => editor.setTitle(e.target.value)}
                 onBlur={editor.saveTitle}
-                className="w-full border-none p-0 text-lg font-semibold text-neutral-900 focus:outline-none focus:ring-0"
+                aria-label="Title"
+                className="w-full border-none bg-transparent p-0 text-lg font-semibold leading-snug tracking-tight text-neutral-900 focus:outline-none focus:ring-0"
               />
 
               <DescriptionEditor
@@ -70,8 +91,8 @@ export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClos
               />
 
               {files.attachments.length > 0 && (
-                <div className="mt-4">
-                  <h3 className="mb-1.5 text-xs font-medium text-neutral-500">Files</h3>
+                <div className="mt-5">
+                  <p className="eyebrow mb-2">Files</p>
                   {/* Every file on the issue, including the ones embedded in
                       the description above. This list is also where they get
                       deleted, so leaving the embedded ones out would make
@@ -91,10 +112,11 @@ export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClos
               {!issue.parent && <SubIssuesSection issue={issue} />}
               <IssueLinksSection issueId={issue.id} />
 
-              <div className="mt-4 flex items-center gap-1.5 text-xs text-neutral-400">
-                <PriorityIcon priority={issue.priority} />
+              <div className="mt-5 flex items-center gap-2 text-xs text-neutral-400">
+                <PriorityIcon priority={issue.priority} size={12} />
+                <Avatar user={issue.creator} size={16} />
                 <span>
-                  Created by {issue.creator.full_name},{' '}
+                  Created by {issue.creator.full_name}{' '}
                   {formatDistanceToNow(new Date(issue.created_at), { addSuffix: true })}
                 </span>
               </div>
@@ -108,7 +130,7 @@ export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClos
               uploading={files.uploading}
               onFilesClaimed={files.invalidate}
             />
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/issues/NewIssueModal.tsx
+++ b/frontend/src/issues/NewIssueModal.tsx
@@ -12,6 +12,8 @@ import {
 } from '@/issues/issueMeta'
 import { MarkdownEditor } from '@/markdown/lazy'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon } from '@/ui/Icon'
+import { Select } from '@/ui/Select'
 
 export function NewIssueModal({ onClose }: { onClose: () => void }) {
   const { team, projects, labels, members, cycles } = useTeamContext()
@@ -61,23 +63,38 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-20 flex items-start justify-center bg-black/30 pt-24"
+      className="scrim fixed inset-0 z-20 flex items-start justify-center px-4 pt-[10vh]"
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-label="New issue"
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-lg rounded-xl border border-neutral-200 bg-white shadow-xl"
+        className="pop-in glass-strong w-full max-w-xl rounded-panel"
       >
         <form onSubmit={onSubmit}>
-          <div className="border-b border-neutral-100 px-4 py-3">
-            <p className="text-xs font-medium text-neutral-400">{team.key}</p>
+          <div className="hairline border-b px-5 pb-4 pt-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="identifier rounded-full bg-neutral-900/6 px-2 py-0.5 text-[11px] font-semibold text-neutral-500">
+                {team.key}
+              </span>
+              <button
+                type="button"
+                onClick={onClose}
+                className="btn btn-ghost btn-icon btn-xs text-neutral-400"
+                aria-label="Close"
+              >
+                <Icon name="close" size={14} />
+              </button>
+            </div>
             <input
               autoFocus
               required
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="Issue title"
-              className="w-full border-none p-0 text-base font-medium text-neutral-900 placeholder-neutral-300 focus:outline-none focus:ring-0"
+              aria-label="Issue title"
+              className="w-full border-none bg-transparent p-0 text-lg font-semibold tracking-tight text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-0"
             />
             <MarkdownEditor
               value={description}
@@ -85,43 +102,45 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
               people={members.map((m) => m.user)}
               placeholder="Add a description… Markdown works here."
               rows={4}
-              className="mt-2"
+              className="mt-3"
             />
           </div>
 
-          {error && <div className="px-4 pt-2 text-sm text-danger-600">{error}</div>}
+          {error && (
+            <div role="alert" className="px-5 pt-3 text-sm text-danger-600">
+              {error}
+            </div>
+          )}
 
-          <div className="flex flex-wrap gap-2 px-4 py-3">
-            <select
-              value={status}
-              onChange={(e) => setStatus(e.target.value as IssueStatus)}
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
-            >
+          <div className="flex flex-wrap gap-2 px-5 py-3">
+            <Select dense value={status} onChange={(e) => setStatus(e.target.value as IssueStatus)} aria-label="Status">
               {STATUS_ORDER.map((s) => (
                 <option key={s} value={s}>
                   {STATUS_META[s].label}
                 </option>
               ))}
-            </select>
+            </Select>
 
-            <select
+            <Select
+              dense
               value={priority}
               onChange={(e) => setPriority(e.target.value as IssuePriority)}
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
+              aria-label="Priority"
             >
               {PRIORITY_ORDER.map((p) => (
                 <option key={p} value={p}>
                   {PRIORITY_META[p].label}
                 </option>
               ))}
-            </select>
+            </Select>
 
-            <select
+            <Select
+              dense
               value={estimate ?? ''}
               onChange={(e) =>
                 setEstimate(ESTIMATE_SCALE.find((p) => String(p) === e.target.value) ?? null)
               }
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
+              aria-label="Estimate"
             >
               <option value="">No estimate</option>
               {ESTIMATE_SCALE.map((points) => (
@@ -129,13 +148,9 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
                   {points} {points === 1 ? 'point' : 'points'}
                 </option>
               ))}
-            </select>
+            </Select>
 
-            <select
-              value={cycleId}
-              onChange={(e) => setCycleId(e.target.value)}
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
-            >
+            <Select dense value={cycleId} onChange={(e) => setCycleId(e.target.value)} aria-label="Cycle">
               <option value="">Backlog</option>
               {cycles
                 .filter((c) => c.state !== 'completed')
@@ -144,25 +159,22 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
                     {cycle.display_name}
                   </option>
                 ))}
-            </select>
+            </Select>
 
-            <select
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
-            >
+            <Select dense value={projectId} onChange={(e) => setProjectId(e.target.value)} aria-label="Project">
               <option value="">No project</option>
               {projects.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name}
                 </option>
               ))}
-            </select>
+            </Select>
 
-            <select
+            <Select
+              dense
               value={assigneeId}
               onChange={(e) => setAssigneeId(e.target.value)}
-              className="rounded-md border border-neutral-200 px-2 py-1 text-xs"
+              aria-label="Assignee"
             >
               <option value="">Unassigned</option>
               {members.map((m) => (
@@ -170,11 +182,11 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
                   {m.user.full_name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
 
           {labels.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 px-4 pb-3">
+            <div className="flex flex-wrap gap-1.5 px-5 pb-4">
               {labels.map((label) => {
                 const active = labelIds.includes(label.id)
                 return (
@@ -182,12 +194,10 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
                     key={label.id}
                     type="button"
                     onClick={() => toggleLabel(label.id)}
-                    className="rounded-full border px-2 py-0.5 text-[11px] font-medium transition"
-                    style={{
-                      borderColor: active ? label.color : '#e5e7eb',
-                      backgroundColor: active ? `${label.color}20` : 'transparent',
-                      color: active ? label.color : '#6b7280',
-                    }}
+                    data-active={active}
+                    aria-pressed={active}
+                    className="chip chip-toggle"
+                    style={{ ['--chip' as string]: label.color }}
                   >
                     {label.name}
                   </button>
@@ -196,18 +206,14 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
             </div>
           )}
 
-          <div className="flex justify-end gap-2 border-t border-neutral-100 px-4 py-3">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md px-3 py-1.5 text-sm text-neutral-600 hover:bg-neutral-50"
-            >
+          <div className="hairline flex items-center justify-end gap-2 border-t px-5 py-3">
+            <button type="button" onClick={onClose} className="btn btn-ghost">
               Cancel
             </button>
             <button
               type="submit"
               disabled={createIssue.isPending || !title.trim()}
-              className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+              className="btn btn-primary"
             >
               {createIssue.isPending ? 'Creating…' : 'Create issue'}
             </button>

--- a/frontend/src/issues/PriorityIcon.tsx
+++ b/frontend/src/issues/PriorityIcon.tsx
@@ -1,7 +1,7 @@
 import type { IssuePriority } from '@/api/generated/models'
 import { PRIORITY_META } from '@/issues/issueMeta'
 
-const BAR_HEIGHTS = [3, 5, 7, 9]
+const BAR_HEIGHTS = [4, 6, 8, 10]
 const FILLED_BARS: Record<IssuePriority, number> = {
   urgent: 4,
   high: 3,
@@ -10,20 +10,31 @@ const FILLED_BARS: Record<IssuePriority, number> = {
   no_priority: 0,
 }
 
+/**
+ * Signal bars, filled in the priority's own colour so a glance at a column
+ * reads hot to cold. Urgent is a tile rather than four bars: it should not
+ * look like "a bit more than high".
+ */
 export function PriorityIcon({ priority, size = 14 }: { priority: IssuePriority; size?: number }) {
   const filled = FILLED_BARS[priority]
-  const isUrgent = priority === 'urgent'
   const meta = PRIORITY_META[priority]
 
-  if (isUrgent) {
+  if (priority === 'urgent') {
     return (
       <span
         title={meta.label}
-        className="flex items-center justify-center rounded-sm bg-priority-urgent"
-        style={{ width: size, height: size }}
+        role="img"
+        aria-label="Urgent"
+        className="flex shrink-0 items-center justify-center rounded-[4px] text-white"
+        style={{
+          width: size,
+          height: size,
+          background: `linear-gradient(160deg, color-mix(in oklab, ${meta.color} 70%, #fff), ${meta.color})`,
+          boxShadow: `0 0 0 1px color-mix(in oklab, ${meta.color} 30%, transparent), 0 2px 6px color-mix(in oklab, ${meta.color} 45%, transparent)`,
+        }}
       >
         <svg width={size * 0.6} height={size * 0.6} viewBox="0 0 10 10" fill="none">
-          <path d="M5 1v5M5 8.5v0.5" stroke="white" strokeWidth="1.4" strokeLinecap="round" />
+          <path d="M5 1.5v4.5M5 8.5v0.5" stroke="white" strokeWidth="1.6" strokeLinecap="round" />
         </svg>
       </span>
     )
@@ -32,14 +43,19 @@ export function PriorityIcon({ priority, size = 14 }: { priority: IssuePriority;
   return (
     <span
       title={meta.label}
-      className="flex items-end gap-[1.5px]"
+      role="img"
+      aria-label={meta.label}
+      className="flex shrink-0 items-end gap-[1.5px]"
       style={{ width: size, height: size }}
     >
       {BAR_HEIGHTS.map((h, i) => (
         <span
           key={i}
-          className={`w-[3px] rounded-sm ${i < filled ? 'bg-neutral-600' : 'bg-neutral-200'}`}
-          style={{ height: h }}
+          className="w-[2.5px] rounded-[1px]"
+          style={{
+            height: (h / 10) * size,
+            background: i < filled ? meta.color : 'color-mix(in oklab, var(--color-neutral-900) 14%, transparent)',
+          }}
         />
       ))}
     </span>

--- a/frontend/src/issues/detail/CommentsSection.tsx
+++ b/frontend/src/issues/detail/CommentsSection.tsx
@@ -65,34 +65,44 @@ export function CommentsSection({
     onFilesClaimed()
   }
 
+  const total = commentsQuery.data?.total ?? 0
+
   return (
-    <div className="border-t border-neutral-100 px-4 py-4">
-      <h3 className="mb-3 text-sm font-medium text-neutral-700">
-        Comments {commentsQuery.data ? `(${commentsQuery.data.total})` : ''}
-      </h3>
-      <div className="mb-3 space-y-3">
+    <div className="hairline border-t px-5 py-4">
+      <div className="mb-3 flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-neutral-800">Activity</h3>
+        {total > 0 && (
+          <span className="identifier rounded-full bg-neutral-900/6 px-1.5 py-0.5 text-[11px] font-medium text-neutral-500">
+            {total}
+          </span>
+        )}
+      </div>
+
+      <div className="mb-4 space-y-4">
         {commentsQuery.data?.items.map((comment) => (
-          <div key={comment.id} className="flex gap-2">
-            <Avatar user={comment.author} size={24} />
+          <div key={comment.id} className="flex gap-2.5">
+            <Avatar user={comment.author} size={26} />
             <div className="min-w-0 flex-1">
               <div className="flex items-baseline gap-2">
-                <span className="text-sm font-medium text-neutral-800">
+                <span className="text-sm font-medium text-neutral-900">
                   {comment.author.full_name}
                 </span>
-                <span className="text-xs text-neutral-400">
+                <span className="text-[11px] text-neutral-400">
                   {formatDistanceToNow(new Date(comment.created_at), { addSuffix: true })}
                 </span>
               </div>
-              {/* Read-only checkboxes: there is no endpoint to edit a comment
-                  yet, so a toggle here could not be saved. Its attachments
-                  are read-only for the same reason. */}
-              <Markdown people={people}>{comment.body}</Markdown>
-              <AttachmentList attachments={comment.attachments ?? []} compact />
+              <div className="well mt-1 rounded-card rounded-tl-sm px-3 py-2">
+                {/* Read-only checkboxes: there is no endpoint to edit a comment
+                    yet, so a toggle here could not be saved. Its attachments
+                    are read-only for the same reason. */}
+                <Markdown people={people}>{comment.body}</Markdown>
+                <AttachmentList attachments={comment.attachments ?? []} compact />
+              </div>
             </div>
           </div>
         ))}
         {commentsQuery.data?.items.length === 0 && (
-          <p className="text-xs text-neutral-400">No comments yet.</p>
+          <p className="text-xs text-neutral-400">No comments yet. Start the conversation below.</p>
         )}
       </div>
 
@@ -111,15 +121,16 @@ export function CommentsSection({
             by taking it back out of a draft. */}
         <AttachmentList attachments={draftFiles} onRemove={removeDraftFile} />
         <div className="mt-2 flex items-center justify-end gap-3">
-          <span className="text-[11px] text-neutral-400">
-            <span className="identifier">⌘↵</span> to send
+          <span className="flex items-center gap-1 text-[11px] text-neutral-400">
+            <kbd className="kbd">⌘</kbd>
+            <kbd className="kbd">↵</kbd> to send
           </span>
           <button
             type="submit"
             disabled={!body.trim() || createComment.isPending || uploading > 0}
-            className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+            className="btn btn-primary btn-sm"
           >
-            Send
+            {createComment.isPending ? 'Sending…' : 'Send'}
           </button>
         </div>
       </form>

--- a/frontend/src/issues/detail/DescriptionEditor.tsx
+++ b/frontend/src/issues/detail/DescriptionEditor.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Markdown, MarkdownEditor } from '@/markdown/lazy'
 import type { Mentionable } from '@/markdown/mentions'
 import { taskProgress } from '@/markdown/tasks'
+import { Icon } from '@/ui/Icon'
 
 /**
  * The description in its three states: empty, rendered, being edited.
@@ -51,7 +52,7 @@ export function DescriptionEditor({
               if (draft !== (saved ?? '')) await onSave(draft)
               setEditing(false)
             }}
-            className="rounded-md bg-brand-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-brand-700"
+            className="btn btn-primary btn-sm"
           >
             Save
           </button>
@@ -61,7 +62,7 @@ export function DescriptionEditor({
               setDraft(saved ?? '')
               setEditing(false)
             }}
-            className="rounded-md px-2.5 py-1 text-xs font-medium text-neutral-500 hover:text-neutral-700"
+            className="btn btn-ghost btn-sm"
           >
             Cancel
           </button>
@@ -76,9 +77,10 @@ export function DescriptionEditor({
         <button
           type="button"
           onClick={() => setEditing(true)}
-          className="text-sm text-neutral-300 hover:text-neutral-500"
+          className="flex w-full items-center gap-2 rounded-card border border-dashed border-neutral-900/15 px-3 py-2.5 text-left text-sm text-neutral-500 transition hover:border-brand-400/60 hover:text-neutral-800"
         >
-          Add a description…
+          <Icon name="plus" size={14} className="opacity-70" />
+          Add a description
         </button>
       </div>
     )
@@ -90,11 +92,7 @@ export function DescriptionEditor({
         {saved}
       </Markdown>
       <div className="mt-2 flex items-center gap-3">
-        <button
-          type="button"
-          onClick={() => setEditing(true)}
-          className="text-xs font-medium text-neutral-400 hover:text-neutral-700"
-        >
+        <button type="button" onClick={() => setEditing(true)} className="btn btn-ghost btn-xs">
           Edit description
         </button>
         <TaskProgress source={saved} />
@@ -109,10 +107,10 @@ function TaskProgress({ source }: { source: string }) {
   if (total === 0) return null
 
   return (
-    <span className="flex items-center gap-2 text-xs text-neutral-400">
-      <span className="h-1 w-16 overflow-hidden rounded-full bg-neutral-100">
+    <span className="flex items-center gap-2 text-xs text-neutral-500">
+      <span className="h-1 w-16 overflow-hidden rounded-full bg-neutral-900/8">
         <span
-          className="block h-full rounded-full bg-brand-500 transition-all"
+          className="block h-full rounded-full bg-linear-to-r from-brand-500 to-accent-sky transition-all"
           style={{ width: `${(done / total) * 100}%` }}
         />
       </span>

--- a/frontend/src/issues/detail/IssueLinksSection.tsx
+++ b/frontend/src/issues/detail/IssueLinksSection.tsx
@@ -9,8 +9,10 @@ import {
   useListIssuesTeamsTeamIdIssuesGet,
 } from '@/api/generated/endpoints/issues/issues'
 import { IssueLinkType, type IssueLinks, type IssueLinkRead } from '@/api/generated/models'
+import { errorDetail } from '@/api/errors'
 import { STATUS_META } from '@/issues/issueMeta'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon } from '@/ui/Icon'
 
 /**
  * The five buckets, in the order they matter to someone reading an issue.
@@ -82,9 +84,7 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
     } catch (err: unknown) {
       // The API refuses self-links, duplicates and contradictions with a
       // specific reason. Show it rather than a generic failure.
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
-        ?.detail
-      setError(typeof detail === 'string' ? detail : 'Could not add that link.')
+      setError(errorDetail(err, 'Could not add that link.'))
     }
   }
 
@@ -97,10 +97,11 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
   const total = GROUPS.reduce((sum, group) => sum + (links?.[group.key]?.length ?? 0), 0)
 
   return (
-    <div className="mt-4">
+    <div className="mt-5">
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-xs font-medium text-neutral-500">
-          Links {total > 0 && <span className="text-neutral-400">({total})</span>}
+        <span className="flex items-center gap-2">
+          <span className="eyebrow">Links</span>
+          {total > 0 && <span className="identifier text-[11px] text-neutral-400">{total}</span>}
         </span>
         <button
           type="button"
@@ -108,27 +109,30 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
             setAdding((open) => !open)
             setError(null)
           }}
-          className="text-xs font-medium text-neutral-400 hover:text-neutral-700"
+          className="btn btn-ghost btn-xs"
         >
-          {adding ? 'Cancel' : '+ Add link'}
+          {adding ? (
+            'Cancel'
+          ) : (
+            <>
+              <Icon name="link" size={12} /> Add
+            </>
+          )}
         </button>
       </div>
 
       {adding && (
-        <div className="mb-3 rounded-lg border border-neutral-200 p-2">
-          <div className="mb-2 flex gap-1.5">
+        <div className="well mb-3 rounded-card p-2">
+          <div className="segmented mb-2">
             {ADDABLE.map((option) => (
               <button
                 key={option.type}
                 type="button"
                 onClick={() => setType(option.type)}
-                className={`rounded-md px-2 py-1 text-[11px] font-medium transition ${
-                  type === option.type
-                    ? 'bg-brand-50 text-brand-700'
-                    : 'text-neutral-500 hover:text-neutral-700'
-                }`}
+                data-active={type === option.type}
+                className="segmented-item"
               >
-                This issue {option.label}…
+                {option.label}
               </button>
             ))}
           </div>
@@ -137,7 +141,7 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search by identifier or title…"
-            className="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+            className="field field-sm"
           />
           <ul className="mt-1.5 space-y-0.5">
             {candidates.map((candidate) => (
@@ -146,27 +150,23 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
                   type="button"
                   onClick={() => add(candidate.id)}
                   disabled={createLink.isPending}
-                  className="flex w-full items-baseline gap-2 rounded px-1.5 py-1 text-left text-sm hover:bg-neutral-50 disabled:opacity-50"
+                  className="flex w-full items-baseline gap-2 rounded-control px-2 py-1 text-left text-sm transition hover:bg-neutral-900/5 disabled:opacity-50"
                 >
                   <span className="identifier text-xs text-neutral-400">
                     {candidate.identifier}
                   </span>
-                  <span className="truncate text-neutral-700">{candidate.title}</span>
+                  <span className="truncate text-neutral-800">{candidate.title}</span>
                 </button>
               </li>
             ))}
             {candidates.length === 0 && (
-              <li className="px-1.5 py-1 text-xs text-neutral-400">
+              <li className="px-2 py-1 text-xs text-neutral-400">
                 {candidatesQuery.isLoading ? 'Loading…' : 'Nothing matches.'}
               </li>
             )}
           </ul>
-          {error && <p className="mt-1.5 px-1.5 text-xs text-danger-600">{error}</p>}
+          {error && <p className="mt-1.5 px-2 text-xs text-danger-600">{error}</p>}
         </div>
-      )}
-
-      {total === 0 && !adding && (
-        <p className="text-xs text-neutral-400">No linked issues.</p>
       )}
 
       <div className="space-y-2">
@@ -175,9 +175,7 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
           if (rows.length === 0) return null
           return (
             <div key={group.key}>
-              <p className="mb-1 text-[11px] uppercase tracking-wide text-neutral-400">
-                {group.label}
-              </p>
+              <p className="mb-1 text-[11px] font-medium text-neutral-500">{group.label}</p>
               <ul className="space-y-0.5">
                 {rows.map((row) => (
                   <LinkRow
@@ -211,8 +209,8 @@ function LinkRow({
   const resolved = row.issue.status === 'done' || row.issue.status === 'cancelled'
 
   return (
-    <li className="group flex items-center gap-2 rounded px-1.5 py-1 hover:bg-neutral-50">
-      <span className={`h-2 w-2 shrink-0 rounded-full ${meta.dot}`} title={meta.label} />
+    <li className="group flex items-center gap-2 rounded-control px-2 py-1 transition hover:bg-neutral-900/4">
+      <span className="dot" style={{ ['--dot' as string]: meta.color }} title={meta.label} />
       <button
         type="button"
         onClick={onOpen}
@@ -223,7 +221,7 @@ function LinkRow({
         </span>
         <span
           className={`truncate text-sm ${
-            resolved ? 'text-neutral-400 line-through' : 'text-neutral-700'
+            resolved ? 'text-neutral-400 line-through' : 'text-neutral-800'
           }`}
         >
           {row.issue.title}
@@ -233,9 +231,9 @@ function LinkRow({
         type="button"
         onClick={onRemove}
         aria-label={`Remove link to ${row.issue.identifier}`}
-        className="shrink-0 text-neutral-300 opacity-0 transition hover:text-danger-600 group-hover:opacity-100"
+        className="btn btn-ghost btn-icon btn-xs shrink-0 text-neutral-400 opacity-0 transition hover:text-danger-600 focus-visible:opacity-100 group-hover:opacity-100"
       >
-        ✕
+        <Icon name="close" size={12} />
       </button>
     </li>
   )

--- a/frontend/src/issues/detail/IssueProperties.tsx
+++ b/frontend/src/issues/detail/IssueProperties.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import {
   type IssuePriority,
   type IssueRead,
@@ -12,8 +14,7 @@ import {
   STATUS_ORDER,
 } from '@/issues/issueMeta'
 import { useTeamContext } from '@/team/TeamContext'
-
-const SELECT = 'rounded-md border border-neutral-200 bg-white px-2 py-1 text-xs'
+import { Select } from '@/ui/Select'
 
 /**
  * The block of selects: status, priority, estimate, cycle, assignee, labels.
@@ -35,46 +36,46 @@ export function IssueProperties({
   const { members, labels, cycles } = useTeamContext()
 
   return (
-    <div className="mt-4 space-y-3 rounded-lg border border-neutral-100 bg-neutral-50 p-3">
-      <Row label="Status">
-        <select
+    <div className="well mt-5 grid gap-x-4 gap-y-3 rounded-card p-3 sm:grid-cols-2">
+      <Row label="Status" hint="S">
+        <Select
+          dense
           data-field="status"
           value={issue.status}
           onChange={(e) => patch({ status: e.target.value as IssueStatus })}
-          className={SELECT}
         >
           {STATUS_ORDER.map((s) => (
             <option key={s} value={s}>
               {STATUS_META[s].label}
             </option>
           ))}
-        </select>
+        </Select>
       </Row>
 
-      <Row label="Priority">
-        <select
+      <Row label="Priority" hint="P">
+        <Select
+          dense
           data-field="priority"
           value={issue.priority}
           onChange={(e) => patch({ priority: e.target.value as IssuePriority })}
-          className={SELECT}
         >
           {PRIORITY_ORDER.map((p) => (
             <option key={p} value={p}>
               {PRIORITY_META[p].label}
             </option>
           ))}
-        </select>
+        </Select>
       </Row>
 
       <Row label="Estimate">
-        <select
+        <Select
+          dense
           value={issue.estimate ?? ''}
           onChange={(e) =>
             // Read the value back out of the scale rather than casting a
             // string to it, so the value is provably one the API accepts.
             patch({ estimate: ESTIMATE_SCALE.find((p) => String(p) === e.target.value) ?? null })
           }
-          className={SELECT}
         >
           <option value="">Not sized</option>
           {ESTIMATE_SCALE.map((points) => (
@@ -82,15 +83,15 @@ export function IssueProperties({
               {points} {points === 1 ? 'point' : 'points'}
             </option>
           ))}
-        </select>
+        </Select>
       </Row>
 
       <Row label="Cycle">
-        <select
+        <Select
+          dense
           data-field="cycle"
           value={issue.cycle_id ?? ''}
           onChange={(e) => patch({ cycle_id: e.target.value ? Number(e.target.value) : null })}
-          className={SELECT}
         >
           <option value="">Backlog</option>
           {cycles
@@ -102,15 +103,15 @@ export function IssueProperties({
                 {cycle.display_name}
               </option>
             ))}
-        </select>
+        </Select>
       </Row>
 
-      <Row label="Assignee">
-        <select
+      <Row label="Assignee" hint="A">
+        <Select
+          dense
           data-field="assignee"
           value={issue.assignee?.id ?? ''}
           onChange={(e) => patch({ assignee_id: e.target.value ? Number(e.target.value) : null })}
-          className={SELECT}
         >
           <option value="">Unassigned</option>
           {members.map((m) => (
@@ -118,11 +119,13 @@ export function IssueProperties({
               {m.user.full_name}
             </option>
           ))}
-        </select>
+        </Select>
       </Row>
 
-      <div>
-        <span className="mb-1.5 block text-xs text-neutral-500">Labels</span>
+      <div className="sm:col-span-2">
+        <span className="mb-1.5 flex items-center gap-1.5 text-xs text-neutral-500">
+          Labels <kbd className="kbd">L</kbd>
+        </span>
         <div className="flex flex-wrap gap-1.5">
           {labels.map((label, index) => {
             const active = currentLabelIds.has(label.id)
@@ -131,13 +134,11 @@ export function IssueProperties({
                 key={label.id}
                 type="button"
                 data-field={index === 0 ? 'labels' : undefined}
+                data-active={active}
+                aria-pressed={active}
                 onClick={() => onToggleLabel(label.id)}
-                className="rounded-full border px-2 py-0.5 text-[11px] font-medium transition"
-                style={{
-                  borderColor: active ? label.color : '#e5e7eb',
-                  backgroundColor: active ? `${label.color}20` : 'transparent',
-                  color: active ? label.color : '#6b7280',
-                }}
+                className="chip chip-toggle"
+                style={{ ['--chip' as string]: label.color }}
               >
                 {label.name}
               </button>
@@ -152,10 +153,13 @@ export function IssueProperties({
   )
 }
 
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
+function Row({ label, hint, children }: { label: string; hint?: string; children: ReactNode }) {
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs text-neutral-500">{label}</span>
+    <div className="flex items-center justify-between gap-3">
+      <span className="flex items-center gap-1.5 text-xs text-neutral-500">
+        {label}
+        {hint && <kbd className="kbd hidden sm:inline-flex">{hint}</kbd>}
+      </span>
       {children}
     </div>
   )

--- a/frontend/src/issues/detail/SubIssuesSection.tsx
+++ b/frontend/src/issues/detail/SubIssuesSection.tsx
@@ -10,6 +10,7 @@ import {
 import type { IssueRead } from '@/api/generated/models'
 import { STATUS_META } from '@/issues/issueMeta'
 import { useTeamContext } from '@/team/TeamContext'
+import { Icon } from '@/ui/Icon'
 
 /**
  * The sub-issues of one issue, plus the breadcrumb when it is itself a child.
@@ -69,39 +70,45 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
       <button
         type="button"
         onClick={() => openIssue(issue.parent!.identifier)}
-        className="mb-2 flex max-w-full items-baseline gap-1.5 text-xs text-neutral-400 hover:text-neutral-700"
+        className="mb-2 flex max-w-full items-center gap-1.5 rounded-full bg-neutral-900/5 py-1 pl-2.5 pr-2 text-xs text-neutral-500 transition hover:bg-neutral-900/8 hover:text-neutral-900"
       >
-        <span className="identifier">{issue.parent!.identifier}</span>
+        <span className="identifier font-medium">{issue.parent!.identifier}</span>
         <span className="truncate">{issue.parent!.title}</span>
-        <span aria-hidden="true">›</span>
+        <Icon name="chevron-right" size={12} />
       </button>
     )
   }
 
   return (
-    <div className="mt-4">
+    <div className="mt-5">
       <div className="mb-2 flex items-center justify-between">
-        <span className="flex items-baseline gap-2 text-xs font-medium text-neutral-500">
-          Sub-issues
+        <span className="flex items-center gap-2">
+          <span className="eyebrow">Sub-issues</span>
           {issue.child_count > 0 && (
-            <span className="text-neutral-400">
-              {issue.completed_child_count} of {issue.child_count} done
+            <span className="identifier text-[11px] text-neutral-400">
+              {issue.completed_child_count}/{issue.child_count} done
             </span>
           )}
         </span>
         <button
           type="button"
           onClick={() => setAdding((open) => !open)}
-          className="text-xs font-medium text-neutral-400 hover:text-neutral-700"
+          className="btn btn-ghost btn-xs"
         >
-          {adding ? 'Cancel' : '+ Add sub-issue'}
+          {adding ? (
+            'Cancel'
+          ) : (
+            <>
+              <Icon name="plus" size={12} /> Add
+            </>
+          )}
         </button>
       </div>
 
       {issue.child_count > 0 && (
-        <div className="mb-2 h-1 overflow-hidden rounded-full bg-neutral-100">
+        <div className="mb-2 h-1 overflow-hidden rounded-full bg-neutral-900/8">
           <div
-            className="h-full rounded-full bg-brand-500 transition-all"
+            className="h-full rounded-full bg-linear-to-r from-brand-500 to-accent-sky transition-all"
             style={{
               width: `${(issue.completed_child_count / issue.child_count) * 100}%`,
             }}
@@ -120,27 +127,25 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
           }}
           onBlur={addChild}
           placeholder="Sub-issue title, then Enter"
-          className="mb-2 w-full rounded-md border border-neutral-200 px-2.5 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+          className="field field-sm mb-2"
         />
       )}
 
-      {children.length === 0 && !adding ? (
-        <p className="text-xs text-neutral-400">No sub-issues.</p>
-      ) : (
+      {children.length > 0 && (
         <ul className="space-y-0.5">
           {children.map((child) => {
             const done = child.status === 'done'
             return (
               <li
                 key={child.id}
-                className="flex items-center gap-2 rounded px-1.5 py-1 hover:bg-neutral-50"
+                className="flex items-center gap-2 rounded-control px-2 py-1 transition hover:bg-neutral-900/4"
               >
                 <input
                   type="checkbox"
                   checked={done}
                   onChange={() => toggleDone(child)}
                   aria-label={done ? `Reopen ${child.identifier}` : `Complete ${child.identifier}`}
-                  className="h-3.5 w-3.5 shrink-0 rounded border-neutral-300 accent-brand-600"
+                  className="h-3.5 w-3.5 shrink-0 rounded accent-brand-600"
                 />
                 <button
                   type="button"
@@ -152,14 +157,15 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
                   </span>
                   <span
                     className={`truncate text-sm ${
-                      done ? 'text-neutral-400 line-through' : 'text-neutral-700'
+                      done ? 'text-neutral-400 line-through' : 'text-neutral-800'
                     }`}
                   >
                     {child.title}
                   </span>
                 </button>
                 <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${STATUS_META[child.status].dot}`}
+                  className="dot"
+                  style={{ ['--dot' as string]: STATUS_META[child.status].color }}
                   title={STATUS_META[child.status].label}
                 />
               </li>

--- a/frontend/src/issues/detail/usePanelShortcuts.ts
+++ b/frontend/src/issues/detail/usePanelShortcuts.ts
@@ -1,16 +1,28 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { isPlainKey, isTypingTarget } from '@/keyboard/typing'
 
-/** The keys that work while an issue panel is open: Escape, S, P, A, L. */
+/**
+ * The keys that work while an issue panel is open: Escape, S, P, A, L.
+ *
+ * The listener is registered once and reads the latest `onClose` through a
+ * ref. Re-registering it on every render put it *after* the board's global
+ * listener, whose Escape handling re-rendered the board mid-dispatch and
+ * removed this listener before it could run.
+ */
 export function usePanelShortcuts(onClose: () => void) {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         // Anything inside the panel that consumes Escape (the mention menu,
         // a native select) stops propagation before this runs, so by the
         // time it reaches here the user does mean the panel.
-        onClose()
+        onCloseRef.current()
         return
       }
 
@@ -31,5 +43,5 @@ export function usePanelShortcuts(onClose: () => void) {
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [onClose])
+  }, [])
 }

--- a/frontend/src/issues/issueMeta.ts
+++ b/frontend/src/issues/issueMeta.ts
@@ -10,13 +10,25 @@ export const STATUS_ORDER: IssueStatus[] = [
   IssueStatus.cancelled,
 ]
 
-export const STATUS_META: Record<IssueStatus, { label: string; dot: string }> = {
-  backlog: { label: 'Backlog', dot: 'bg-status-backlog' },
-  todo: { label: 'Todo', dot: 'bg-status-todo' },
-  in_progress: { label: 'In Progress', dot: 'bg-status-progress' },
-  in_review: { label: 'In Review', dot: 'bg-status-review' },
-  done: { label: 'Done', dot: 'bg-status-done' },
-  cancelled: { label: 'Cancelled', dot: 'bg-status-cancelled' },
+/**
+ * Label, the Tailwind class for a plain dot, and the raw colour for anything
+ * that needs it as a CSS value (the glowing `.dot`, chart keys).
+ */
+export const STATUS_META: Record<IssueStatus, { label: string; dot: string; color: string }> = {
+  backlog: { label: 'Backlog', dot: 'bg-status-backlog', color: 'var(--color-status-backlog)' },
+  todo: { label: 'Todo', dot: 'bg-status-todo', color: 'var(--color-status-todo)' },
+  in_progress: {
+    label: 'In Progress',
+    dot: 'bg-status-progress',
+    color: 'var(--color-status-progress)',
+  },
+  in_review: { label: 'In Review', dot: 'bg-status-review', color: 'var(--color-status-review)' },
+  done: { label: 'Done', dot: 'bg-status-done', color: 'var(--color-status-done)' },
+  cancelled: {
+    label: 'Cancelled',
+    dot: 'bg-status-cancelled',
+    color: 'var(--color-status-cancelled)',
+  },
 }
 
 export const PRIORITY_ORDER: IssuePriority[] = [
@@ -28,11 +40,11 @@ export const PRIORITY_ORDER: IssuePriority[] = [
 ]
 
 export const PRIORITY_META: Record<IssuePriority, { label: string; color: string }> = {
-  urgent: { label: 'Urgent', color: 'text-priority-urgent' },
-  high: { label: 'High', color: 'text-priority-high' },
-  medium: { label: 'Medium', color: 'text-priority-medium' },
-  low: { label: 'Low', color: 'text-priority-low' },
-  no_priority: { label: 'No priority', color: 'text-priority-none' },
+  urgent: { label: 'Urgent', color: 'var(--color-priority-urgent)' },
+  high: { label: 'High', color: 'var(--color-priority-high)' },
+  medium: { label: 'Medium', color: 'var(--color-priority-medium)' },
+  low: { label: 'Low', color: 'var(--color-priority-low)' },
+  no_priority: { label: 'No priority', color: 'var(--color-priority-none)' },
 }
 
 /**

--- a/frontend/src/keyboard/CommandPalette.tsx
+++ b/frontend/src/keyboard/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import type { IssueRead } from '@/api/generated/models'
 import { STATUS_META } from '@/issues/issueMeta'
+import { Icon } from '@/ui/Icon'
 
 export type Command = {
   id: string
@@ -100,36 +101,39 @@ export function CommandPalette({
 
   return (
     <div
-      className="fixed inset-0 z-40 flex items-start justify-center bg-black/20 pt-[12vh]"
+      className="scrim fixed inset-0 z-40 flex items-start justify-center px-4 pt-[12vh]"
       onClick={onClose}
     >
       <div
         role="dialog"
         aria-label="Command palette"
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-lg overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-2xl"
+        className="pop-in glass-strong w-full max-w-lg overflow-hidden rounded-panel"
       >
-        <input
-          autoFocus
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder="Jump to an issue, or type a command…"
-          aria-label="Command"
-          className="w-full border-b border-neutral-100 px-4 py-3 text-sm text-neutral-800 placeholder-neutral-300 focus:outline-none"
-        />
+        <div className="hairline relative border-b">
+          <Icon
+            name="search"
+            size={16}
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-neutral-400"
+          />
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Jump to an issue, or type a command…"
+            aria-label="Command"
+            className="w-full bg-transparent py-3.5 pl-11 pr-4 text-sm text-neutral-900 placeholder:text-neutral-400 focus:outline-none"
+          />
+        </div>
 
-        <ul ref={listRef} className="max-h-80 overflow-y-auto py-1" role="listbox">
+        <ul ref={listRef} className="scroll-thin max-h-80 overflow-y-auto p-1.5" role="listbox">
           {results.map((result, index) => {
             const header = result.group !== lastGroup ? result.group : null
             lastGroup = result.group
             return (
               <li key={result.id}>
-                {header && (
-                  <p className="px-4 pb-1 pt-2 text-[11px] uppercase tracking-wide text-neutral-400">
-                    {header}
-                  </p>
-                )}
+                {header && <p className="eyebrow px-2.5 pb-1 pt-2">{header}</p>}
                 <button
                   type="button"
                   role="option"
@@ -137,13 +141,11 @@ export function CommandPalette({
                   data-highlighted={index === highlighted}
                   onMouseEnter={() => setHighlighted(index)}
                   onClick={() => choose(index)}
-                  className={`flex w-full items-baseline gap-2 px-4 py-1.5 text-left text-sm ${
-                    index === highlighted ? 'bg-brand-50' : ''
+                  className={`flex w-full items-center gap-3 rounded-control px-2.5 py-2 text-left text-sm transition-colors ${
+                    index === highlighted ? 'bg-brand-500/12 text-neutral-900' : 'text-neutral-800'
                   }`}
                 >
-                  <span className="min-w-0 flex-1 truncate text-neutral-800">
-                    {result.label}
-                  </span>
+                  <span className="min-w-0 flex-1 truncate">{result.label}</span>
                   {result.hint && (
                     <span className="identifier shrink-0 text-xs text-neutral-400">
                       {result.hint}
@@ -160,6 +162,19 @@ export function CommandPalette({
             </li>
           )}
         </ul>
+
+        <div className="hairline flex items-center gap-3 border-t px-4 py-2 text-[11px] text-neutral-400">
+          <span className="flex items-center gap-1">
+            <kbd className="kbd">↑</kbd>
+            <kbd className="kbd">↓</kbd> navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="kbd">↵</kbd> open
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="kbd">esc</kbd> close
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/keyboard/ShortcutsCheatsheet.tsx
+++ b/frontend/src/keyboard/ShortcutsCheatsheet.tsx
@@ -1,47 +1,46 @@
 import { MOD_KEY, SHORTCUT_GROUPS } from '@/keyboard/shortcuts'
+import { Icon } from '@/ui/Icon'
 
 export function ShortcutsCheatsheet({ onClose }: { onClose: () => void }) {
   return (
     <div
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/20 px-4"
+      className="scrim fixed inset-0 z-40 flex items-center justify-center px-4"
       onClick={onClose}
     >
       <div
         role="dialog"
         aria-label="Keyboard shortcuts"
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-md rounded-xl border border-neutral-200 bg-white p-5 shadow-2xl"
+        className="pop-in glass-strong w-full max-w-md rounded-panel p-5"
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-neutral-900">Keyboard shortcuts</h2>
+          <h2 className="text-base font-semibold tracking-tight text-neutral-900">
+            Keyboard shortcuts
+          </h2>
           <button
+            type="button"
             onClick={onClose}
             aria-label="Close"
-            className="text-neutral-400 hover:text-neutral-700"
+            className="btn btn-ghost btn-icon btn-sm text-neutral-400"
           >
-            ✕
+            <Icon name="close" size={15} />
           </button>
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-5">
           {SHORTCUT_GROUPS.map((group) => (
             <div key={group.title}>
-              <p className="mb-1.5 text-[11px] uppercase tracking-wide text-neutral-400">
-                {group.title}
-              </p>
-              <ul className="space-y-1">
+              <p className="eyebrow mb-2">{group.title}</p>
+              <ul className="space-y-1.5">
                 {group.shortcuts.map((shortcut) => (
                   <li
                     key={shortcut.description}
-                    className="flex items-baseline justify-between gap-4"
+                    className="flex items-center justify-between gap-4"
                   >
-                    <span className="text-sm text-neutral-600">{shortcut.description}</span>
+                    <span className="text-sm text-neutral-700">{shortcut.description}</span>
                     <span className="flex shrink-0 gap-1">
                       {shortcut.keys.map((key) => (
-                        <kbd
-                          key={key}
-                          className="identifier rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 text-[11px] text-neutral-600"
-                        >
+                        <kbd key={key} className="kbd">
                           {key === '⌘' ? MOD_KEY : key}
                         </kbd>
                       ))}

--- a/frontend/src/markdown/Markdown.tsx
+++ b/frontend/src/markdown/Markdown.tsx
@@ -43,21 +43,13 @@ export function Markdown({
       void node
       if (linkClass === 'mention') {
         return (
-          <span
-            className="rounded bg-brand-50 px-1 font-medium text-brand-700"
-            title={props.title}
-          >
+          <span className="mention" title={props.title}>
             {linkChildren}
           </span>
         )
       }
       return (
-        <a
-          {...props}
-          target="_blank"
-          rel="noopener noreferrer nofollow"
-          className="text-brand-600 underline underline-offset-2 hover:text-brand-700"
-        >
+        <a {...props} target="_blank" rel="noopener noreferrer nofollow" className="link">
           {linkChildren}
         </a>
       )
@@ -122,9 +114,7 @@ export function Markdown({
       return <code className="font-mono text-xs leading-relaxed">{children}</code>
     },
     pre: ({ children }) => (
-      <pre className="my-2 overflow-x-auto rounded-md bg-neutral-50 p-3 ring-1 ring-neutral-100">
-        {children}
-      </pre>
+      <pre className="well scroll-thin my-2 overflow-x-auto rounded-card p-3">{children}</pre>
     ),
     table: ({ children }) => (
       <div className="my-2 overflow-x-auto">

--- a/frontend/src/markdown/MarkdownEditor.tsx
+++ b/frontend/src/markdown/MarkdownEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { Markdown } from '@/markdown/Markdown'
 import { type Mentionable, matchMentions, mentionHandles } from '@/markdown/mentions'
 import { mentionQueryAt } from '@/markdown/mentionQuery'
+import { Icon } from '@/ui/Icon'
 
 type Mode = 'write' | 'preview'
 
@@ -190,31 +191,36 @@ export function MarkdownEditor({
     }
   }
 
-  const tabClass = (active: boolean) =>
-    `rounded-md px-2 py-1 text-xs font-medium transition ${
-      active ? 'bg-white text-neutral-800 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'
-    }`
-
   return (
     <div className={className}>
-      <div className="mb-1.5 flex items-center justify-between">
-        <div className="inline-flex gap-0.5 rounded-lg bg-neutral-100 p-0.5">
-          <button type="button" onClick={() => setMode('write')} className={tabClass(mode === 'write')}>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="segmented" role="tablist" aria-label="Editor mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'write'}
+            data-active={mode === 'write'}
+            onClick={() => setMode('write')}
+            className="segmented-item"
+          >
             Write
           </button>
           <button
             type="button"
+            role="tab"
+            aria-selected={mode === 'preview'}
+            data-active={mode === 'preview'}
             onClick={() => setMode('preview')}
-            className={tabClass(mode === 'preview')}
+            className="segmented-item"
           >
             Preview
           </button>
         </div>
         {mode === 'write' && (
-          <span className="flex items-center gap-2 text-[11px] text-neutral-400">
+          <span className="flex min-w-0 items-center gap-2 text-[11px] text-neutral-400">
             {onUploadFiles ? (
               <>
-                <span>
+                <span className="hidden truncate sm:inline">
                   Markdown · <span className="identifier">@</span> to mention · paste or
                   drop a file
                 </span>
@@ -232,13 +238,14 @@ export function MarkdownEditor({
                 <button
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
-                  className="rounded-md px-1.5 py-0.5 font-medium text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700"
+                  className="btn btn-ghost btn-xs"
                 >
+                  <Icon name="paperclip" size={12} />
                   {busy ? 'Uploading…' : 'Attach'}
                 </button>
               </>
             ) : (
-              <span>
+              <span className="hidden truncate sm:inline">
                 Markdown supported · <span className="identifier">@</span> to mention
               </span>
             )}
@@ -276,10 +283,8 @@ export function MarkdownEditor({
             }}
             placeholder={placeholder}
             rows={rows}
-            className={`w-full resize-y rounded-md border px-2.5 py-2 text-sm text-neutral-700 placeholder-neutral-300 focus:outline-none ${
-              droppingOver
-                ? 'border-brand-400 bg-brand-50'
-                : 'border-neutral-200 focus:border-brand-400'
+            className={`field resize-y rounded-card leading-relaxed ${
+              droppingOver ? 'border-brand-400! bg-brand-500/8!' : ''
             }`}
           />
 
@@ -287,7 +292,7 @@ export function MarkdownEditor({
             <ul
               role="listbox"
               aria-label="Team members"
-              className="absolute left-2 top-full z-30 mt-1 w-64 overflow-hidden rounded-lg border border-neutral-200 bg-white py-1 shadow-lg"
+              className="glass-strong pop-in absolute left-2 top-full z-30 mt-1 w-64 overflow-hidden rounded-card p-1"
             >
               {suggestions.map((person, index) => (
                 <li key={person.id}>
@@ -298,11 +303,11 @@ export function MarkdownEditor({
                     onMouseEnter={() => setHighlighted(index)}
                     onMouseDown={(e) => e.preventDefault()}
                     onClick={() => insertMention(person)}
-                    className={`flex w-full items-baseline gap-2 px-2.5 py-1.5 text-left text-sm ${
-                      index === highlighted ? 'bg-brand-50' : ''
+                    className={`flex w-full items-baseline gap-2 rounded-control px-2.5 py-1.5 text-left text-sm ${
+                      index === highlighted ? 'bg-brand-500/12' : ''
                     }`}
                   >
-                    <span className="font-medium text-neutral-800">{person.full_name}</span>
+                    <span className="font-medium text-neutral-900">{person.full_name}</span>
                     <span className="identifier truncate text-xs text-neutral-400">
                       @{mentionHandles(people).get(person.id)}
                     </span>
@@ -313,11 +318,11 @@ export function MarkdownEditor({
           )}
         </div>
       ) : (
-        <div className="min-h-[5rem] rounded-md border border-neutral-200 px-2.5 py-2">
+        <div className="well min-h-[5rem] rounded-card px-3 py-2">
           {value.trim() ? (
             <Markdown people={people}>{value}</Markdown>
           ) : (
-            <p className="text-sm text-neutral-300">Nothing to preview yet.</p>
+            <p className="text-sm text-neutral-400">Nothing to preview yet.</p>
           )}
         </div>
       )}

--- a/frontend/src/reports/Chart.tsx
+++ b/frontend/src/reports/Chart.tsx
@@ -19,9 +19,9 @@ export function Figure({
   empty?: string
 }) {
   return (
-    <figure className="rounded-lg border border-neutral-200 bg-white p-4">
+    <figure className="glass rounded-panel p-4">
       <figcaption className="mb-3">
-        <h3 className="text-sm font-medium text-neutral-900">{title}</h3>
+        <h3 className="text-sm font-semibold text-neutral-900">{title}</h3>
         {note && <p className="mt-0.5 text-xs text-neutral-500">{note}</p>}
       </figcaption>
       {empty ? (
@@ -155,21 +155,21 @@ export function Tooltip({
   const flip = x > width * 0.6
   return (
     <div
-      className="pointer-events-none absolute top-2 z-10 min-w-32 rounded-md border border-neutral-200 bg-white px-2 py-1.5 shadow-lg"
+      className="glass-strong pointer-events-none absolute top-2 z-10 min-w-32 rounded-card px-2.5 py-2"
       style={
         flip
           ? { right: `${((width - x) / width) * 100}%`, marginRight: 8 }
           : { left: `${(x / width) * 100}%`, marginLeft: 8 }
       }
     >
-      <p className="mb-0.5 text-[11px] font-medium text-neutral-700">{title}</p>
+      <p className="mb-0.5 text-[11px] font-semibold text-neutral-800">{title}</p>
       {rows.map((row) => (
         <p key={row.label} className="flex items-center gap-1.5 text-[11px] text-neutral-500">
           {row.colour && (
             <span className="h-2 w-2 rounded-sm" style={{ background: row.colour }} />
           )}
           {row.label}
-          <span className="identifier ml-auto text-neutral-800">{row.value}</span>
+          <span className="identifier ml-auto text-neutral-900">{row.value}</span>
         </p>
       ))}
     </div>

--- a/frontend/src/reports/ReportsView.tsx
+++ b/frontend/src/reports/ReportsView.tsx
@@ -6,11 +6,12 @@ import {
   useTeamCumulativeFlowTeamsTeamIdCumulativeFlowGet,
   useTeamVelocityTeamsTeamIdVelocityGet,
 } from '@/api/generated/endpoints/reports/reports'
-import { useTeamContext } from '@/team/TeamContext'
 import { BurndownChart } from '@/reports/BurndownChart'
 import { CreatedResolvedChart } from '@/reports/CreatedResolvedChart'
 import { FlowChart } from '@/reports/FlowChart'
 import { VelocityChart } from '@/reports/VelocityChart'
+import { useTeamContext } from '@/team/TeamContext'
+import { Select } from '@/ui/Select'
 
 const WINDOWS = [14, 30, 90] as const
 
@@ -38,14 +39,14 @@ export function ReportsView() {
   )
 
   return (
-    <div className="h-full overflow-y-auto p-4">
+    <div className="scroll-thin h-full overflow-y-auto">
       {/* Filters in one row above the charts. */}
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        <select
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Select
+          dense
           value={selected?.id ?? ''}
           onChange={(e) => setCycleId(e.target.value ? Number(e.target.value) : null)}
           disabled={cycles.length === 0}
-          className="rounded-md border border-neutral-200 bg-white px-2 py-1 text-xs disabled:opacity-60"
           aria-label="Cycle"
         >
           {cycles.length === 0 && <option value="">No cycles</option>}
@@ -54,18 +55,18 @@ export function ReportsView() {
               {cycle.display_name}
             </option>
           ))}
-        </select>
+        </Select>
 
-        <div className="inline-flex gap-0.5 rounded-lg bg-neutral-100 p-0.5">
+        <div className="segmented" role="tablist" aria-label="Window">
           {WINDOWS.map((window) => (
             <button
               key={window}
+              type="button"
+              role="tab"
+              aria-selected={days === window}
+              data-active={days === window}
               onClick={() => setDays(window)}
-              className={`rounded-md px-2 py-1 text-xs font-medium transition ${
-                days === window
-                  ? 'bg-white text-neutral-800 shadow-sm'
-                  : 'text-neutral-500 hover:text-neutral-700'
-              }`}
+              className="segmented-item"
             >
               {window}d
             </button>
@@ -73,12 +74,12 @@ export function ReportsView() {
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-2">
+      <div className="grid gap-3 xl:grid-cols-2">
         {selected && burndown.data ? (
           <BurndownChart data={burndown.data} />
         ) : (
-          <figure className="rounded-lg border border-neutral-200 bg-white p-4">
-            <h3 className="text-sm font-medium text-neutral-900">Burndown</h3>
+          <figure className="glass rounded-panel p-4">
+            <h3 className="text-sm font-semibold text-neutral-900">Burndown</h3>
             <p className="py-10 text-center text-sm text-neutral-400">
               {cycles.length === 0
                 ? 'Create a cycle to see a burndown.'
@@ -92,7 +93,7 @@ export function ReportsView() {
         {createdResolved.data && <CreatedResolvedChart data={createdResolved.data} />}
       </div>
 
-      <p className="mt-4 text-xs text-neutral-400">
+      <p className="mt-3 px-1 text-xs text-neutral-400">
         {/* Say why an empty chart is empty, rather than letting it look broken. */}
         Charts are built from recorded issue history, so they begin from the day
         history started being kept — earlier activity cannot be reconstructed.

--- a/frontend/src/reports/chartTokens.ts
+++ b/frontend/src/reports/chartTokens.ts
@@ -18,6 +18,9 @@
  *
  * The two-series pairs below both pass every check (ΔE 44 and ΔE 34 in normal
  * vision, and no worse than 26 under simulated CVD).
+ *
+ * Grid and axis inks are mixed from the neutral ramp so they follow the theme:
+ * a fixed light grey would vanish on the dark canvas.
  */
 
 /** Workflow stages, bottom to top, light to dark. */
@@ -49,7 +52,7 @@ export const INK = {
   contrastSeries: 'var(--color-priority-medium)',
   /** Validated against `measure`: ΔE 34 normal, 27 deutan. */
   resolved: 'var(--color-status-done)',
-  grid: 'var(--color-neutral-200)',
+  grid: 'color-mix(in oklab, var(--color-neutral-900) 9%, transparent)',
   axis: 'var(--color-neutral-400)',
-  surface: 'var(--color-neutral-50)',
+  surface: 'transparent',
 } as const

--- a/frontend/src/search/SearchResults.tsx
+++ b/frontend/src/search/SearchResults.tsx
@@ -2,9 +2,10 @@ import { formatDistanceToNow } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
 
 import type { SearchHit } from '@/api/generated/models'
+import { PriorityIcon } from '@/issues/PriorityIcon'
 import { STATUS_META } from '@/issues/issueMeta'
 import { useTeamContext } from '@/team/TeamContext'
-import { PriorityIcon } from '@/issues/PriorityIcon'
+import { Loading } from '@/ui/Loading'
 
 /** Where the match was found, said plainly. */
 const MATCHED_IN_LABEL: Record<string, string> = {
@@ -28,33 +29,32 @@ export function SearchResults({
   const { team } = useTeamContext()
 
   if (isLoading) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-neutral-400">
-        Searching…
-      </div>
-    )
+    return <Loading label="Searching…" />
   }
 
   if (hits.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-1 text-sm text-neutral-400">
+      <div className="glass flex h-full flex-col items-center justify-center gap-1 rounded-panel text-sm text-neutral-500">
         <p>
-          Nothing matches <span className="font-medium text-neutral-600">“{query}”</span>.
+          Nothing matches <span className="font-medium text-neutral-800">“{query}”</span>.
         </p>
-        <p className="text-xs">Titles, descriptions and comments were all searched.</p>
+        <p className="text-xs text-neutral-400">
+          Titles, descriptions and comments were all searched.
+        </p>
       </div>
     )
   }
 
   return (
-    <div className="h-full overflow-y-auto p-4">
-      <p className="mb-3 text-xs text-neutral-400">
-        {total} {total === 1 ? 'result' : 'results'} for{' '}
-        <span className="font-medium text-neutral-600">“{query}”</span>
+    <div className="glass scroll-thin h-full overflow-y-auto rounded-panel">
+      <p className="hairline border-b px-4 py-2.5 text-xs text-neutral-500">
+        <span className="identifier font-medium text-neutral-800">{total}</span>{' '}
+        {total === 1 ? 'result' : 'results'} for{' '}
+        <span className="font-medium text-neutral-800">“{query}”</span>
         {total > hits.length && <> · showing the first {hits.length}</>}
       </p>
 
-      <ul className="space-y-1.5">
+      <ul className="divide-y divide-neutral-900/8">
         {hits.map((hit) => {
           const meta = STATUS_META[hit.status]
           return (
@@ -62,11 +62,11 @@ export function SearchResults({
               <button
                 type="button"
                 onClick={() => navigate(`/${team.key}/issue/${hit.identifier.split('-')[1]}`)}
-                className="w-full rounded-lg border border-neutral-200 bg-white p-3 text-left transition hover:border-neutral-300 hover:shadow-sm"
+                className="w-full px-4 py-3 text-left transition-colors hover:bg-neutral-900/4 focus:outline-none focus-visible:bg-brand-500/10"
               >
-                <div className="flex items-baseline gap-2">
-                  <span className={`h-2 w-2 shrink-0 translate-y-px rounded-full ${meta.dot}`} />
-                  <span className="identifier shrink-0 text-xs text-neutral-400">
+                <div className="flex items-center gap-2.5">
+                  <span className="dot" style={{ ['--dot' as string]: meta.color }} />
+                  <span className="identifier shrink-0 text-xs font-medium text-neutral-400">
                     {hit.identifier}
                   </span>
                   <span className="min-w-0 flex-1 truncate text-sm font-medium text-neutral-900">
@@ -76,12 +76,12 @@ export function SearchResults({
                 </div>
 
                 {hit.snippet && (
-                  <p className="mt-1 line-clamp-2 pl-4 text-xs leading-relaxed text-neutral-500">
+                  <p className="mt-1 line-clamp-2 pl-[1.4rem] text-xs leading-relaxed text-neutral-500">
                     {hit.snippet}
                   </p>
                 )}
 
-                <p className="mt-1 pl-4 text-[11px] text-neutral-400">
+                <p className="mt-1 pl-[1.4rem] text-[11px] text-neutral-400">
                   {/* Saying where the match was stops a result whose title has
                       nothing to do with the query looking like a mistake. */}
                   matched in {MATCHED_IN_LABEL[hit.matched_in] ?? hit.matched_in} ·{' '}

--- a/frontend/src/team/NewTeamPage.tsx
+++ b/frontend/src/team/NewTeamPage.tsx
@@ -2,7 +2,9 @@ import { type FormEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useCreateTeamTeamsPost } from '@/api/generated/endpoints/teams/teams'
+import { errorDetail } from '@/api/errors'
 import { useAuth } from '@/auth/AuthContext'
+import { Logo } from '@/ui/Logo'
 
 export default function NewTeamPage() {
   const navigate = useNavigate()
@@ -22,56 +24,67 @@ export default function NewTeamPage() {
       })
       navigate(`/${team.key}`, { replace: true })
     } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
-        ?.detail
-      setError(detail ?? 'Could not create the team.')
+      setError(errorDetail(err, 'Could not create the team.'))
     }
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4">
-      <div className="w-full max-w-sm">
-        <div className="mb-6 flex items-center justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-neutral-900">
-              {user ? `Welcome, ${user.full_name.split(' ')[0]}` : 'Create a team'}
-            </h1>
-            <p className="mt-1 text-sm text-neutral-500">
-              Teams group your projects and issues, e.g. "Engineering" with key ENG.
-            </p>
+    <div className="flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="pop-in w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <div className="mb-4 flex justify-center">
+            <Logo size={52} />
           </div>
+          <h1 className="text-2xl font-semibold tracking-tight text-neutral-900">
+            {user ? (
+              <>
+                Welcome, <span className="text-gradient">{user.full_name.split(' ')[0]}</span>
+              </>
+            ) : (
+              'Create a team'
+            )}
+          </h1>
+          <p className="mt-1.5 text-sm text-neutral-500">
+            Teams group your projects and issues, e.g. "Engineering" with key ENG.
+          </p>
         </div>
 
-        <form
-          onSubmit={onSubmit}
-          className="space-y-4 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm"
-        >
+        <form onSubmit={onSubmit} className="glass-strong sheen space-y-4 rounded-panel p-6">
           {error && (
-            <div className="rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-700">{error}</div>
+            <div
+              role="alert"
+              className="rounded-control bg-danger-50 px-3 py-2 text-sm text-danger-700"
+            >
+              {error}
+            </div>
           )}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">Team name</label>
+            <label htmlFor="team-name" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Team name
+            </label>
             <input
+              id="team-name"
               required
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field"
               placeholder="Engineering"
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700">
-              Key <span className="text-neutral-400">(2-6 letters, used as issue prefix)</span>
+            <label htmlFor="team-key" className="mb-1.5 block text-sm font-medium text-neutral-700">
+              Key <span className="font-normal text-neutral-400">· 2 to 6 letters, the issue prefix</span>
             </label>
             <input
+              id="team-key"
               required
               minLength={2}
               maxLength={6}
               value={key}
               onChange={(e) => setKey(e.target.value.toUpperCase().replace(/[^A-Z]/g, ''))}
-              className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm uppercase tracking-wide focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              className="field identifier uppercase tracking-wide"
               placeholder="ENG"
             />
           </div>
@@ -79,15 +92,16 @@ export default function NewTeamPage() {
           <button
             type="submit"
             disabled={createTeam.isPending}
-            className="w-full rounded-md bg-brand-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-700 disabled:opacity-60"
+            className="btn btn-primary h-10 w-full text-sm"
           >
             {createTeam.isPending ? 'Creating…' : 'Create team'}
           </button>
         </form>
 
         <button
+          type="button"
           onClick={logout}
-          className="mt-4 w-full text-center text-sm text-neutral-400 hover:text-neutral-600"
+          className="mt-5 w-full text-center text-sm text-neutral-400 hover:text-neutral-700"
         >
           Sign out
         </button>

--- a/frontend/src/team/TeamsHome.tsx
+++ b/frontend/src/team/TeamsHome.tsx
@@ -1,6 +1,7 @@
 import { Navigate } from 'react-router-dom'
 
 import { useMyTeams } from '@/team/useTeams'
+import { Loading } from '@/ui/Loading'
 
 /**
  * Landing route for authenticated users: redirect to their first team's
@@ -11,8 +12,8 @@ export default function TeamsHome() {
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center text-sm text-neutral-400">
-        Loading…
+      <div className="h-screen">
+        <Loading />
       </div>
     )
   }

--- a/frontend/src/ui/Avatar.tsx
+++ b/frontend/src/ui/Avatar.tsx
@@ -6,6 +6,10 @@ function initials(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
 }
 
+/**
+ * Initials on the person's own colour, with a glass rim so it sits on any
+ * surface -- a card, the aurora, or a dark panel -- without a hard edge.
+ */
 export function Avatar({
   user,
   size = 24,
@@ -16,12 +20,15 @@ export function Avatar({
   return (
     <div
       title={user.full_name}
-      className="flex shrink-0 items-center justify-center rounded-full font-medium text-white"
+      className="flex shrink-0 items-center justify-center rounded-full font-semibold text-white"
       style={{
         width: size,
         height: size,
-        backgroundColor: user.avatar_color,
-        fontSize: Math.max(9, size * 0.4),
+        fontSize: Math.max(9, size * 0.38),
+        background: `linear-gradient(145deg, color-mix(in oklab, ${user.avatar_color} 78%, #fff), ${user.avatar_color})`,
+        boxShadow:
+          'inset 0 1px 0 rgba(255,255,255,0.45), 0 0 0 1.5px var(--glass-border), 0 2px 6px rgba(20,18,40,0.18)',
+        letterSpacing: '0.01em',
       }}
     >
       {initials(user.full_name)}

--- a/frontend/src/ui/Icon.tsx
+++ b/frontend/src/ui/Icon.tsx
@@ -1,0 +1,116 @@
+import type { JSX, SVGProps } from 'react'
+
+export type IconName =
+  | 'search'
+  | 'plus'
+  | 'close'
+  | 'menu'
+  | 'sun'
+  | 'moon'
+  | 'chevron-down'
+  | 'chevron-right'
+  | 'chevron-left'
+  | 'board'
+  | 'list'
+  | 'chart'
+  | 'paperclip'
+  | 'check'
+  | 'link'
+  | 'upload'
+  | 'logout'
+  | 'sparkle'
+  | 'command'
+  | 'filter'
+  | 'calendar'
+  | 'flag'
+  | 'users'
+
+const PATHS: Record<IconName, JSX.Element> = {
+  search: (
+    <>
+      <circle cx="11" cy="11" r="6.5" />
+      <path d="m20 20-4.2-4.2" />
+    </>
+  ),
+  plus: <path d="M12 5v14M5 12h14" />,
+  close: <path d="M6 6l12 12M18 6 6 18" />,
+  menu: <path d="M4 7h16M4 12h16M4 17h16" />,
+  sun: (
+    <>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+    </>
+  ),
+  moon: <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />,
+  'chevron-down': <path d="m6 9 6 6 6-6" />,
+  'chevron-right': <path d="m9 6 6 6-6 6" />,
+  'chevron-left': <path d="m15 6-6 6 6 6" />,
+  board: (
+    <>
+      <rect x="3" y="4" width="5" height="16" rx="1.5" />
+      <rect x="9.5" y="4" width="5" height="11" rx="1.5" />
+      <rect x="16" y="4" width="5" height="8" rx="1.5" />
+    </>
+  ),
+  list: <path d="M8 6h13M8 12h13M8 18h13M3.5 6h.01M3.5 12h.01M3.5 18h.01" />,
+  chart: <path d="M4 19V5M4 19h16M8 15v-4M12 15V8M16 15v-2M20 15V6" />,
+  paperclip: (
+    <path d="m21 11.5-8.5 8.5a5.5 5.5 0 0 1-7.8-7.8l9-9a3.7 3.7 0 0 1 5.2 5.2l-9 9a1.8 1.8 0 0 1-2.6-2.6l8.3-8.3" />
+  ),
+  check: <path d="m5 12.5 4.5 4.5L19 7.5" />,
+  link: (
+    <>
+      <path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" />
+      <path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" />
+    </>
+  ),
+  upload: <path d="M12 16V4m0 0-4 4m4-4 4 4M4 16v3a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-3" />,
+  logout: <path d="M10 17l5-5-5-5M15 12H3M13 4h6a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1h-6" />,
+  sparkle: <path d="M12 3v4M12 17v4M3 12h4M17 12h4M6.3 6.3l2.8 2.8M14.9 14.9l2.8 2.8M6.3 17.7l2.8-2.8M14.9 9.1l2.8-2.8" />,
+  command: (
+    <path d="M9 9V6a3 3 0 1 0-3 3h3Zm0 0h6m-6 0v6m6-6V6a3 3 0 1 1 3 3h-3Zm0 0v6m0 0v3a3 3 0 1 0 3-3h-3Zm0 0H9m0 0v3a3 3 0 1 1-3-3h3Z" />
+  ),
+  filter: <path d="M4 5h16l-6.5 8v5l-3 2v-7L4 5Z" />,
+  calendar: (
+    <>
+      <rect x="3" y="5" width="18" height="16" rx="2" />
+      <path d="M3 10h18M8 3v4M16 3v4" />
+    </>
+  ),
+  flag: <path d="M5 21V4m0 0h11l-2 4 2 4H5" />,
+  users: (
+    <>
+      <circle cx="9" cy="8" r="3.5" />
+      <path d="M2.5 20a6.5 6.5 0 0 1 13 0M16 4.5a3.5 3.5 0 0 1 0 7M21.5 20a6.5 6.5 0 0 0-5-6.3" />
+    </>
+  ),
+}
+
+/** Stroked line icons on a 24-unit grid. Colour comes from `currentColor`. */
+export function Icon({
+  name,
+  size = 16,
+  strokeWidth = 1.8,
+  ...props
+}: { name: IconName; size?: number; strokeWidth?: number } & Omit<
+  SVGProps<SVGSVGElement>,
+  'name'
+>) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      {PATHS[name]}
+    </svg>
+  )
+}

--- a/frontend/src/ui/Loading.tsx
+++ b/frontend/src/ui/Loading.tsx
@@ -1,0 +1,14 @@
+/** A quiet full-height loading state, used while a route resolves. */
+export function Loading({ label = 'Loading…' }: { label?: string }) {
+  return (
+    <div className="flex h-full min-h-[40vh] w-full items-center justify-center" role="status">
+      <div className="glass flex items-center gap-3 rounded-full px-4 py-2 text-sm text-neutral-500">
+        <span className="relative inline-flex h-3.5 w-3.5">
+          <span className="absolute inset-0 animate-ping rounded-full bg-brand-400/60" />
+          <span className="relative inline-flex h-3.5 w-3.5 rounded-full bg-linear-to-br from-brand-400 to-accent-sky" />
+        </span>
+        {label}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/ui/Logo.tsx
+++ b/frontend/src/ui/Logo.tsx
@@ -1,6 +1,7 @@
 /**
  * The SoftTrack mark: a routed path that reads as an "S" and as work moving
- * across a board. Deliberately distinct from `PriorityIcon`'s ascending bars.
+ * across a board. The tile carries the brand gradient with a glass highlight
+ * so it belongs with the rest of the surfaces.
  *
  * `withWordmark` renders the full lockup. The mark alone is for tight spots
  * (favicon, collapsed sidebar); never re-typeset the wordmark by hand.
@@ -20,8 +21,21 @@ export function Logo({
       role="img"
       aria-label={withWordmark ? undefined : 'SoftTrack'}
       aria-hidden={withWordmark || undefined}
+      style={{ filter: 'drop-shadow(0 4px 10px color-mix(in oklab, var(--color-brand-600) 45%, transparent))' }}
     >
-      <rect width="32" height="32" rx="9" className="fill-brand-600" />
+      <defs>
+        <linearGradient id="st-logo-fill" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="var(--color-brand-400)" />
+          <stop offset="0.6" stopColor="var(--color-brand-600)" />
+          <stop offset="1" stopColor="var(--color-accent-sky)" />
+        </linearGradient>
+        <linearGradient id="st-logo-sheen" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#fff" stopOpacity="0.45" />
+          <stop offset="0.55" stopColor="#fff" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <rect width="32" height="32" rx="9" fill="url(#st-logo-fill)" />
+      <rect width="32" height="32" rx="9" fill="url(#st-logo-sheen)" />
       <path
         d="M21.6 9.6h-7.2a3.4 3.4 0 0 0 0 6.8h3.2a3.4 3.4 0 0 1 0 6.8h-7.2"
         fill="none"

--- a/frontend/src/ui/Select.tsx
+++ b/frontend/src/ui/Select.tsx
@@ -1,0 +1,35 @@
+import type { SelectHTMLAttributes } from 'react'
+
+import { Icon } from '@/ui/Icon'
+
+/**
+ * A native `<select>` dressed as a glass pill.
+ *
+ * Native on purpose: it is keyboard-accessible, screen-reader friendly and
+ * works on every platform for free. Only the chrome is ours -- the arrow is
+ * drawn here so it matches the rest of the controls in both themes.
+ */
+export function Select({
+  dense = false,
+  block = false,
+  className = '',
+  children,
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement> & {
+  /** The compact size used in dense rows such as the issue properties. */
+  dense?: boolean
+  /** Stretch to the container's width. */
+  block?: boolean
+}) {
+  return (
+    <span className={`select-wrap ${block ? 'w-full' : ''} ${className}`}>
+      <select
+        {...props}
+        className={`select ${dense ? 'select-sm' : ''} ${block ? 'select-block' : ''}`}
+      >
+        {children}
+      </select>
+      <Icon name="chevron-down" size={dense ? 12 : 14} className="select-chevron" />
+    </span>
+  )
+}

--- a/frontend/src/ui/theme.ts
+++ b/frontend/src/ui/theme.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'softtrack.theme'
+
+const media = () =>
+  typeof window !== 'undefined' && 'matchMedia' in window
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null
+
+/** What the user chose, or null to follow the system. */
+function stored(): Theme | null {
+  try {
+    const value = localStorage.getItem(THEME_STORAGE_KEY)
+    return value === 'light' || value === 'dark' ? value : null
+  } catch {
+    return null
+  }
+}
+
+function systemTheme(): Theme {
+  return media()?.matches ? 'dark' : 'light'
+}
+
+/** Resolve and stamp the theme on <html>. Mirrors the inline script in index.html. */
+export function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme
+}
+
+/**
+ * The current theme and a toggle.
+ *
+ * An explicit choice is remembered; with none, the system preference is
+ * followed live. index.html applies the same rule before React loads so the
+ * first paint is already the right colour.
+ */
+export function useTheme(): { theme: Theme; toggle: () => void } {
+  const [theme, setTheme] = useState<Theme>(() => stored() ?? systemTheme())
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  useEffect(() => {
+    const query = media()
+    if (!query) return
+    const follow = () => {
+      if (stored() === null) setTheme(query.matches ? 'dark' : 'light')
+    }
+    query.addEventListener('change', follow)
+    return () => query.removeEventListener('change', follow)
+  }, [])
+
+  const toggle = useCallback(() => {
+    setTheme((current) => {
+      const next: Theme = current === 'dark' ? 'light' : 'dark'
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next)
+      } catch {
+        // Storage can be unavailable; the choice then lasts the session.
+      }
+      return next
+    })
+  }, [])
+
+  return { theme, toggle }
+}


### PR DESCRIPTION
## What this changes

A liquid-glass redesign of the whole frontend, plus one migration fix that was blocking existing SQLite installs.

- **Design system** in `frontend/src/index.css`: an aurora canvas, layered translucent glass surfaces with backdrop blur and specular edges, pill controls, a gradient primary action, tinted label chips, and a theme-aware neutral ramp. Light and dark themes with a remembered toggle, stamped before first paint.
- **Shell**: floating glass sidebar and toolbar; board columns as individual panels that fit the viewport, Cancelled folded to a rail, any column collapsible; a drawer sidebar and snap-scrolling columns below `lg`.
- **Every screen restyled**: board, list, issue panel, new-issue and cycle modals, Jira import, command palette, shortcuts sheet, search results, reports, sign-in, register, new team.
- **Shared primitives** under `frontend/src/ui`: line icons, a glass `Select` wrapper around the native control, a loading pill, the theme hook.
- **Fixes folded in**:
  - Drag-and-drop status changes threw `old?.map is not a function` since pagination landed; the optimistic update now edits `items` on the page envelope.
  - Escape did nothing on a freshly opened issue panel; the overlay reducer now returns the same state on no-op actions and the panel registers its listener once.
  - The cycles migration failed on any SQLite database with a team (NOT NULL column added and default dropped in one batch); it now uses two batches.

## Why

The previous UI was clean but flat, failed contrast on most secondary text, hid the Done column at common laptop widths, and had no responsive layout at all. The two frontend bugs were found while reviewing and would have been the first thing anyone testing the redesign hit. The migration bug is what had wrecked a local development database.

## How it was verified

- `npx tsc -b --noEmit` clean; `npm run lint` shows only the two pre-existing fast-refresh warnings; `npx vitest run` 82 passed; `npm run build` succeeds.
- `black --check` clean; `pytest` passes; `alembic heads` reports one head.
- In the browser at 1440×900, light and dark: board, list, reports, issue panel, command palette, new-issue modal. At 375px: the toolbar wraps, the drawer opens and closes, columns snap-scroll.
- A drag from Todo to In Progress sent `PATCH /issues/6 → 200` and the card stayed in its new column. Escape on a freshly opened panel navigates back to the board.
- The migration fix was run against a copy of a stuck SQLite database (stamped at `78b80bc56bda` with leftover `cycle` and `_alembic_tmp_issue` tables): all four remaining migrations applied, every row survived, teams got `next_cycle_number = 1`, and the app booted and served sign-in and issue listing. The same migrations then ran on a Postgres volume with six teams.

## Checklist

- [x] `cd backend && black . && pytest` passes
- [x] No backend routes or schemas changed, so the API client was not regenerated
- [x] No model change; one existing migration was made runnable on SQLite, no new revision
- [ ] No new automated tests: the two frontend fixes and the migration fix were verified by hand as described above
- [x] No business logic in route handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
