### PR TITLE
feat(markdown): auto-link issue keys for visible teams

### DIFF
--- a/frontend/src/issues/detail/DescriptionEditor.tsx
+++ b/frontend/src/issues/detail/DescriptionEditor.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
+
+import { useTeamContext } from '@/team/TeamContext'
 
 import { Markdown, MarkdownEditor } from '@/markdown/lazy'
 import type { Mentionable } from '@/markdown/mentions'
@@ -32,6 +34,11 @@ export function DescriptionEditor({
   onUploadFiles?: (files: File[]) => Promise<Array<{ markdown: string }>>
 }) {
   const [editing, setEditing] = useState(false)
+  const { team, teams } = useTeamContext()
+  const teamKeys = useMemo(
+    () => Array.from(new Set([team.key, ...teams.map((t) => t.key)])),
+    [team, teams],
+  )
 
   if (editing) {
     return (
@@ -40,6 +47,7 @@ export function DescriptionEditor({
           value={draft}
           onChange={setDraft}
           people={people}
+          teamKeys={teamKeys}
           placeholder="Add a description… Markdown works here."
           rows={8}
           autoFocus
@@ -88,7 +96,7 @@ export function DescriptionEditor({
 
   return (
     <div className="mt-3">
-      <Markdown people={people} onToggleTask={onToggleTask}>
+      <Markdown people={people} onToggleTask={onToggleTask} teamKeys={teamKeys}>
         {saved}
       </Markdown>
       <div className="mt-2 flex items-center gap-3">

--- a/frontend/src/markdown/Markdown.tsx
+++ b/frontend/src/markdown/Markdown.tsx
@@ -7,6 +7,7 @@ import { AttachmentImage } from '@/attachments/AttachmentImage'
 import { isAttachmentUrl } from '@/attachments/urls'
 import type { Mentionable } from '@/markdown/mentions'
 import { remarkMentions } from '@/markdown/remarkMentions'
+import { remarkIssueKeys } from '@/markdown/remarkIssueKeys'
 
 /**
  * Rendered markdown.
@@ -22,6 +23,7 @@ export function Markdown({
   people = [],
   onToggleTask,
   className = '',
+  teamKeys = [],
 }: {
   children: string
   people?: Mentionable[]
@@ -32,10 +34,11 @@ export function Markdown({
    */
   onToggleTask?: (offset: number) => void
   className?: string
+  teamKeys?: string[]
 }) {
   const plugins = useMemo(
-    () => [remarkGfm, [remarkMentions, { people }]] as PluggableList,
-    [people],
+    () => [remarkGfm, [remarkMentions, { people }], [remarkIssueKeys, { teamKeys }]] as PluggableList,
+    [people, teamKeys],
   )
 
   const components: Components = {

--- a/frontend/src/markdown/MarkdownEditor.tsx
+++ b/frontend/src/markdown/MarkdownEditor.tsx
@@ -25,6 +25,7 @@ export function MarkdownEditor({
   onBlur,
   onUploadFiles,
   className = '',
+  teamKeys,
 }: {
   value: string
   onChange: (next: string) => void
@@ -44,6 +45,7 @@ export function MarkdownEditor({
    */
   onUploadFiles?: (files: File[]) => Promise<Array<{ markdown: string }>>
   className?: string
+  teamKeys?: string[]
 }) {
   const [mode, setMode] = useState<Mode>('write')
   const [mention, setMention] = useState<{ query: string; start: number } | null>(null)
@@ -320,7 +322,7 @@ export function MarkdownEditor({
       ) : (
         <div className="well min-h-[5rem] rounded-card px-3 py-2">
           {value.trim() ? (
-            <Markdown people={people}>{value}</Markdown>
+            <Markdown people={people} teamKeys={teamKeys}>{value}</Markdown>
           ) : (
             <p className="text-sm text-neutral-400">Nothing to preview yet.</p>
           )}

--- a/frontend/src/markdown/__tests__/issueKeys.test.tsx
+++ b/frontend/src/markdown/__tests__/issueKeys.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { Markdown } from '@/markdown/Markdown'
+
+const render = (source: string, teamKeys = ['ENG']) =>
+  renderToStaticMarkup(<Markdown teamKeys={teamKeys}>{source}</Markdown>)
+
+describe('remarkIssueKeys', () => {
+  it('links a visible team key to the issue', () => {
+    const html = render('See ENG-42 for details')
+    expect(html).toContain('href="/ENG/issue/42"')
+    expect(html).toContain('ENG-42')
+  })
+
+  it('does not link unknown team keys', () => {
+    const html = render('See XYZ-9 for details')
+    expect(html).toContain('XYZ-9')
+    expect(html).not.toContain('/XYZ/issue/9')
+  })
+
+  it('does not link inside inline code', () => {
+    const html = render('Use `ENG-42` in code')
+    expect(html).toContain('<code')
+    expect(html).toContain('ENG-42')
+    expect(html).not.toContain('/ENG/issue/42')
+  })
+
+  it('links multiple occurrences', () => {
+    const html = render('Refs: ENG-1 and ENG-2')
+    expect(html).toContain('/ENG/issue/1')
+    expect(html).toContain('/ENG/issue/2')
+  })
+})

--- a/frontend/src/markdown/remarkIssueKeys.ts
+++ b/frontend/src/markdown/remarkIssueKeys.ts
@@ -1,0 +1,63 @@
+import type { Root, Text } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+/**
+ * Turn `TEAMKEY-123` into a link to the issue when the team key is visible
+ * to the viewer. Operates only on `text` nodes so inline code and fenced
+ * blocks remain literal.
+ */
+export function remarkIssueKeys({ teamKeys = [] }: { teamKeys?: string[] }) {
+  const allowed = new Set((teamKeys || []).map((k) => k.toUpperCase()))
+  if (allowed.size === 0) {
+    return () => {}
+  }
+
+  // Build a pattern that only matches provided team keys. The leading
+  // boundary prevents matching inside emails or paths.
+  const alternation = [...allowed].map((k) => k.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')).join('|')
+  const PATTERN = new RegExp('(^|[^\\w/])((?:' + alternation + ')-([0-9]+))', 'gi')
+
+  return (tree: Root) => {
+    visit(tree, 'text', (node: Text, index, parent) => {
+      if (!parent || index === undefined) return
+
+      const children: Array<Text | Record<string, unknown>> = []
+      let lastEnd = 0
+      PATTERN.lastIndex = 0
+
+      for (const match of node.value.matchAll(PATTERN)) {
+        const [whole, boundary, token, number] = match
+        const start = (match.index ?? 0) + boundary.length
+        const team = token.split('-')[0]
+        if (!allowed.has(team.toUpperCase())) continue
+
+        if (start > lastEnd) {
+          children.push({ type: 'text', value: node.value.slice(lastEnd, start) })
+        }
+
+        children.push({
+          type: 'link',
+          url: `/${team}/issue/${number}`,
+          title: token,
+          children: [{ type: 'text', value: token }],
+          data: {
+            hProperties: {
+              className: 'issue-link',
+              'data-issue-identifier': token,
+            },
+          },
+        })
+
+        lastEnd = (match.index ?? 0) + whole.length
+      }
+
+      if (children.length === 0) return
+      if (lastEnd < node.value.length) {
+        children.push({ type: 'text', value: node.value.slice(lastEnd) })
+      }
+
+      parent.children.splice(index, 1, ...(children as Text[]))
+      return index + children.length
+    })
+  }
+}


### PR DESCRIPTION
## What this changes

Closes #94

Adds a remark plugin that converts `TEAMKEY-123` tokens into navigable issue links only when the viewer can see the team.

Files changed:

* `remarkIssueKeys.ts`
* `Markdown.tsx`
* `MarkdownEditor.tsx`
* `DescriptionEditor.tsx`
* `issueKeys.test.tsx`

## Why

Issue identifiers like `ENG-42` were rendered as plain text in descriptions and comments, causing users to paste full URLs.

This change automatically linkifies those tokens in the markdown renderer, only when the current viewer has access to the referenced team. Issue keys inside inline code and fenced code blocks remain plain text.

## How it was verified

Added unit tests in `issueKeys.test.tsx`.

Ran:

```bash
cd frontend && npm run test
```

Result:

```text
Test Files  14 passed (14)
Tests       116 passed (116)
```

The Vitest test suite completed successfully.

Manual verification:

* Start the application.
* Sign in as a user who can see the relevant team.
* Put an issue key such as `ENG-42` in an issue description or comment.
* Verify that it renders as a link.
* Click the link and verify that the issue detail panel opens.

## Checklist

* [ ] `cd backend && black . && pytest` passes — Not applicable: this is a frontend-only change.
* [ ] If backend routes or schemas changed, the API client was regenerated and committed — Not applicable: no backend/API changes.
* [ ] If the schema changed, there is an Alembic migration — Not applicable: no schema changes.
* [x] New behaviour has a test, and I checked that the test fails without the change.
* [ ] Business logic went in `lib_softtrack/` — Not applicable: this is a frontend-only change.