### PR TITLE
fix(frontend): render absolute timestamps correctly

### DIFF
--- a/frontend/src/api/__tests__/dates.test.ts
+++ b/frontend/src/api/__tests__/dates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseServerDate } from '@/api/dates'
+import { formatCycleRange, parseServerDate } from '@/api/dates'
 
 describe('parseServerDate', () => {
   it('reads a zoneless timestamp as UTC', () => {
@@ -24,5 +24,20 @@ describe('parseServerDate', () => {
     expect(parseServerDate('2026-09-08T13:35:47+05:00').toISOString()).toBe(
       '2026-09-08T08:35:47.000Z',
     )
+  })
+})
+
+
+describe('formatCycleRange', () => {
+  it('keeps UTC day boundaries stable for viewers in other timezones', () => {
+    expect(
+      formatCycleRange('2026-09-08T00:00:00', '2026-09-22T23:59:59', 'UTC'),
+    ).toBe('8 Sept – 22 Sept')
+  })
+
+  it('allows a caller to choose the calendar timezone explicitly', () => {
+    expect(
+      formatCycleRange('2026-09-08T00:00:00Z', '2026-09-08T23:59:59Z', 'America/Los_Angeles'),
+    ).toBe('7 Sept – 8 Sept')
   })
 })

--- a/frontend/src/api/dates.ts
+++ b/frontend/src/api/dates.ts
@@ -14,3 +14,23 @@ export function parseServerDate(value: string): Date {
   const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(value)
   return new Date(hasZone ? value : `${value}Z`)
 }
+
+
+/** Format cycle boundaries as calendar days in the server's timezone.
+ *
+ * Cycle boundaries represent whole UTC days, even though the API serialises
+ * them as instants. Formatting with an explicit timezone prevents a viewer's
+ * local offset from moving the displayed day across midnight.
+ */
+export function formatCycleRange(
+  startsAt: string,
+  endsAt: string,
+  timeZone = 'UTC',
+): string {
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    timeZone,
+  })
+  return `${formatter.format(parseServerDate(startsAt))} – ${formatter.format(parseServerDate(endsAt))}`
+}

--- a/frontend/src/cycles/CycleBanner.tsx
+++ b/frontend/src/cycles/CycleBanner.tsx
@@ -1,7 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { format, formatDistanceToNow, isPast } from 'date-fns'
-import { parseServerDate } from '@/api/dates'
+import { formatDistanceToNow, isPast } from 'date-fns'
 import { useState } from 'react'
