### PR TITLE
Fix cross-team issue link navigation (#116)

### DIFF
--- a/backend/lib_softtrack/issues.py
+++ b/backend/lib_softtrack/issues.py
@@ -47,6 +47,8 @@ def _parent_ref(issue: Issue, session: Session) -> Optional[ParentRef]:
     team = session.get(Team, parent.team_id)
     return ParentRef(
         id=parent.id,
+        team_key=team.key,
+        number=parent.number,
         identifier=f"{team.key}-{parent.number}",
         title=parent.title,
     )
@@ -66,6 +68,7 @@ def issue_to_read(issue: Issue, session: Session) -> IssueRead:
     return IssueRead(
         id=issue.id,
         team_id=issue.team_id,
+        team_key=team.key,
         project_id=issue.project_id,
         number=issue.number,
         identifier=f"{team.key}-{issue.number}",
@@ -147,6 +150,7 @@ def _expand_issues(issues: list[Issue], session: Session) -> list[IssueRead]:
         IssueRead(
             id=issue.id,
             team_id=issue.team_id,
+            team_key=teams[issue.team_id].key,
             project_id=issue.project_id,
             number=issue.number,
             identifier=f"{teams[issue.team_id].key}-{issue.number}",
@@ -180,6 +184,8 @@ def _parent_ref_from(parent: Optional[Issue], teams: dict) -> Optional[ParentRef
         return None
     return ParentRef(
         id=parent.id,
+        team_key=teams[parent.team_id].key,
+        number=parent.number,
         identifier=f"{teams[parent.team_id].key}-{parent.number}",
         title=parent.title,
     )

--- a/backend/lib_softtrack/links.py
+++ b/backend/lib_softtrack/links.py
@@ -53,6 +53,8 @@ def _linked_issue(
 ) -> LinkedIssue:
     return LinkedIssue(
         id=issue.id,
+        team_key=teams[issue.team_id].key,
+        number=issue.number,
         identifier=f"{teams[issue.team_id].key}-{issue.number}",
         title=issue.title,
         status=StatusRead.model_validate(statuses[issue.status_id]),

--- a/backend/lib_softtrack/models/issues.py
+++ b/backend/lib_softtrack/models/issues.py
@@ -44,6 +44,8 @@ class ParentRef(BaseModel):
     """Just enough of the parent to render a breadcrumb."""
 
     id: int
+    team_key: str
+    number: int
     identifier: str
     title: str
 
@@ -84,6 +86,7 @@ class IssueUpdate(BaseModel):
 class IssueRead(BaseModel):
     id: int
     team_id: int
+    team_key: str
     project_id: Optional[int] = None
     number: int
     identifier: str

--- a/backend/lib_softtrack/models/links.py
+++ b/backend/lib_softtrack/models/links.py
@@ -16,6 +16,8 @@ class LinkedIssue(BaseModel):
     """Just enough of the other issue to render a row and click through."""
 
     id: int
+    team_key: str
+    number: int
     identifier: str
     title: str
     status: StatusRead

--- a/backend/lib_softtrack/models/search.py
+++ b/backend/lib_softtrack/models/search.py
@@ -13,6 +13,8 @@ class SearchHit(BaseModel):
     status: StatusRead
     priority: IssuePriority
     team_id: int
+    team_key: str
+    number: int
     updated_at: datetime
     #: Where the match was found: "title", "description" or "comment". Shown
     #: next to the result so a hit with no visible match in the title does not

--- a/backend/lib_softtrack/search.py
+++ b/backend/lib_softtrack/search.py
@@ -128,6 +128,8 @@ def search_issues(
                 status=StatusRead.model_validate(statuses[issue.status_id]),
                 priority=issue.priority,
                 team_id=issue.team_id,
+                team_key=teams[issue.team_id].key,
+                number=issue.number,
                 updated_at=issue.updated_at,
                 matched_in=matched_in,
                 snippet=snippet,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6341,6 +6341,10 @@
             "type": "integer",
             "title": "Team Id"
           },
+          "team_key": {
+            "type": "string",
+            "title": "Team Key"
+          },
           "project_id": {
             "anyOf": [
               {
@@ -6472,6 +6476,7 @@
         "required": [
           "id",
           "team_id",
+          "team_key",
           "number",
           "identifier",
           "title",
@@ -6665,6 +6670,14 @@
             "type": "integer",
             "title": "Id"
           },
+          "team_key": {
+            "type": "string",
+            "title": "Team Key"
+          },
+          "number": {
+            "type": "integer",
+            "title": "Number"
+          },
           "identifier": {
             "type": "string",
             "title": "Identifier"
@@ -6683,6 +6696,8 @@
         "type": "object",
         "required": [
           "id",
+          "team_key",
+          "number",
           "identifier",
           "title",
           "status",
@@ -7031,6 +7046,14 @@
             "type": "integer",
             "title": "Id"
           },
+          "team_key": {
+            "type": "string",
+            "title": "Team Key"
+          },
+          "number": {
+            "type": "integer",
+            "title": "Number"
+          },
           "identifier": {
             "type": "string",
             "title": "Identifier"
@@ -7043,6 +7066,8 @@
         "type": "object",
         "required": [
           "id",
+          "team_key",
+          "number",
           "identifier",
           "title"
         ],
@@ -7797,6 +7822,14 @@
             "type": "integer",
             "title": "Team Id"
           },
+          "team_key": {
+            "type": "string",
+            "title": "Team Key"
+          },
+          "number": {
+            "type": "integer",
+            "title": "Number"
+          },
           "updated_at": {
             "type": "string",
             "format": "date-time",
@@ -7819,6 +7852,8 @@
           "status",
           "priority",
           "team_id",
+          "team_key",
+          "number",
           "updated_at",
           "matched_in",
           "snippet"

--- a/backend/tests/test_links.py
+++ b/backend/tests/test_links.py
@@ -84,9 +84,31 @@ def test_the_linked_issue_carries_enough_to_render_a_row(client, team):
 
     linked = links_of(client, team, a)["blocks"][0]["issue"]
     assert linked["identifier"].startswith("ENG-")
+    assert linked["team_key"] == "ENG"
+    assert linked["number"] == b["number"]
     assert linked["title"] == "B"
     assert linked["status"]["name"] == "In Progress"
     assert linked["priority"] == "urgent"
+
+
+def test_a_cross_team_link_carries_the_other_issues_team_key(client, team):
+    """Rows need their own team key so click-through does not invent ENG-7."""
+    eng = make_issue(client, team, "ENG work")
+    ops_team = client.post(
+        "/teams", json={"name": "Operations", "key": "OPS"}, headers=team["headers"]
+    ).json()
+    ops = client.post(
+        f"/teams/{ops_team['id']}/issues",
+        json={"title": "OPS work"},
+        headers=team["headers"],
+    ).json()
+
+    assert link(client, team, eng, ops, "relates_to").status_code == 200
+
+    linked = links_of(client, team, eng)["relates_to"][0]["issue"]
+    assert linked["identifier"] == f"OPS-{ops['number']}"
+    assert linked["team_key"] == "OPS"
+    assert linked["number"] == ops["number"]
 
 
 # --- what is refused ---------------------------------------------------

--- a/backend/tests/test_subissues.py
+++ b/backend/tests/test_subissues.py
@@ -33,6 +33,8 @@ def test_a_child_can_be_created_under_a_parent(client, team):
     assert child["parent"]["id"] == parent["id"]
     assert child["parent"]["title"] == "Ship the release"
     assert child["parent"]["identifier"].startswith("ENG-")
+    assert child["parent"]["team_key"] == "ENG"
+    assert child["parent"]["number"] == parent["number"]
 
 
 def test_an_existing_issue_can_be_nested_later(client, team):
@@ -188,6 +190,7 @@ def test_the_list_endpoint_reports_the_same_counts(client, team):
     ).json()["items"]
     by_title = {item["title"]: item for item in items}
 
+    assert by_title["C"]["team_key"] == "ENG"
     assert by_title["P"]["child_count"] == 1
     assert by_title["P"]["completed_child_count"] == 1
     assert by_title["C"]["parent"]["id"] == parent["id"]

--- a/frontend/src/api/generated/models/issueRead.ts
+++ b/frontend/src/api/generated/models/issueRead.ts
@@ -14,6 +14,7 @@ import type { UserPublic } from './userPublic';
 export interface IssueRead {
   id: number;
   team_id: number;
+  team_key: string;
   project_id?: number | null;
   number: number;
   identifier: string;

--- a/frontend/src/api/generated/models/linkedIssue.ts
+++ b/frontend/src/api/generated/models/linkedIssue.ts
@@ -13,6 +13,8 @@ import type { StatusRead } from './statusRead';
  */
 export interface LinkedIssue {
   id: number;
+  team_key: string;
+  number: number;
   identifier: string;
   title: string;
   status: StatusRead;

--- a/frontend/src/api/generated/models/parentRef.ts
+++ b/frontend/src/api/generated/models/parentRef.ts
@@ -11,6 +11,8 @@
  */
 export interface ParentRef {
   id: number;
+  team_key: string;
+  number: number;
   identifier: string;
   title: string;
 }

--- a/frontend/src/api/generated/models/searchHit.ts
+++ b/frontend/src/api/generated/models/searchHit.ts
@@ -15,6 +15,8 @@ export interface SearchHit {
   status: StatusRead;
   priority: IssuePriority;
   team_id: number;
+  team_key: string;
+  number: number;
   updated_at: string;
   matched_in: string;
   snippet: string;

--- a/frontend/src/issues/detail/IssueLinksSection.tsx
+++ b/frontend/src/issues/detail/IssueLinksSection.tsx
@@ -181,9 +181,7 @@ export function IssueLinksSection({ issueId }: { issueId: number }) {
                   <LinkRow
                     key={row.id}
                     row={row}
-                    onOpen={() =>
-                      navigate(`/${team.key}/issue/${row.issue.identifier.split('-')[1]}`)
-                    }
+                    onOpen={() => navigate(`/${row.issue.team_key}/issue/${row.issue.number}`)}
                     onRemove={() => remove(row.id)}
                   />
                 ))}

--- a/frontend/src/issues/detail/SubIssuesSection.tsx
+++ b/frontend/src/issues/detail/SubIssuesSection.tsx
@@ -41,8 +41,8 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
     queryClient.invalidateQueries({ queryKey: [`/issues/${issue.id}`] })
   }
 
-  const openIssue = (identifier: string) =>
-    navigate(`/${team.key}/issue/${identifier.split('-')[1]}`)
+  const openIssue = ({ team_key, number }: Pick<IssueRead, 'team_key' | 'number'>) =>
+    navigate(`/${team_key}/issue/${number}`)
 
   const addChild = async () => {
     const trimmed = title.trim()
@@ -82,7 +82,7 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
     return (
       <button
         type="button"
-        onClick={() => openIssue(issue.parent!.identifier)}
+        onClick={() => openIssue(issue.parent!)}
         className="mb-2 flex max-w-full items-center gap-1.5 rounded-full bg-neutral-900/5 py-1 pl-2.5 pr-2 text-xs text-neutral-500 transition hover:bg-neutral-900/8 hover:text-neutral-900"
       >
         <span className="identifier font-medium">{issue.parent!.identifier}</span>
@@ -163,7 +163,7 @@ export function SubIssuesSection({ issue }: { issue: IssueRead }) {
                 />
                 <button
                   type="button"
-                  onClick={() => openIssue(child.identifier)}
+                  onClick={() => openIssue(child)}
                   className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
                 >
                   <span className="identifier shrink-0 text-xs text-neutral-400">

--- a/frontend/src/search/SearchResults.tsx
+++ b/frontend/src/search/SearchResults.tsx
@@ -4,7 +4,6 @@ import { parseServerDate } from '@/api/dates'
 
 import type { SearchHit } from '@/api/generated/models'
 import { PriorityIcon } from '@/issues/PriorityIcon'
-import { useTeamContext } from '@/team/TeamContext'
 import { Loading } from '@/ui/Loading'
 
 /** Where the match was found, said plainly. */
@@ -26,7 +25,6 @@ export function SearchResults({
   isLoading: boolean
 }) {
   const navigate = useNavigate()
-  const { team } = useTeamContext()
 
   if (isLoading) {
     return <Loading label="Searching…" />
@@ -61,7 +59,7 @@ export function SearchResults({
             <li key={hit.id}>
               <button
                 type="button"
-                onClick={() => navigate(`/${team.key}/issue/${hit.identifier.split('-')[1]}`)}
+                onClick={() => navigate(`/${hit.team_key}/issue/${hit.number}`)}
                 className="w-full px-4 py-3 text-left transition-colors hover:bg-neutral-900/4 focus:outline-none focus-visible:bg-brand-500/10"
               >
                 <div className="flex items-center gap-2.5">


### PR DESCRIPTION
Closes #116

**What this changes**
Carries team_key and number directly on backend payloads (LinkedIssue, ParentRef, SearchHit, IssueRead) and updates frontend navigation components to use the issue's own team key instead of splitting strings with the board's team key.

**Why**
When clicking a cross-team link (ex., OPS-7 on an ENG board), the frontend would split the identifier and force it under the current board's team key (/${team.key}/issue/...). This caused users to be silently redirected to the incorrect issue.

**How it was checked**

- Backend unit tests run: PYTHONPATH=backend pytest backend/tests/test_links.py backend/tests/test_subissues.py (39/39) tests passed successfully
- cd frontend && npm run build (Passed with no errors). Verified frontend build and type check
- Added a new cross-team link test in test_links.py to verify the team key is not lost.

**Checklist**
[x] cd backend && black . && pytest passes
[x] If backend routes or schemas changed, the API client was regenerated and committed (npm run export:openapi && npm run generate:api in frontend/)
[ ] If the schema changed, there is an Alembic migration and I have read what autogenerate wrote — (No database schema changes, only response/payload models updated)
[x] New behaviour has a test, and I checked that the test fails without the change
[x] Business logic went in lib_softtrack/, not in a route handler