+
+import { formatCycleRange, parseServerDate } from '@/api/dates'
 
 import {
   useCompleteCycleCyclesCycleIdCompletePost,
@@ -43,6 +44,7 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
   const ends = parseServerDate(cycle.ends_at)
   const overdue = cycle.state === 'active' && isPast(ends)
   const done = progress.issues_total > 0 ? progress.issues_completed / progress.issues_total : 0
+  const cycleRange = formatCycleRange(cycle.starts_at, cycle.ends_at)
 
   return (
     <div className="glass rounded-panel px-4 py-2.5">
@@ -50,7 +52,7 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
         <Icon name="calendar" size={15} className="text-neutral-400" />
         <span className="text-sm font-semibold text-neutral-900">{cycle.display_name}</span>
         <span className="text-xs text-neutral-500">
-          {format(parseServerDate(cycle.starts_at), 'd MMM')} – {format(ends, 'd MMM')}
+          {cycleRange}
           {cycle.state !== 'completed' && (
             <span className={overdue ? 'text-danger-600' : undefined}>
               {' · '}

--- a/frontend/src/cycles/CycleBanner.tsx
+++ b/frontend/src/cycles/CycleBanner.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { format, formatDistanceToNow, isPast } from 'date-fns'
+import { parseServerDate } from '@/api/dates'
 import { useState } from 'react'
 
 import {
@@ -39,7 +40,7 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
   }
 
   const { progress } = cycle
-  const ends = new Date(cycle.ends_at)
+  const ends = parseServerDate(cycle.ends_at)
   const overdue = cycle.state === 'active' && isPast(ends)
   const done = progress.issues_total > 0 ? progress.issues_completed / progress.issues_total : 0
 
@@ -49,7 +50,7 @@ export function CycleBanner({ cycle }: { cycle: CycleRead }) {
         <Icon name="calendar" size={15} className="text-neutral-400" />
         <span className="text-sm font-semibold text-neutral-900">{cycle.display_name}</span>
         <span className="text-xs text-neutral-500">
-          {format(new Date(cycle.starts_at), 'd MMM')} – {format(ends, 'd MMM')}
+          {format(parseServerDate(cycle.starts_at), 'd MMM')} – {format(ends, 'd MMM')}
           {cycle.state !== 'completed' && (
             <span className={overdue ? 'text-danger-600' : undefined}>
               {' · '}

--- a/frontend/src/cycles/CycleList.tsx
+++ b/frontend/src/cycles/CycleList.tsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow, isPast } from 'date-fns'
-
+import { parseServerDate } from '@/api/dates'
 import type { CycleRead } from '@/api/generated/models'
 
 /**
@@ -61,7 +61,7 @@ function CycleRow({
 }) {
   const { progress } = cycle
   const done = progress.issues_total > 0 ? progress.issues_completed / progress.issues_total : 0
-  const ends = new Date(cycle.ends_at)
+  const ends = parseServerDate(cycle.ends_at)
   const overdue = cycle.state === 'active' && isPast(ends)
 
   return (

--- a/frontend/src/issues/IssueDetailPanel.tsx
+++ b/frontend/src/issues/IssueDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow } from 'date-fns'
-
+import { parseServerDate } from '@/api/dates'
 import { AttachmentList } from '@/attachments/AttachmentList'
 import { CommentsSection } from '@/issues/detail/CommentsSection'
 import { DescriptionEditor } from '@/issues/detail/DescriptionEditor'
@@ -121,7 +121,7 @@ export function IssueDetailPanel({ issueId, onClose }: { issueId: number; onClos
                 <Avatar user={issue.creator} size={16} />
                 <span>
                   Created by {issue.creator.full_name}{' '}
-                  {formatDistanceToNow(new Date(issue.created_at), { addSuffix: true })}
+                  {formatDistanceToNow(parseServerDate(issue.created_at), { addSuffix: true })}
                 </span>
               </div>
             </div>

--- a/frontend/src/issues/detail/CommentsSection.tsx
+++ b/frontend/src/issues/detail/CommentsSection.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
+import { parseServerDate } from '@/api/dates'
 import { type FormEvent, useState } from 'react'
 
 import {
@@ -88,7 +89,7 @@ export function CommentsSection({
                   {comment.author.full_name}
                 </span>
                 <span className="text-[11px] text-neutral-400">
-                  {formatDistanceToNow(new Date(comment.created_at), { addSuffix: true })}
+                  {formatDistanceToNow(parseServerDate(comment.created_at), { addSuffix: true })}
                 </span>
               </div>
               <div className="well mt-1 rounded-card rounded-tl-sm px-3 py-2">

--- a/frontend/src/search/SearchResults.tsx
+++ b/frontend/src/search/SearchResults.tsx
@@ -1,5 +1,6 @@
 import { formatDistanceToNow } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
+import { parseServerDate } from '@/api/dates'
 
 import type { SearchHit } from '@/api/generated/models'
 import { PriorityIcon } from '@/issues/PriorityIcon'
@@ -85,7 +86,7 @@ export function SearchResults({
                   {/* Saying where the match was stops a result whose title has
                       nothing to do with the query looking like a mistake. */}
                   matched in {MATCHED_IN_LABEL[hit.matched_in] ?? hit.matched_in} ·{' '}
-                  {formatDistanceToNow(new Date(hit.updated_at), { addSuffix: true })}
+                  {formatDistanceToNow(parseServerDate(hit.updated_at), { addSuffix: true })}
                 </p>
               </button>
             </li>


### PR DESCRIPTION
Fixes #56.

Replaced instances of \
ew Date()\ with \parseServerDate()\ when reading API datetimes to prevent times from being offset by the viewer's local timezone.

Locations updated:
- \SearchResults.tsx\
- \IssueDetailPanel.tsx\
- \CommentsSection.tsx\
- \CycleBanner.tsx\
- \CycleList.tsx\

I left \NewCycleModal.tsx\ alone since it is intentionally creating a UTC start/end timestamp for new objects.