### PR TITLE
Design/mobile mockups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# SoftTrack
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/logo-dark.svg">
+  <img src="docs/logo.svg" alt="SoftTrack" width="245">
+</picture>
 
 An open-source, self-hostable issue tracker inspired by Linear. Teams and
 projects, a kanban board with drag-and-drop, cycles and estimates, sub-issues

--- a/docs/design/mobile/138-app-foundation.svg
+++ b/docs/design/mobile/138-app-foundation.svg
@@ -1,0 +1,411 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">App foundation: navigation &amp; theming</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============================== PHONE ============================== -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- status bar -->
+  <text x="88" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="344" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="349" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="354" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="359" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M372 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="396" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="398.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="417" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- header: Teams + theme toggle -->
+  <text x="84" y="196" font-size="24" font-weight="700" fill="#15131f">Teams</text>
+  <rect x="356" y="172" width="64" height="30" rx="15" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="374" cy="187" r="9" fill="#6342db"/>
+  <circle cx="406" cy="187" r="7" fill="#b6b3c8" opacity="0.7"/>
+
+  <!-- search -->
+  <rect x="76" y="220" width="358" height="44" rx="10" fill="#f7f6fb"/>
+  <circle cx="98" cy="241" r="6" fill="none" stroke="#b6b3c8" stroke-width="2"/>
+  <line x1="102.5" y1="245.5" x2="108" y2="251" stroke="#b6b3c8" stroke-width="2"/>
+  <text x="118" y="247" font-size="15" fill="#b6b3c8">Search teams</text>
+
+  <text x="84" y="298" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">YOUR TEAMS</text>
+
+  <!-- team card: ENG -->
+  <rect x="76" y="312" width="358" height="96" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="94" y="340" width="40" height="40" rx="10" fill="#6342db"/>
+  <text x="114" y="365" font-size="16" font-weight="700" fill="#ffffff" text-anchor="middle">E</text>
+  <text x="150" y="356" font-size="16" font-weight="600" fill="#15131f">Engineering</text>
+  <text x="150" y="378" font-size="13" fill="#7a7791">ENG · 8 members · 12 active issues</text>
+  <text x="410" y="368" font-size="18" fill="#b6b3c8">›</text>
+  <!-- team card: DES -->
+  <rect x="76" y="422" width="358" height="96" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="94" y="450" width="40" height="40" rx="10" fill="#ff6fae"/>
+  <text x="114" y="475" font-size="16" font-weight="700" fill="#ffffff" text-anchor="middle">D</text>
+  <text x="150" y="466" font-size="16" font-weight="600" fill="#15131f">Design</text>
+  <text x="150" y="488" font-size="13" fill="#7a7791">DES · 5 members · 7 active issues</text>
+  <text x="410" y="478" font-size="18" fill="#b6b3c8">›</text>
+  <!-- team card: OPS -->
+  <rect x="76" y="532" width="358" height="96" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="94" y="560" width="40" height="40" rx="10" fill="#2fd4a7"/>
+  <text x="114" y="585" font-size="16" font-weight="700" fill="#ffffff" text-anchor="middle">O</text>
+  <text x="150" y="576" font-size="16" font-weight="600" fill="#15131f">Operations</text>
+  <text x="150" y="598" font-size="13" fill="#7a7791">OPS · 4 members · 3 active issues</text>
+  <text x="410" y="588" font-size="18" fill="#b6b3c8">›</text>
+
+  <text x="84" y="672" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">RECENT ISSUES</text>
+  <circle cx="92" cy="700" r="4" fill="#f29d0b"/>
+  <text x="106" y="705" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="164" y="705" font-size="13" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <circle cx="92" cy="746" r="4" fill="#8b5cf6"/>
+  <text x="106" y="751" font-size="11" font-weight="600" fill="#7a7791">DES-58</text>
+  <text x="164" y="751" font-size="13" fill="#15131f">Empty state illustration pass</text>
+  <circle cx="92" cy="792" r="4" fill="#6f6c86"/>
+  <text x="106" y="797" font-size="11" font-weight="600" fill="#7a7791">OPS-19</text>
+  <text x="164" y="797" font-size="13" fill="#15131f">On-call rotation reminders</text>
+
+  <!-- bottom nav -->
+  <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="836" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="99" y="874" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+  <rect x="166" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="177" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="244" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="255" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="333" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="400" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="411" y="874" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- ============================== FOLDABLE ============================== -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+  <!-- nav rail -->
+  <rect x="531" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="568" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="606" y1="111" x2="606" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="210" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="568" y="246" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+  <rect x="557" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="557" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="414" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="450" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="557" y="482" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="518" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="620" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1164" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="1169" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="1174" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="1179" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M1192 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="1216" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="1218.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="1237" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- left pane: teams list -->
+  <text x="630" y="196" font-size="22" font-weight="700" fill="#15131f">Teams</text>
+  <rect x="812" y="172" width="56" height="28" rx="14" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="828" cy="186" r="8" fill="#6342db"/>
+  <circle cx="856" cy="186" r="6" fill="#b6b3c8" opacity="0.7"/>
+
+  <rect x="622" y="232" width="264" height="64" rx="12" fill="#6342db" fill-opacity="0.08"/>
+  <rect x="636" y="246" width="36" height="36" rx="10" fill="#6342db"/>
+  <text x="654" y="269" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">E</text>
+  <text x="684" y="259" font-size="15" font-weight="600" fill="#15131f">Engineering</text>
+  <text x="684" y="279" font-size="12" fill="#7a7791">8 members · 12 active</text>
+  <text x="864" y="270" font-size="16" fill="#b6b3c8">›</text>
+
+  <rect x="622" y="304" width="264" height="64" rx="12" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="636" y="318" width="36" height="36" rx="10" fill="#ff6fae"/>
+  <text x="654" y="341" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">D</text>
+  <text x="684" y="331" font-size="15" font-weight="600" fill="#15131f">Design</text>
+  <text x="684" y="351" font-size="12" fill="#7a7791">5 members · 7 active</text>
+  <text x="864" y="342" font-size="16" fill="#b6b3c8">›</text>
+
+  <rect x="622" y="376" width="264" height="64" rx="12" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="636" y="390" width="36" height="36" rx="10" fill="#2fd4a7"/>
+  <text x="654" y="413" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">O</text>
+  <text x="684" y="403" font-size="15" font-weight="600" fill="#15131f">Operations</text>
+  <text x="684" y="423" font-size="12" fill="#7a7791">4 members · 3 active</text>
+  <text x="864" y="414" font-size="16" fill="#b6b3c8">›</text>
+
+  <text x="630" y="490" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">CYCLES</text>
+  <circle cx="636" cy="514" r="5" fill="#f29d0b"/>
+  <text x="652" y="519" font-size="13" fill="#15131f">Cycle 14 · active</text>
+  <circle cx="636" cy="550" r="5" fill="#6f6c86"/>
+  <text x="652" y="555" font-size="13" fill="#514e66">Cycle 15 · upcoming</text>
+  <circle cx="636" cy="586" r="5" fill="#12a474"/>
+  <text x="652" y="591" font-size="13" fill="#514e66">Cycle 13 · done</text>
+
+  <text x="630" y="656" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">RECENT</text>
+  <rect x="630" y="674" width="184" height="10" rx="5" fill="#eeedf5"/>
+  <rect x="630" y="698" width="224" height="10" rx="5" fill="#eeedf5"/>
+  <rect x="630" y="722" width="152" height="10" rx="5" fill="#eeedf5"/>
+
+  <!-- right pane: selected team board preview -->
+  <text x="914" y="196" font-size="18" font-weight="700" fill="#15131f">Engineering · Cycle 14</text>
+  <text x="914" y="220" font-size="13" fill="#7a7791">12 active issues</text>
+
+  <rect x="914" y="240" width="164" height="540" rx="12" fill="#f7f6fb"/>
+  <circle cx="932" cy="266" r="5" fill="#f29d0b"/>
+  <text x="944" y="271" font-size="13" font-weight="600" fill="#514e66">In Progress</text>
+  <text x="1064" y="271" font-size="12" fill="#7a7791" text-anchor="end">3</text>
+  <rect x="922" y="286" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="934" y="306" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+  <text x="934" y="324" font-size="12" fill="#15131f">Offline queue for</text>
+  <text x="934" y="340" font-size="12" fill="#15131f">issue edits</text>
+  <rect x="934" y="352" width="46" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="957" y="365" font-size="12" fill="#f2721c" text-anchor="middle">High</text>
+  <circle cx="1052" cy="361" r="9" fill="#4f8cff"/>
+  <rect x="922" y="394" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="934" y="414" font-size="11" font-weight="600" fill="#7a7791">ENG-129</text>
+  <text x="934" y="432" font-size="12" fill="#15131f">Auto-link ENG-123</text>
+  <text x="934" y="448" font-size="12" fill="#15131f">tokens in comments</text>
+  <rect x="934" y="460" width="60" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/>
+  <text x="964" y="473" font-size="12" fill="#ef9d0b" text-anchor="middle">Medium</text>
+  <circle cx="1052" cy="469" r="9" fill="#ff6fae"/>
+  <rect x="922" y="502" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="934" y="522" font-size="11" font-weight="600" fill="#7a7791">ENG-127</text>
+  <text x="934" y="540" font-size="12" fill="#15131f">Theme tokens for</text>
+  <text x="934" y="556" font-size="12" fill="#15131f">dark mode</text>
+  <rect x="934" y="568" width="46" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="957" y="581" font-size="12" fill="#f2721c" text-anchor="middle">High</text>
+  <circle cx="1052" cy="577" r="9" fill="#2fd4a7"/>
+  <text x="934" y="630" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <rect x="1092" y="240" width="164" height="540" rx="12" fill="#f7f6fb"/>
+  <circle cx="1110" cy="266" r="5" fill="#6f6c86"/>
+  <text x="1122" y="271" font-size="13" font-weight="600" fill="#514e66">Todo</text>
+  <text x="1242" y="271" font-size="12" fill="#7a7791" text-anchor="end">4</text>
+  <rect x="1100" y="286" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1112" y="306" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="1112" y="324" font-size="12" fill="#15131f">Fix drag ghost</text>
+  <text x="1112" y="340" font-size="12" fill="#15131f">offset on Safari</text>
+  <rect x="1112" y="352" width="54" height="18" rx="9" fill="#e0424a" fill-opacity="0.15"/>
+  <text x="1139" y="365" font-size="12" fill="#e0424a" text-anchor="middle">Urgent</text>
+  <circle cx="1230" cy="361" r="9" fill="#ffb648"/>
+  <rect x="1100" y="394" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1112" y="414" font-size="11" font-weight="600" fill="#7a7791">ENG-140</text>
+  <text x="1112" y="432" font-size="12" fill="#15131f">Debounce board</text>
+  <text x="1112" y="448" font-size="12" fill="#15131f">search input</text>
+  <rect x="1112" y="460" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1133" y="473" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="1230" cy="469" r="9" fill="#6342db"/>
+  <rect x="1100" y="502" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1112" y="522" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+  <text x="1112" y="540" font-size="12" fill="#15131f">Cycle burndown</text>
+  <text x="1112" y="556" font-size="12" fill="#15131f">empty state</text>
+  <rect x="1112" y="568" width="60" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/>
+  <text x="1142" y="581" font-size="12" fill="#ef9d0b" text-anchor="middle">Medium</text>
+  <circle cx="1230" cy="577" r="9" fill="#4f8cff"/>
+  <rect x="1100" y="610" width="148" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1112" y="630" font-size="11" font-weight="600" fill="#7a7791">ENG-136</text>
+  <text x="1112" y="648" font-size="12" fill="#15131f">Keyboard nav for</text>
+  <text x="1112" y="664" font-size="12" fill="#15131f">column focus</text>
+  <rect x="1112" y="676" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1133" y="689" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="1230" cy="685" r="9" fill="#ff6fae"/>
+  <text x="1112" y="740" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <!-- ============================== TABLET ============================== -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- nav rail -->
+  <rect x="1351" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="1388" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="1426" y1="111" x2="1426" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="210" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="1388" y="246" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+  <rect x="1377" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="1377" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="414" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="450" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="1377" y="482" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="518" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="1440" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2394" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="2399" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="2404" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="2409" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M2422 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="2446" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="2448.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="2467" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- persistent sidebar -->
+  <text x="1450" y="200" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">TEAMS</text>
+  <rect x="1442" y="214" width="192" height="44" rx="10" fill="#6342db" fill-opacity="0.08"/>
+  <rect x="1452" y="224" width="24" height="24" rx="7" fill="#6342db"/>
+  <text x="1464" y="240" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">E</text>
+  <text x="1486" y="241" font-size="14" font-weight="600" fill="#15131f">Engineering</text>
+  <text x="1622" y="241" font-size="12" fill="#7a7791" text-anchor="end">8</text>
+  <rect x="1452" y="274" width="24" height="24" rx="7" fill="#ff6fae"/>
+  <text x="1464" y="290" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">D</text>
+  <text x="1486" y="291" font-size="14" fill="#514e66">Design</text>
+  <text x="1622" y="291" font-size="12" fill="#7a7791" text-anchor="end">5</text>
+  <rect x="1452" y="324" width="24" height="24" rx="7" fill="#2fd4a7"/>
+  <text x="1464" y="340" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">O</text>
+  <text x="1486" y="341" font-size="14" fill="#514e66">Operations</text>
+  <text x="1622" y="341" font-size="12" fill="#7a7791" text-anchor="end">4</text>
+
+  <text x="1450" y="412" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">CYCLES</text>
+  <circle cx="1458" cy="436" r="5" fill="#f29d0b"/>
+  <text x="1474" y="441" font-size="13" fill="#15131f">Cycle 14 · active</text>
+  <circle cx="1458" cy="472" r="5" fill="#6f6c86"/>
+  <text x="1474" y="477" font-size="13" fill="#514e66">Cycle 15 · upcoming</text>
+  <circle cx="1458" cy="508" r="5" fill="#12a474"/>
+  <text x="1474" y="513" font-size="13" fill="#514e66">Cycle 13 · done</text>
+
+  <text x="1450" y="584" font-size="12" font-weight="600" fill="#7a7791" letter-spacing="1">VIEWS</text>
+  <rect x="1450" y="602" width="132" height="10" rx="5" fill="#eeedf5"/>
+  <rect x="1450" y="626" width="164" height="10" rx="5" fill="#eeedf5"/>
+  <rect x="1450" y="650" width="108" height="10" rx="5" fill="#eeedf5"/>
+  <line x1="1650" y1="111" x2="1650" y2="889" stroke="#eeedf5" stroke-width="2"/>
+
+  <!-- board header -->
+  <text x="1674" y="196" font-size="20" font-weight="700" fill="#15131f">Engineering — Board</text>
+  <rect x="2350" y="172" width="56" height="28" rx="14" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="2366" cy="186" r="8" fill="#6342db"/>
+  <circle cx="2392" cy="186" r="6" fill="#b6b3c8" opacity="0.7"/>
+  <circle cx="2444" cy="186" r="14" fill="#4f8cff"/>
+  <text x="2444" y="190" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+
+  <!-- column: Backlog -->
+  <rect x="1674" y="224" width="190" height="570" rx="12" fill="#f7f6fb"/>
+  <circle cx="1692" cy="252" r="5" fill="#9b98b0"/>
+  <text x="1704" y="257" font-size="13" font-weight="600" fill="#514e66">Backlog</text>
+  <text x="1850" y="257" font-size="12" fill="#7a7791" text-anchor="end">3</text>
+  <rect x="1684" y="272" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1696" y="292" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+  <text x="1696" y="310" font-size="12" fill="#15131f">Bulk edit from board</text>
+  <text x="1696" y="326" font-size="12" fill="#15131f">selection</text>
+  <rect x="1696" y="338" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1717" y="351" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="1836" cy="347" r="9" fill="#ffb648"/>
+  <rect x="1684" y="380" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1696" y="400" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+  <text x="1696" y="418" font-size="12" fill="#15131f">Import issues from</text>
+  <text x="1696" y="434" font-size="12" fill="#15131f">Linear CSV</text>
+  <rect x="1696" y="446" width="60" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/>
+  <text x="1726" y="459" font-size="12" fill="#ef9d0b" text-anchor="middle">Medium</text>
+  <circle cx="1836" cy="455" r="9" fill="#4f8cff"/>
+  <rect x="1684" y="488" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1696" y="508" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+  <text x="1696" y="526" font-size="12" fill="#15131f">Issue templates</text>
+  <text x="1696" y="542" font-size="12" fill="#15131f">per team</text>
+  <rect x="1696" y="554" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1717" y="567" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="1836" cy="563" r="9" fill="#2fd4a7"/>
+  <text x="1696" y="620" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <!-- column: Todo -->
+  <rect x="1880" y="224" width="190" height="570" rx="12" fill="#f7f6fb"/>
+  <circle cx="1898" cy="252" r="5" fill="#6f6c86"/>
+  <text x="1910" y="257" font-size="13" font-weight="600" fill="#514e66">Todo</text>
+  <text x="2056" y="257" font-size="12" fill="#7a7791" text-anchor="end">4</text>
+  <rect x="1890" y="272" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1902" y="292" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="1902" y="310" font-size="12" fill="#15131f">Fix drag ghost offset</text>
+  <text x="1902" y="326" font-size="12" fill="#15131f">on Safari</text>
+  <rect x="1902" y="338" width="54" height="18" rx="9" fill="#e0424a" fill-opacity="0.15"/>
+  <text x="1929" y="351" font-size="12" fill="#e0424a" text-anchor="middle">Urgent</text>
+  <circle cx="2042" cy="347" r="9" fill="#ffb648"/>
+  <rect x="1890" y="380" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1902" y="400" font-size="11" font-weight="600" fill="#7a7791">ENG-140</text>
+  <text x="1902" y="418" font-size="12" fill="#15131f">Debounce board</text>
+  <text x="1902" y="434" font-size="12" fill="#15131f">search input</text>
+  <rect x="1902" y="446" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1923" y="459" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="2042" cy="455" r="9" fill="#6342db"/>
+  <rect x="1890" y="488" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1902" y="508" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+  <text x="1902" y="526" font-size="12" fill="#15131f">Cycle burndown</text>
+  <text x="1902" y="542" font-size="12" fill="#15131f">empty state</text>
+  <rect x="1902" y="554" width="60" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/>
+  <text x="1932" y="567" font-size="12" fill="#ef9d0b" text-anchor="middle">Medium</text>
+  <circle cx="2042" cy="563" r="9" fill="#4f8cff"/>
+  <rect x="1890" y="596" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1902" y="616" font-size="11" font-weight="600" fill="#7a7791">ENG-136</text>
+  <text x="1902" y="634" font-size="12" fill="#15131f">Keyboard nav for</text>
+  <text x="1902" y="650" font-size="12" fill="#15131f">column focus</text>
+  <rect x="1902" y="662" width="42" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/>
+  <text x="1923" y="675" font-size="12" fill="#3f82f6" text-anchor="middle">Low</text>
+  <circle cx="2042" cy="671" r="9" fill="#ff6fae"/>
+  <text x="1902" y="728" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <!-- column: In Progress -->
+  <rect x="2086" y="224" width="190" height="570" rx="12" fill="#f7f6fb"/>
+  <circle cx="2104" cy="252" r="5" fill="#f29d0b"/>
+  <text x="2116" y="257" font-size="13" font-weight="600" fill="#514e66">In Progress</text>
+  <text x="2262" y="257" font-size="12" fill="#7a7791" text-anchor="end">3</text>
+  <rect x="2096" y="272" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2108" y="292" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+  <text x="2108" y="310" font-size="12" fill="#15131f">Offline queue for</text>
+  <text x="2108" y="326" font-size="12" fill="#15131f">issue edits</text>
+  <rect x="2108" y="338" width="46" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="2131" y="351" font-size="12" fill="#f2721c" text-anchor="middle">High</text>
+  <circle cx="2248" cy="347" r="9" fill="#4f8cff"/>
+  <rect x="2096" y="380" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2108" y="400" font-size="11" font-weight="600" fill="#7a7791">ENG-129</text>
+  <text x="2108" y="418" font-size="12" fill="#15131f">Auto-link ENG-123</text>
+  <text x="2108" y="434" font-size="12" fill="#15131f">tokens in comments</text>
+  <rect x="2108" y="446" width="60" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/>
+  <text x="2138" y="459" font-size="12" fill="#ef9d0b" text-anchor="middle">Medium</text>
+  <circle cx="2248" cy="455" r="9" fill="#ff6fae"/>
+  <rect x="2096" y="488" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2108" y="508" font-size="11" font-weight="600" fill="#7a7791">ENG-127</text>
+  <text x="2108" y="526" font-size="12" fill="#15131f">Theme tokens for</text>
+  <text x="2108" y="542" font-size="12" fill="#15131f">dark mode</text>
+  <rect x="2108" y="554" width="46" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="2131" y="567" font-size="12" fill="#f2721c" text-anchor="middle">High</text>
+  <circle cx="2248" cy="563" r="9" fill="#2fd4a7"/>
+  <text x="2108" y="620" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <!-- column: Done -->
+  <rect x="2292" y="224" width="190" height="570" rx="12" fill="#f7f6fb"/>
+  <circle cx="2310" cy="252" r="5" fill="#12a474"/>
+  <text x="2322" y="257" font-size="13" font-weight="600" fill="#514e66">Done</text>
+  <text x="2468" y="257" font-size="12" fill="#7a7791" text-anchor="end">3</text>
+  <rect x="2302" y="272" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2314" y="292" font-size="11" font-weight="600" fill="#7a7791">ENG-124</text>
+  <text x="2314" y="310" font-size="12" fill="#15131f">Avatar accessibility</text>
+  <text x="2314" y="326" font-size="12" fill="#15131f">labels</text>
+  <rect x="2314" y="338" width="50" height="18" rx="9" fill="#12a474" fill-opacity="0.15"/>
+  <text x="2339" y="351" font-size="12" fill="#12a474" text-anchor="middle">Done</text>
+  <circle cx="2454" cy="347" r="9" fill="#6342db"/>
+  <rect x="2302" y="380" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2314" y="400" font-size="11" font-weight="600" fill="#7a7791">ENG-121</text>
+  <text x="2314" y="418" font-size="12" fill="#15131f">Cross-team issue</text>
+  <text x="2314" y="434" font-size="12" fill="#15131f">link navigation</text>
+  <rect x="2314" y="446" width="50" height="18" rx="9" fill="#12a474" fill-opacity="0.15"/>
+  <text x="2339" y="459" font-size="12" fill="#12a474" text-anchor="middle">Done</text>
+  <circle cx="2454" cy="455" r="9" fill="#ffb648"/>
+  <rect x="2302" y="488" width="170" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="2314" y="508" font-size="11" font-weight="600" fill="#7a7791">ENG-118</text>
+  <text x="2314" y="526" font-size="12" fill="#15131f">Landing page hero</text>
+  <text x="2314" y="542" font-size="12" fill="#15131f">polish</text>
+  <rect x="2314" y="554" width="50" height="18" rx="9" fill="#12a474" fill-opacity="0.15"/>
+  <text x="2339" y="567" font-size="12" fill="#12a474" text-anchor="middle">Done</text>
+  <circle cx="2454" cy="563" r="9" fill="#4f8cff"/>
+  <text x="2314" y="620" font-size="12" fill="#b6b3c8">+ New issue</text>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Bottom navigation on compact becomes a left nav rail on medium and expanded; the same five destinations persist while panes are added — teams list, then board preview, then sidebar + full board.</text>
+</svg>

--- a/docs/design/mobile/139-login.svg
+++ b/docs/design/mobile/139-login.svg
@@ -1,0 +1,195 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Login: server link, username, password</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============================== PHONE ============================== -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- status bar -->
+  <text x="88" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="344" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="349" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="354" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="359" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M372 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="396" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="398.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="417" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- wordmark -->
+  <rect x="193" y="192" width="24" height="24" rx="7" fill="#6342db"/>
+  <text x="225" y="210" font-size="20" font-weight="700" fill="#15131f">SoftTrack</text>
+
+  <text x="255" y="272" font-size="22" font-weight="700" fill="#15131f" text-anchor="middle">Welcome back</text>
+  <text x="255" y="296" font-size="14" fill="#7a7791" text-anchor="middle">Sign in to your workspace</text>
+
+  <!-- Server link -->
+  <text x="92" y="340" font-size="13" fill="#514e66">Server link</text>
+  <rect x="92" y="348" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="106" y="378" font-size="15" fill="#b6b3c8">https://track.yourcompany.com</text>
+  <!-- Username -->
+  <text x="92" y="428" font-size="13" fill="#514e66">Username</text>
+  <rect x="92" y="436" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="106" y="466" font-size="15" fill="#b6b3c8">amina</text>
+  <!-- Password -->
+  <text x="92" y="516" font-size="13" fill="#514e66">Password</text>
+  <rect x="92" y="524" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="106" y="554" font-size="15" fill="#514e66">••••••••</text>
+
+  <rect x="92" y="600" width="326" height="44" rx="10" fill="#6342db"/>
+  <text x="255" y="628" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Sign in</text>
+  <text x="255" y="684" font-size="14" font-weight="600" fill="#6342db" text-anchor="middle">Create an account</text>
+  <text x="255" y="724" font-size="12" fill="#b6b3c8" text-anchor="middle">Self-hosted? Point the server link at your instance.</text>
+
+  <!-- bottom nav -->
+  <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="99" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="166" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="177" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="244" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="255" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="333" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="400" y="836" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="411" y="874" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+  <!-- ============================== FOLDABLE ============================== -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- welcome panel (left of hinge) -->
+  <rect x="607" y="112" width="293" height="776" fill="#f3f1ff"/>
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+  <!-- nav rail -->
+  <rect x="531" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="568" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="606" y1="111" x2="606" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="210" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="557" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="557" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="414" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="450" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="557" y="482" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="568" y="518" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="620" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1164" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="1169" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="1174" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="1179" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M1192 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="1216" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="1218.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="1237" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- left pane: brand / welcome -->
+  <rect x="648" y="266" width="48" height="48" rx="12" fill="#6342db"/>
+  <text x="708" y="299" font-size="26" font-weight="700" fill="#15131f">SoftTrack</text>
+  <text x="648" y="356" font-size="15" fill="#514e66">Track issues. Ship faster.</text>
+  <!-- decorative low-fi issue cards -->
+  <rect x="648" y="404" width="204" height="64" rx="12" fill="#ffffff" stroke="#dedcea"/>
+  <rect x="662" y="420" width="60" height="8" rx="4" fill="#dedcea"/>
+  <rect x="662" y="440" width="140" height="10" rx="5" fill="#eeedf5"/>
+  <circle cx="832" cy="446" r="9" fill="#4f8cff"/>
+  <rect x="668" y="484" width="204" height="64" rx="12" fill="#ffffff" stroke="#dedcea" opacity="0.75"/>
+  <rect x="682" y="500" width="60" height="8" rx="4" fill="#dedcea"/>
+  <rect x="682" y="520" width="128" height="10" rx="5" fill="#eeedf5"/>
+  <circle cx="852" cy="526" r="9" fill="#2fd4a7"/>
+
+  <!-- right pane: form (entirely right of hinge) -->
+  <text x="938" y="240" font-size="20" font-weight="700" fill="#15131f">Sign in</text>
+  <text x="938" y="264" font-size="13" fill="#7a7791">Connect to your workspace</text>
+
+  <text x="938" y="300" font-size="13" fill="#514e66">Server link</text>
+  <rect x="938" y="308" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="338" font-size="15" fill="#b6b3c8">https://track.yourcompany.com</text>
+  <text x="938" y="388" font-size="13" fill="#514e66">Username</text>
+  <rect x="938" y="396" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="426" font-size="15" fill="#b6b3c8">amina</text>
+  <text x="938" y="476" font-size="13" fill="#514e66">Password</text>
+  <rect x="938" y="484" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="514" font-size="15" fill="#514e66">••••••••</text>
+
+  <rect x="938" y="560" width="296" height="44" rx="10" fill="#6342db"/>
+  <text x="1086" y="588" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Sign in</text>
+  <text x="1086" y="644" font-size="14" font-weight="600" fill="#6342db" text-anchor="middle">Create an account</text>
+
+  <!-- ============================== TABLET ============================== -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- welcome panel -->
+  <rect x="1427" y="112" width="543" height="776" fill="#f3f1ff"/>
+  <!-- nav rail -->
+  <rect x="1351" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="1388" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="1426" y1="111" x2="1426" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="210" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="1377" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="1377" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="414" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="450" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <rect x="1377" y="482" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <text x="1388" y="518" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="1440" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2394" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="2399" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="2404" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="2409" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M2422 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="2446" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="2448.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="2467" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- welcome panel content -->
+  <rect x="1490" y="242" width="56" height="56" rx="14" fill="#6342db"/>
+  <text x="1562" y="280" font-size="30" font-weight="700" fill="#15131f">SoftTrack</text>
+  <text x="1490" y="348" font-size="16" fill="#514e66">Track issues. Ship faster.</text>
+
+  <circle cx="1502" cy="415" r="11" fill="#6342db" fill-opacity="0.15"/>
+  <text x="1502" y="420" font-size="12" fill="#6342db" text-anchor="middle">✓</text>
+  <text x="1524" y="420" font-size="14" fill="#514e66">Offline-first sync across devices</text>
+  <circle cx="1502" cy="463" r="11" fill="#6342db" fill-opacity="0.15"/>
+  <text x="1502" y="468" font-size="12" fill="#6342db" text-anchor="middle">✓</text>
+  <text x="1524" y="468" font-size="14" fill="#514e66">Boards, cycles, and triage in one place</text>
+  <circle cx="1502" cy="511" r="11" fill="#6342db" fill-opacity="0.15"/>
+  <text x="1502" y="516" font-size="12" fill="#6342db" text-anchor="middle">✓</text>
+  <text x="1524" y="516" font-size="14" fill="#514e66">Self-host on your own server</text>
+
+  <!-- right panel: form -->
+  <text x="2045" y="270" font-size="22" font-weight="700" fill="#15131f">Sign in to your workspace</text>
+
+  <text x="2045" y="316" font-size="13" fill="#514e66">Server link</text>
+  <rect x="2045" y="324" width="380" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2059" y="354" font-size="15" fill="#b6b3c8">https://track.yourcompany.com</text>
+  <text x="2045" y="404" font-size="13" fill="#514e66">Username</text>
+  <rect x="2045" y="412" width="380" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2059" y="442" font-size="15" fill="#b6b3c8">amina</text>
+  <text x="2045" y="492" font-size="13" fill="#514e66">Password</text>
+  <rect x="2045" y="500" width="380" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2059" y="530" font-size="15" fill="#514e66">••••••••</text>
+
+  <rect x="2045" y="576" width="380" height="44" rx="10" fill="#6342db"/>
+  <text x="2235" y="604" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Sign in</text>
+  <text x="2235" y="660" font-size="14" font-weight="600" fill="#6342db" text-anchor="middle">Create an account</text>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">The sign-in form is a single column at every size class; medium and expanded add a brand welcome panel beside it instead of reflowing the three fields.</text>
+</svg>

--- a/docs/design/mobile/140-register-invite.svg
+++ b/docs/design/mobile/140-register-invite.svg
@@ -1,0 +1,198 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Registration &amp; invite acceptance</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============================== PHONE ============================== -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- status bar -->
+  <text x="88" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="344" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="349" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="354" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="359" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M372 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="396" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="398.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="417" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- wordmark -->
+  <rect x="193" y="184" width="24" height="24" rx="7" fill="#6342db"/>
+  <text x="225" y="202" font-size="20" font-weight="700" fill="#15131f">SoftTrack</text>
+
+  <!-- invite card -->
+  <rect x="90" y="248" width="342" height="344" rx="14" fill="#26243a" opacity="0.05"/>
+  <rect x="84" y="240" width="342" height="344" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <circle cx="255" cy="302" r="24" fill="#ff6fae"/>
+  <text x="255" y="306" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">SM</text>
+  <text x="255" y="354" font-size="17" font-weight="700" fill="#15131f" text-anchor="middle">Sara M. invited you to join</text>
+  <rect x="187" y="368" width="52" height="24" rx="12" fill="#6342db" fill-opacity="0.12"/>
+  <text x="213" y="384" font-size="12" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+  <rect x="247" y="368" width="76" height="24" rx="12" fill="#6f6c86" fill-opacity="0.12"/>
+  <text x="285" y="384" font-size="12" font-weight="600" fill="#6f6c86" text-anchor="middle">Member</text>
+  <text x="255" y="420" font-size="12" fill="#7a7791" text-anchor="middle">on track.acme.dev</text>
+  <rect x="112" y="448" width="286" height="44" rx="10" fill="#6342db"/>
+  <text x="255" y="476" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Accept invite</text>
+  <text x="255" y="530" font-size="13" font-weight="600" fill="#6342db" text-anchor="middle">Sign in with a different account</text>
+
+  <text x="255" y="632" font-size="12" fill="#b6b3c8" text-anchor="middle">Invited by sara@acme.dev · expires in 6 days</text>
+
+  <!-- bottom nav -->
+  <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="99" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="166" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="177" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="244" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="255" y="874" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="836" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <circle cx="346" cy="836" r="4.5" fill="#e0424a" stroke="#ffffff" stroke-width="1.5"/>
+  <text x="333" y="874" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+  <rect x="400" y="836" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="411" y="874" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- ============================== FOLDABLE ============================== -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+  <!-- nav rail -->
+  <rect x="531" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="568" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="606" y1="111" x2="606" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="210" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="557" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="557" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="414" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <circle cx="581" cy="414" r="4.5" fill="#e0424a" stroke="#f7f6fb" stroke-width="1.5"/>
+  <text x="568" y="450" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+  <rect x="557" y="482" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="568" y="518" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="620" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1164" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="1169" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="1174" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="1179" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M1192 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="1216" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="1218.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="1237" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- left pane: invite card -->
+  <text x="630" y="200" font-size="20" font-weight="700" fill="#15131f">You're invited</text>
+  <rect x="622" y="230" width="264" height="300" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <circle cx="754" cy="284" r="22" fill="#ff6fae"/>
+  <text x="754" y="288" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">SM</text>
+  <text x="754" y="330" font-size="15" font-weight="700" fill="#15131f" text-anchor="middle">Sara M. invited you</text>
+  <text x="754" y="352" font-size="13" fill="#514e66" text-anchor="middle">to join ENG as Member</text>
+  <text x="754" y="382" font-size="12" fill="#7a7791" text-anchor="middle">on track.acme.dev</text>
+  <rect x="646" y="406" width="216" height="44" rx="10" fill="#6342db"/>
+  <text x="754" y="434" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Accept invite</text>
+  <text x="754" y="488" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Sign in with a different account</text>
+  <text x="754" y="570" font-size="12" fill="#b6b3c8" text-anchor="middle">Invited by sara@acme.dev</text>
+
+  <!-- right pane: registration form -->
+  <text x="938" y="204" font-size="20" font-weight="700" fill="#15131f">Create your account</text>
+
+  <text x="938" y="240" font-size="13" fill="#514e66">Full name</text>
+  <rect x="938" y="248" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="278" font-size="15" fill="#b6b3c8">Amina Khan</text>
+  <text x="938" y="328" font-size="13" fill="#514e66">Email</text>
+  <rect x="938" y="336" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="366" font-size="15" fill="#b6b3c8">amina@acme.dev</text>
+  <text x="938" y="416" font-size="13" fill="#514e66">Username (optional)</text>
+  <rect x="938" y="424" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="454" font-size="15" fill="#b6b3c8">amina</text>
+  <text x="938" y="504" font-size="13" fill="#514e66">Password</text>
+  <rect x="938" y="512" width="296" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="952" y="542" font-size="15" fill="#514e66">••••••••</text>
+
+  <rect x="938" y="588" width="296" height="44" rx="10" fill="#6342db"/>
+  <text x="1086" y="616" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create account</text>
+  <text x="938" y="668" font-size="12" fill="#b6b3c8">Joining ENG on track.acme.dev as Member.</text>
+
+  <!-- ============================== TABLET ============================== -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <!-- nav rail -->
+  <rect x="1351" y="111" width="75" height="778" rx="27" fill="#f7f6fb"/>
+  <rect x="1388" y="111" width="38" height="778" fill="#f7f6fb"/>
+  <line x1="1426" y1="111" x2="1426" y2="889" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="150" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="210" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="1377" y="278" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="314" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+  <rect x="1377" y="346" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="382" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="414" width="22" height="22" rx="7" fill="#6342db" fill-opacity="0.18" stroke="#6342db" stroke-width="1.5"/>
+  <circle cx="1401" cy="414" r="4.5" fill="#e0424a" stroke="#f7f6fb" stroke-width="1.5"/>
+  <text x="1388" y="450" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+  <rect x="1377" y="482" width="22" height="22" rx="7" fill="#7a7791" fill-opacity="0.15" stroke="#7a7791" stroke-width="1.5"/>
+  <text x="1388" y="518" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  <!-- status bar -->
+  <text x="1440" y="133" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2394" y="129" width="3" height="4" fill="#514e66"/>
+  <rect x="2399" y="126" width="3" height="7" fill="#514e66"/>
+  <rect x="2404" y="123" width="3" height="10" fill="#514e66"/>
+  <rect x="2409" y="120" width="3" height="13" fill="#514e66"/>
+  <path d="M2422 121 h14 l-7 9 z" fill="#514e66"/>
+  <rect x="2446" y="121" width="20" height="11" rx="3" fill="none" stroke="#514e66" stroke-width="1.5"/>
+  <rect x="2448.5" y="123.5" width="12" height="6" fill="#514e66"/>
+  <rect x="2467" y="124" width="2.5" height="5" fill="#514e66"/>
+
+  <!-- left pane: invite card -->
+  <text x="1490" y="224" font-size="22" font-weight="700" fill="#15131f">You're invited</text>
+  <rect x="1490" y="250" width="380" height="320" rx="14" fill="#ffffff" stroke="#eeedf5"/>
+  <circle cx="1680" cy="310" r="24" fill="#ff6fae"/>
+  <text x="1680" y="314" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">SM</text>
+  <text x="1680" y="362" font-size="17" font-weight="700" fill="#15131f" text-anchor="middle">Sara M. invited you</text>
+  <text x="1680" y="386" font-size="14" fill="#514e66" text-anchor="middle">to join ENG as Member</text>
+  <text x="1680" y="416" font-size="12" fill="#7a7791" text-anchor="middle">on track.acme.dev</text>
+  <rect x="1550" y="440" width="260" height="44" rx="10" fill="#6342db"/>
+  <text x="1680" y="468" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Accept invite</text>
+  <text x="1680" y="522" font-size="13" font-weight="600" fill="#6342db" text-anchor="middle">Sign in with a different account</text>
+  <text x="1680" y="608" font-size="12" fill="#b6b3c8" text-anchor="middle">Invited by sara@acme.dev · expires in 6 days</text>
+  <line x1="1950" y1="112" x2="1950" y2="888" stroke="#eeedf5" stroke-width="2"/>
+
+  <!-- right pane: pending-invites banner + registration form -->
+  <rect x="1974" y="168" width="502" height="48" rx="10" fill="#6342db" fill-opacity="0.08"/>
+  <circle cx="1996" cy="192" r="5" fill="#6342db"/>
+  <text x="2010" y="197" font-size="13" font-weight="600" fill="#6342db">1 pending invite for wak@…</text>
+  <text x="2452" y="197" font-size="13" font-weight="700" fill="#6342db" text-anchor="end">View</text>
+
+  <text x="2028" y="262" font-size="20" font-weight="700" fill="#15131f">Create your account</text>
+
+  <text x="2028" y="296" font-size="13" fill="#514e66">Full name</text>
+  <rect x="2028" y="304" width="420" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2042" y="334" font-size="15" fill="#b6b3c8">Amina Khan</text>
+  <text x="2028" y="384" font-size="13" fill="#514e66">Email</text>
+  <rect x="2028" y="392" width="420" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2042" y="422" font-size="15" fill="#b6b3c8">amina@acme.dev</text>
+  <text x="2028" y="472" font-size="13" fill="#514e66">Username (optional)</text>
+  <rect x="2028" y="480" width="420" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2042" y="510" font-size="15" fill="#b6b3c8">amina</text>
+  <text x="2028" y="560" font-size="13" fill="#514e66">Password</text>
+  <rect x="2028" y="568" width="420" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2042" y="598" font-size="15" fill="#514e66">••••••••</text>
+
+  <rect x="2028" y="644" width="420" height="44" rx="10" fill="#6342db"/>
+  <text x="2238" y="672" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create account</text>
+  <text x="2028" y="724" font-size="12" fill="#b6b3c8">Joining ENG on track.acme.dev as Member.</text>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Invite deep links open straight into the app: compact shows acceptance full-screen, while medium and expanded pair the invite with the registration form.</text>
+</svg>

--- a/docs/design/mobile/141-teams.svg
+++ b/docs/design/mobile/141-teams.svg
@@ -1,0 +1,310 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cpP"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cpF"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="cpT"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Teams: home, switcher, creation</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE FRAME ============ -->
+  <rect x="64" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpP)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="396" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="401" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="406" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="417" cy="128" r="4" fill="#514e66"/>
+    <rect x="424" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="440" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="76" y="182" font-size="22" font-weight="700" fill="#15131f">Teams</text>
+    <circle cx="420" cy="174" r="14" fill="#6342db"/>
+    <text x="420" y="178" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">ST</text>
+
+    <!-- team cards -->
+    <rect x="76" y="200" width="358" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="92" y="218" width="40" height="40" rx="10" fill="#6342db" fill-opacity="0.14"/>
+    <text x="112" y="243" font-size="12" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="146" y="235" font-size="15" font-weight="600" fill="#15131f">Engineering</text>
+    <text x="146" y="256" font-size="12" fill="#7a7791">8 members</text>
+    <text x="416" y="245" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="76" y="288" width="358" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="92" y="306" width="40" height="40" rx="10" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="112" y="331" font-size="12" font-weight="700" fill="#8b5cf6" text-anchor="middle">DES</text>
+    <text x="146" y="323" font-size="15" font-weight="600" fill="#15131f">Design</text>
+    <text x="146" y="344" font-size="12" fill="#7a7791">4 members</text>
+    <text x="416" y="333" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="76" y="376" width="358" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="92" y="394" width="40" height="40" rx="10" fill="#12a474" fill-opacity="0.14"/>
+    <text x="112" y="419" font-size="12" font-weight="700" fill="#12a474" text-anchor="middle">OPS</text>
+    <text x="146" y="411" font-size="15" font-weight="600" fill="#15131f">Operations</text>
+    <text x="146" y="432" font-size="12" fill="#7a7791">3 members</text>
+    <text x="416" y="421" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <!-- New team button -->
+    <rect x="76" y="478" width="358" height="44" rx="10" fill="#6342db"/>
+    <text x="255" y="506" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">+  New team</text>
+
+    <!-- low-fi hint of more content -->
+    <rect x="76" y="544" width="128" height="12" rx="6" fill="#eeedf5"/>
+
+    <!-- bottom nav (under scrim) -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="99" y="878" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+    <rect x="166" y="838" width="6" height="20" fill="#7a7791"/>
+    <rect x="174" y="842" width="6" height="16" fill="#7a7791"/>
+    <rect x="182" y="845" width="6" height="13" fill="#7a7791"/>
+    <text x="177" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="253" cy="847" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="259" y1="853" x2="264" y2="858" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="255" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="333" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#7a7791"/>
+    <text x="411" y="878" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- scrim + bottom sheet: team switcher -->
+    <rect x="60" y="110" width="390" height="780" fill="#15131f" opacity="0.35"/>
+    <rect x="60" y="560" width="390" height="360" rx="20" fill="#ffffff"/>
+    <rect x="237" y="574" width="36" height="5" rx="2.5" fill="#dedcea"/>
+    <text x="84" y="612" font-size="16" font-weight="700" fill="#15131f">Switch team</text>
+
+    <rect x="72" y="626" width="366" height="56" rx="12" fill="#f7f6fb"/>
+    <rect x="88" y="638" width="32" height="32" rx="8" fill="#6342db" fill-opacity="0.14"/>
+    <text x="104" y="658" font-size="11" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="132" y="652" font-size="15" font-weight="600" fill="#15131f">Engineering</text>
+    <text x="132" y="670" font-size="12" fill="#7a7791">8 members</text>
+    <text x="422" y="660" font-size="16" font-weight="700" fill="#6342db" text-anchor="middle">✓</text>
+
+    <rect x="88" y="698" width="32" height="32" rx="8" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="104" y="718" font-size="11" font-weight="700" fill="#8b5cf6" text-anchor="middle">DES</text>
+    <text x="132" y="712" font-size="15" font-weight="600" fill="#15131f">Design</text>
+    <text x="132" y="730" font-size="12" fill="#7a7791">4 members</text>
+
+    <rect x="88" y="758" width="32" height="32" rx="8" fill="#12a474" fill-opacity="0.14"/>
+    <text x="104" y="778" font-size="11" font-weight="700" fill="#12a474" text-anchor="middle">OPS</text>
+    <text x="132" y="772" font-size="15" font-weight="600" fill="#15131f">Operations</text>
+    <text x="132" y="790" font-size="12" fill="#7a7791">3 members</text>
+
+    <line x1="88" y1="692" x2="432" y2="692" stroke="#eeedf5" stroke-width="1"/>
+    <line x1="88" y1="752" x2="432" y2="752" stroke="#eeedf5" stroke-width="1"/>
+    <line x1="88" y1="806" x2="432" y2="806" stroke="#eeedf5" stroke-width="1"/>
+
+    <rect x="88" y="818" width="32" height="32" rx="8" fill="none" stroke="#dedcea" stroke-dasharray="4 3"/>
+    <text x="104" y="839" font-size="16" fill="#7a7791" text-anchor="middle">+</text>
+    <text x="132" y="839" font-size="14" font-weight="600" fill="#6342db">Create new team</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE FRAME ============ -->
+  <rect x="534" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpF)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1216" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="1221" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="1226" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="1237" cy="128" r="4" fill="#514e66"/>
+    <rect x="1244" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="1260" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="210" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="568" y="246" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+    <rect x="557" y="282" width="6" height="20" fill="#7a7791"/>
+    <rect x="565" y="286" width="6" height="16" fill="#7a7791"/>
+    <rect x="573" y="289" width="6" height="13" fill="#7a7791"/>
+    <text x="568" y="316" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="566" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="572" y1="366" x2="577" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="568" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="568" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="501" r="11" fill="#7a7791"/>
+    <text x="568" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- left pane: teams list -->
+    <text x="626" y="184" font-size="20" font-weight="700" fill="#15131f">Teams</text>
+
+    <rect x="622" y="204" width="262" height="68" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="636" y="220" width="36" height="36" rx="9" fill="#6342db" fill-opacity="0.14"/>
+    <text x="654" y="243" font-size="11" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="684" y="234" font-size="14" font-weight="600" fill="#15131f">Engineering</text>
+    <text x="684" y="254" font-size="12" fill="#7a7791">8 members</text>
+    <text x="866" y="244" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="622" y="284" width="262" height="68" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="636" y="300" width="36" height="36" rx="9" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="654" y="323" font-size="11" font-weight="700" fill="#8b5cf6" text-anchor="middle">DES</text>
+    <text x="684" y="314" font-size="14" font-weight="600" fill="#15131f">Design</text>
+    <text x="684" y="334" font-size="12" fill="#7a7791">4 members</text>
+    <text x="866" y="324" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="622" y="364" width="262" height="68" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="636" y="380" width="36" height="36" rx="9" fill="#12a474" fill-opacity="0.14"/>
+    <text x="654" y="403" font-size="11" font-weight="700" fill="#12a474" text-anchor="middle">OPS</text>
+    <text x="684" y="394" font-size="14" font-weight="600" fill="#15131f">Operations</text>
+    <text x="684" y="414" font-size="12" fill="#7a7791">3 members</text>
+    <text x="866" y="404" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="622" y="448" width="262" height="44" rx="10" fill="#6342db"/>
+    <text x="753" y="476" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">+  New team</text>
+
+    <!-- low-fi pending invite -->
+    <rect x="622" y="524" width="140" height="12" rx="6" fill="#eeedf5"/>
+    <rect x="622" y="548" width="262" height="56" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="638" y="564" width="120" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="638" y="582" width="180" height="10" rx="5" fill="#eeedf5"/>
+
+    <!-- right pane: create team form -->
+    <text x="924" y="184" font-size="20" font-weight="700" fill="#15131f">Create team</text>
+    <text x="924" y="208" font-size="13" fill="#7a7791">Teams group issues, cycles, and projects.</text>
+
+    <text x="924" y="246" font-size="13" fill="#514e66">Name</text>
+    <rect x="924" y="256" width="322" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="940" y="286" font-size="15" fill="#15131f">Mobile</text>
+
+    <text x="924" y="340" font-size="13" fill="#514e66">Key</text>
+    <rect x="924" y="350" width="322" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="940" y="380" font-size="15" fill="#15131f">MOB</text>
+    <text x="924" y="424" font-size="13" fill="#7a7791">Key is permanent — it appears in issue</text>
+    <text x="924" y="442" font-size="13" fill="#7a7791">IDs like ENG-42.</text>
+
+    <rect x="924" y="472" width="322" height="44" rx="10" fill="#6342db"/>
+    <text x="1085" y="500" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create team</text>
+
+    <!-- preview card -->
+    <text x="924" y="566" font-size="12" fill="#7a7791">Preview</text>
+    <rect x="924" y="578" width="322" height="56" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="940" y="601" font-size="12" font-weight="600" fill="#7a7791">MOB-1</text>
+    <text x="940" y="621" font-size="14" fill="#15131f">Your first issue</text>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET FRAME ============ -->
+  <rect x="1354" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpT)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2446" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="2451" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="2456" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="2467" cy="128" r="4" fill="#514e66"/>
+    <rect x="2474" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="2490" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="210" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="1388" y="246" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Home</text>
+    <rect x="1377" y="282" width="6" height="20" fill="#7a7791"/>
+    <rect x="1385" y="286" width="6" height="16" fill="#7a7791"/>
+    <rect x="1393" y="289" width="6" height="13" fill="#7a7791"/>
+    <text x="1388" y="316" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="1392" y1="366" x2="1397" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="1388" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="1388" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="501" r="11" fill="#7a7791"/>
+    <text x="1388" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- teams list panel -->
+    <text x="1462" y="186" font-size="22" font-weight="700" fill="#15131f">Teams</text>
+    <text x="1462" y="210" font-size="13" fill="#7a7791">3 teams in this workspace</text>
+    <rect x="1908" y="156" width="144" height="40" rx="10" fill="#6342db"/>
+    <text x="1980" y="181" font-size="14" font-weight="600" fill="#ffffff" text-anchor="middle">+  New team</text>
+
+    <rect x="1462" y="236" width="590" height="84" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1478" y="256" width="44" height="44" rx="12" fill="#6342db" fill-opacity="0.14"/>
+    <text x="1500" y="283" font-size="13" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="1538" y="272" font-size="16" font-weight="600" fill="#15131f">Engineering</text>
+    <text x="1538" y="294" font-size="13" fill="#7a7791">8 members · 46 open issues</text>
+    <circle cx="1954" cy="278" r="12" fill="#4f8cff" stroke="#ffffff" stroke-width="2"/>
+    <text x="1954" y="282" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <circle cx="1972" cy="278" r="12" fill="#2fd4a7" stroke="#ffffff" stroke-width="2"/>
+    <text x="1972" y="282" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <circle cx="1990" cy="278" r="12" fill="#ffb648" stroke="#ffffff" stroke-width="2"/>
+    <text x="1990" y="282" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+    <text x="2030" y="283" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="1462" y="332" width="590" height="84" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1478" y="352" width="44" height="44" rx="12" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="1500" y="379" font-size="13" font-weight="700" fill="#8b5cf6" text-anchor="middle">DES</text>
+    <text x="1538" y="368" font-size="16" font-weight="600" fill="#15131f">Design</text>
+    <text x="1538" y="390" font-size="13" fill="#7a7791">4 members · 18 open issues</text>
+    <circle cx="1954" cy="374" r="12" fill="#ff6fae" stroke="#ffffff" stroke-width="2"/>
+    <text x="1954" y="378" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+    <circle cx="1972" cy="374" r="12" fill="#6342db" stroke="#ffffff" stroke-width="2"/>
+    <text x="1972" y="378" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">NR</text>
+    <text x="2030" y="379" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="1462" y="428" width="590" height="84" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1478" y="448" width="44" height="44" rx="12" fill="#12a474" fill-opacity="0.14"/>
+    <text x="1500" y="475" font-size="13" font-weight="700" fill="#12a474" text-anchor="middle">OPS</text>
+    <text x="1538" y="464" font-size="16" font-weight="600" fill="#15131f">Operations</text>
+    <text x="1538" y="486" font-size="13" fill="#7a7791">3 members · 9 open issues</text>
+    <circle cx="1972" cy="470" r="12" fill="#ffb648" stroke="#ffffff" stroke-width="2"/>
+    <text x="1972" y="474" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">JT</text>
+    <text x="2030" y="475" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <rect x="1462" y="536" width="590" height="52" rx="12" fill="#f7f6fb" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1482" y="567" font-size="13" font-weight="600" fill="#514e66">Archived teams (1)</text>
+    <text x="2030" y="567" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <!-- side sheet: create team -->
+    <rect x="2078" y="138" width="10" height="752" fill="#26243a" opacity="0.05"/>
+    <rect x="2088" y="138" width="412" height="752" fill="#ffffff"/>
+    <line x1="2088" y1="138" x2="2088" y2="890" stroke="#dedcea" stroke-width="2"/>
+    <text x="2116" y="192" font-size="20" font-weight="700" fill="#15131f">Create team</text>
+    <text x="2464" y="192" font-size="18" fill="#7a7791" text-anchor="middle">×</text>
+    <text x="2116" y="216" font-size="13" fill="#7a7791">New teams get their own board and backlog.</text>
+
+    <text x="2116" y="254" font-size="13" fill="#514e66">Name</text>
+    <rect x="2116" y="264" width="356" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2132" y="294" font-size="15" fill="#15131f">Mobile</text>
+
+    <text x="2116" y="348" font-size="13" fill="#514e66">Key</text>
+    <rect x="2116" y="358" width="356" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2132" y="388" font-size="15" fill="#15131f">MOB</text>
+    <text x="2116" y="432" font-size="13" fill="#7a7791">Key is permanent — it appears in issue</text>
+    <text x="2116" y="450" font-size="13" fill="#7a7791">IDs like ENG-42.</text>
+
+    <rect x="2116" y="480" width="356" height="44" rx="10" fill="#6342db"/>
+    <text x="2294" y="508" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create team</text>
+    <text x="2294" y="552" font-size="14" fill="#7a7791" text-anchor="middle">Cancel</text>
+
+    <text x="2116" y="608" font-size="13" fill="#514e66">Invite members (optional)</text>
+    <rect x="2116" y="618" width="356" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2132" y="648" font-size="15" fill="#b6b3c8">name@company.com</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Teams: single list with a bottom-sheet switcher on phone; list | create-form split at the hinge on foldable; persistent list with a side-sheet form on tablet.</text>
+</svg>

--- a/docs/design/mobile/142-board-list.svg
+++ b/docs/design/mobile/142-board-list.svg
@@ -1,0 +1,526 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cpP"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cpF"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="cpT"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Board &amp; list views with filters</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE FRAME ============ -->
+  <rect x="64" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpP)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="396" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="401" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="406" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="417" cy="128" r="4" fill="#514e66"/>
+    <rect x="424" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="440" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="76" y="180" font-size="20" font-weight="700" fill="#15131f">ENG · Board</text>
+    <circle cx="412" cy="170" r="8" stroke="#514e66" stroke-width="2" fill="none"/>
+    <line x1="418" y1="176" x2="424" y2="182" stroke="#514e66" stroke-width="2"/>
+
+    <!-- filter chips -->
+    <rect x="76" y="196" width="132" height="30" rx="15" fill="#e0424a" fill-opacity="0.12"/>
+    <text x="142" y="215" font-size="12" font-weight="600" fill="#e0424a" text-anchor="middle">Priority: Urgent  ×</text>
+    <rect x="218" y="196" width="100" height="30" rx="15" fill="#f2647d" fill-opacity="0.12"/>
+    <text x="268" y="215" font-size="12" font-weight="600" fill="#f2647d" text-anchor="middle">Label: bug  ×</text>
+    <rect x="328" y="196" width="78" height="30" rx="15" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="367" y="215" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">+ Filter</text>
+
+    <!-- neighbor column slivers (swipe affordance) -->
+    <rect x="28" y="244" width="56" height="560" rx="12" fill="#f7f6fb"/>
+    <rect x="426" y="244" width="56" height="560" rx="12" fill="#f7f6fb"/>
+
+    <!-- main column: In Progress -->
+    <rect x="92" y="244" width="326" height="560" rx="12" fill="#f7f6fb"/>
+    <circle cx="110" cy="270" r="5" fill="#f29d0b"/>
+    <text x="122" y="275" font-size="15" font-weight="600" fill="#15131f">In Progress</text>
+    <text x="402" y="275" font-size="12" fill="#7a7791" text-anchor="end">4 · 13 pts</text>
+
+    <!-- card 1 -->
+    <rect x="104" y="292" width="302" height="100" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="118" y="316" font-size="12" font-weight="600" fill="#7a7791">ENG-138</text>
+    <text x="118" y="338" font-size="14" fill="#15131f">Debounce board search input</text>
+    <rect x="118" y="374" width="4" height="6" fill="#ef9d0b"/>
+    <rect x="124" y="370" width="4" height="10" fill="#ef9d0b"/>
+    <rect x="130" y="366" width="4" height="14" fill="#ef9d0b"/>
+    <rect x="142" y="360" width="30" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="157" y="374" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="180" y="360" width="64" height="20" rx="10" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="212" y="374" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <circle cx="382" cy="370" r="12" fill="#2fd4a7"/>
+    <text x="382" y="374" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <!-- card 2: dragged / lifted -->
+    <g transform="rotate(-3 255 460)">
+      <rect x="108" y="412" width="302" height="112" rx="14" fill="#26243a" opacity="0.16"/>
+      <rect x="104" y="404" width="302" height="112" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+      <text x="118" y="430" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+      <text x="118" y="452" font-size="14" fill="#15131f">Fix drag ghost offset</text>
+      <text x="118" y="470" font-size="14" fill="#15131f">on Safari</text>
+      <rect x="118" y="496" width="4" height="6" fill="#f2721c"/>
+      <rect x="124" y="492" width="4" height="10" fill="#f2721c"/>
+      <rect x="130" y="488" width="4" height="14" fill="#f2721c"/>
+      <rect x="142" y="482" width="30" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+      <text x="157" y="496" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+      <rect x="180" y="482" width="42" height="20" rx="10" fill="#f2647d" fill-opacity="0.14"/>
+      <text x="201" y="496" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+      <circle cx="382" cy="492" r="12" fill="#4f8cff"/>
+      <text x="382" y="496" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    </g>
+
+    <!-- card 3 -->
+    <rect x="104" y="532" width="302" height="100" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="118" y="556" font-size="12" font-weight="600" fill="#7a7791">ENG-131</text>
+    <text x="118" y="578" font-size="14" fill="#15131f">Sync conflict toast on reconnect</text>
+    <rect x="118" y="614" width="4" height="6" fill="#e0424a"/>
+    <rect x="124" y="610" width="4" height="10" fill="#e0424a"/>
+    <rect x="130" y="606" width="4" height="14" fill="#e0424a"/>
+    <rect x="142" y="600" width="30" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="157" y="614" font-size="11" fill="#514e66" text-anchor="middle">5</text>
+    <rect x="180" y="600" width="62" height="20" rx="10" fill="#12a474" fill-opacity="0.14"/>
+    <text x="211" y="614" font-size="11" fill="#12a474" text-anchor="middle">backend</text>
+    <circle cx="382" cy="610" r="12" fill="#ffb648"/>
+    <text x="382" y="614" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+
+    <!-- card 4 -->
+    <rect x="104" y="644" width="302" height="100" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="118" y="668" font-size="12" font-weight="600" fill="#7a7791">ENG-127</text>
+    <text x="118" y="690" font-size="14" fill="#15131f">Offline cache for issue list</text>
+    <rect x="118" y="726" width="4" height="6" fill="#3f82f6"/>
+    <rect x="124" y="722" width="4" height="10" fill="#3f82f6"/>
+    <rect x="130" y="718" width="4" height="14" fill="#3f82f6"/>
+    <rect x="142" y="712" width="30" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="157" y="726" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="180" y="712" width="54" height="20" rx="10" fill="#6342db" fill-opacity="0.14"/>
+    <text x="207" y="726" font-size="11" fill="#6342db" text-anchor="middle">mobile</text>
+    <circle cx="382" cy="722" r="12" fill="#ff6fae"/>
+    <text x="382" y="726" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+
+    <!-- FAB -->
+    <circle cx="405" cy="782" r="28" fill="#26243a" opacity="0.12"/>
+    <circle cx="402" cy="778" r="28" fill="#6342db"/>
+    <text x="402" y="787" font-size="26" fill="#ffffff" text-anchor="middle">+</text>
+
+    <!-- bottom nav -->
+    <rect x="60" y="826" width="390" height="64" fill="#ffffff"/>
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="99" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="166" y="838" width="6" height="20" fill="#6342db"/>
+    <rect x="174" y="842" width="6" height="16" fill="#6342db"/>
+    <rect x="182" y="845" width="6" height="13" fill="#6342db"/>
+    <text x="177" y="878" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="253" cy="847" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="259" y1="853" x2="264" y2="858" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="255" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="333" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#7a7791"/>
+    <text x="411" y="878" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE FRAME ============ -->
+  <rect x="534" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpF)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1216" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="1221" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="1226" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="1237" cy="128" r="4" fill="#514e66"/>
+    <rect x="1244" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="1260" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="210" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="568" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="557" y="282" width="6" height="20" fill="#6342db"/>
+    <rect x="565" y="286" width="6" height="16" fill="#6342db"/>
+    <rect x="573" y="289" width="6" height="13" fill="#6342db"/>
+    <text x="568" y="316" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="566" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="572" y1="366" x2="577" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="568" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="568" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="501" r="11" fill="#7a7791"/>
+    <text x="568" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- hinge as column gutter -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- header -->
+    <text x="626" y="182" font-size="20" font-weight="700" fill="#15131f">ENG · Board</text>
+    <rect x="916" y="156" width="132" height="30" rx="15" fill="#e0424a" fill-opacity="0.12"/>
+    <text x="982" y="175" font-size="12" font-weight="600" fill="#e0424a" text-anchor="middle">Priority: Urgent  ×</text>
+    <rect x="1058" y="156" width="78" height="30" rx="15" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1097" y="175" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">+ Filter</text>
+
+    <!-- left column: Todo -->
+    <rect x="618" y="210" width="266" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="636" cy="238" r="5" fill="#6f6c86"/>
+    <text x="648" y="243" font-size="15" font-weight="600" fill="#15131f">Todo</text>
+    <text x="868" y="243" font-size="12" fill="#7a7791" text-anchor="end">6 · 21 pts</text>
+
+    <rect x="630" y="262" width="242" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="286" font-size="12" font-weight="600" fill="#7a7791">ENG-145</text>
+    <text x="644" y="307" font-size="13" fill="#15131f">Empty state for filtered board</text>
+    <rect x="644" y="340" width="4" height="6" fill="#ef9d0b"/>
+    <rect x="650" y="336" width="4" height="10" fill="#ef9d0b"/>
+    <rect x="656" y="332" width="4" height="14" fill="#ef9d0b"/>
+    <rect x="668" y="327" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="682" y="340" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="704" y="327" width="54" height="19" rx="9.5" fill="#ff6fae" fill-opacity="0.14"/>
+    <text x="731" y="340" font-size="11" fill="#ff6fae" text-anchor="middle">design</text>
+    <circle cx="846" cy="336" r="12" fill="#2fd4a7"/>
+    <text x="846" y="340" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <rect x="630" y="370" width="242" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="394" font-size="12" font-weight="600" fill="#7a7791">ENG-121</text>
+    <text x="644" y="415" font-size="13" fill="#15131f">Keyboard nav for column focus</text>
+    <rect x="644" y="448" width="4" height="6" fill="#3f82f6"/>
+    <rect x="650" y="444" width="4" height="10" fill="#3f82f6"/>
+    <rect x="656" y="440" width="4" height="14" fill="#3f82f6"/>
+    <rect x="668" y="435" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="682" y="448" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="704" y="435" width="46" height="19" rx="9.5" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="727" y="448" font-size="11" fill="#8b5cf6" text-anchor="middle">a11y</text>
+    <circle cx="846" cy="444" r="12" fill="#ffb648"/>
+    <text x="846" y="448" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+
+    <rect x="630" y="478" width="242" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="502" font-size="12" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="644" y="523" font-size="13" fill="#15131f">Team switcher deep link</text>
+    <rect x="644" y="556" width="4" height="6" fill="#f2721c"/>
+    <rect x="650" y="552" width="4" height="10" fill="#f2721c"/>
+    <rect x="656" y="548" width="4" height="14" fill="#f2721c"/>
+    <rect x="668" y="543" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="682" y="556" font-size="11" fill="#514e66" text-anchor="middle">1</text>
+    <rect x="704" y="543" width="54" height="19" rx="9.5" fill="#6342db" fill-opacity="0.14"/>
+    <text x="731" y="556" font-size="11" fill="#6342db" text-anchor="middle">mobile</text>
+    <circle cx="846" cy="552" r="12" fill="#ff6fae"/>
+    <text x="846" y="556" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+
+    <rect x="630" y="586" width="242" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="644" y="606" width="90" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="626" width="180" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="654" width="120" height="10" rx="5" fill="#eeedf5"/>
+    <text x="644" y="712" font-size="12" fill="#7a7791">+ 2 more</text>
+
+    <!-- right column: In Progress -->
+    <rect x="916" y="210" width="338" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="934" cy="238" r="5" fill="#f29d0b"/>
+    <text x="946" y="243" font-size="15" font-weight="600" fill="#15131f">In Progress</text>
+    <text x="1238" y="243" font-size="12" fill="#7a7791" text-anchor="end">4 · 13 pts</text>
+
+    <rect x="928" y="262" width="314" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="942" y="286" font-size="12" font-weight="600" fill="#7a7791">ENG-138</text>
+    <text x="942" y="307" font-size="13" fill="#15131f">Debounce board search input</text>
+    <rect x="942" y="340" width="4" height="6" fill="#ef9d0b"/>
+    <rect x="948" y="336" width="4" height="10" fill="#ef9d0b"/>
+    <rect x="954" y="332" width="4" height="14" fill="#ef9d0b"/>
+    <rect x="966" y="327" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="980" y="340" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="1002" y="327" width="64" height="19" rx="9.5" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="1034" y="340" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <circle cx="1216" cy="336" r="12" fill="#2fd4a7"/>
+    <text x="1216" y="340" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <rect x="928" y="370" width="314" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="942" y="394" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="942" y="415" font-size="13" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="942" y="448" width="4" height="6" fill="#f2721c"/>
+    <rect x="948" y="444" width="4" height="10" fill="#f2721c"/>
+    <rect x="954" y="440" width="4" height="14" fill="#f2721c"/>
+    <rect x="966" y="435" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="980" y="448" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="1002" y="435" width="42" height="19" rx="9.5" fill="#f2647d" fill-opacity="0.14"/>
+    <text x="1023" y="448" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+    <circle cx="1216" cy="444" r="12" fill="#4f8cff"/>
+    <text x="1216" y="448" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+
+    <rect x="928" y="478" width="314" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="942" y="502" font-size="12" font-weight="600" fill="#7a7791">ENG-131</text>
+    <text x="942" y="523" font-size="13" fill="#15131f">Sync conflict toast on reconnect</text>
+    <rect x="942" y="556" width="4" height="6" fill="#e0424a"/>
+    <rect x="948" y="552" width="4" height="10" fill="#e0424a"/>
+    <rect x="954" y="548" width="4" height="14" fill="#e0424a"/>
+    <rect x="966" y="543" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="980" y="556" font-size="11" fill="#514e66" text-anchor="middle">5</text>
+    <rect x="1002" y="543" width="62" height="19" rx="9.5" fill="#12a474" fill-opacity="0.14"/>
+    <text x="1033" y="556" font-size="11" fill="#12a474" text-anchor="middle">backend</text>
+    <circle cx="1216" cy="552" r="12" fill="#ffb648"/>
+    <text x="1216" y="556" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+
+    <rect x="928" y="586" width="314" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="942" y="610" font-size="12" font-weight="600" fill="#7a7791">ENG-127</text>
+    <text x="942" y="631" font-size="13" fill="#15131f">Offline cache for issue list</text>
+    <rect x="942" y="664" width="4" height="6" fill="#3f82f6"/>
+    <rect x="948" y="660" width="4" height="10" fill="#3f82f6"/>
+    <rect x="954" y="656" width="4" height="14" fill="#3f82f6"/>
+    <rect x="966" y="651" width="28" height="19" rx="9.5" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="980" y="664" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="1002" y="651" width="54" height="19" rx="9.5" fill="#6342db" fill-opacity="0.14"/>
+    <text x="1029" y="664" font-size="11" fill="#6342db" text-anchor="middle">mobile</text>
+    <circle cx="1216" cy="660" r="12" fill="#ff6fae"/>
+    <text x="1216" y="664" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET FRAME ============ -->
+  <rect x="1354" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpT)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2446" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="2451" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="2456" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="2467" cy="128" r="4" fill="#514e66"/>
+    <rect x="2474" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="2490" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="210" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="1388" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1377" y="282" width="6" height="20" fill="#6342db"/>
+    <rect x="1385" y="286" width="6" height="16" fill="#6342db"/>
+    <rect x="1393" y="289" width="6" height="13" fill="#6342db"/>
+    <text x="1388" y="316" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="1392" y1="366" x2="1397" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="1388" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="1388" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="501" r="11" fill="#7a7791"/>
+    <text x="1388" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- top bar -->
+    <text x="1462" y="182" font-size="20" font-weight="700" fill="#15131f">ENG · Engineering</text>
+    <rect x="2028" y="154" width="300" height="40" rx="10" fill="#f7f6fb" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2032" y="158" width="96" height="32" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2080" y="179" font-size="13" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <text x="2178" y="179" font-size="13" fill="#7a7791" text-anchor="middle">List</text>
+    <text x="2278" y="179" font-size="13" fill="#7a7791" text-anchor="middle">Reports</text>
+    <rect x="2348" y="154" width="104" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <rect x="2366" y="167" width="16" height="2.5" fill="#514e66"/>
+    <rect x="2370" y="173" width="8" height="2.5" fill="#514e66"/>
+    <rect x="2373" y="179" width="3" height="2.5" fill="#514e66"/>
+    <text x="2392" y="179" font-size="13" font-weight="600" fill="#514e66">Filter</text>
+
+    <!-- column 1: Backlog -->
+    <rect x="1446" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1464" cy="244" r="5" fill="#9b98b0"/>
+    <text x="1476" y="249" font-size="14" font-weight="600" fill="#15131f">Backlog</text>
+    <text x="1678" y="249" font-size="12" fill="#7a7791" text-anchor="end">5 · 11 pts</text>
+
+    <rect x="1458" y="264" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1470" y="286" font-size="11" font-weight="600" fill="#7a7791">ENG-152</text>
+    <text x="1470" y="306" font-size="13" fill="#15131f">Audit chart color contrast</text>
+    <rect x="1470" y="338" width="4" height="5" fill="#a29fb5"/>
+    <rect x="1476" y="335" width="4" height="8" fill="#a29fb5"/>
+    <rect x="1482" y="332" width="4" height="11" fill="#a29fb5"/>
+    <rect x="1492" y="328" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1505" y="341" font-size="11" fill="#514e66" text-anchor="middle">1</text>
+    <rect x="1524" y="328" width="52" height="18" rx="9" fill="#ff6fae" fill-opacity="0.14"/>
+    <text x="1550" y="341" font-size="11" fill="#ff6fae" text-anchor="middle">design</text>
+    <circle cx="1660" cy="337" r="10" fill="#ff6fae"/>
+    <text x="1660" y="341" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+
+    <rect x="1458" y="366" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1470" y="388" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+    <text x="1470" y="408" font-size="13" fill="#15131f">Spike: sync benchmarks</text>
+    <rect x="1470" y="440" width="4" height="5" fill="#3f82f6"/>
+    <rect x="1476" y="437" width="4" height="8" fill="#3f82f6"/>
+    <rect x="1482" y="434" width="4" height="11" fill="#3f82f6"/>
+    <rect x="1492" y="430" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1505" y="443" font-size="11" fill="#514e66" text-anchor="middle">5</text>
+    <rect x="1524" y="430" width="46" height="18" rx="9" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="1547" y="443" font-size="11" fill="#8b5cf6" text-anchor="middle">spike</text>
+    <circle cx="1660" cy="439" r="10" fill="#4f8cff"/>
+    <text x="1660" y="443" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+
+    <rect x="1458" y="468" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1470" y="490" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+    <text x="1470" y="510" font-size="13" fill="#15131f">Refactor avatar cache</text>
+    <rect x="1470" y="542" width="4" height="5" fill="#ef9d0b"/>
+    <rect x="1476" y="539" width="4" height="8" fill="#ef9d0b"/>
+    <rect x="1482" y="536" width="4" height="11" fill="#ef9d0b"/>
+    <rect x="1492" y="532" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1505" y="545" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="1524" y="532" width="50" height="18" rx="9" fill="#9b98b0" fill-opacity="0.18"/>
+    <text x="1549" y="545" font-size="11" fill="#6f6c86" text-anchor="middle">chore</text>
+    <circle cx="1660" cy="541" r="10" fill="#2fd4a7"/>
+    <text x="1660" y="545" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <text x="1470" y="592" font-size="12" fill="#7a7791">+ 2 more</text>
+
+    <!-- column 2: Todo -->
+    <rect x="1708" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1726" cy="244" r="5" fill="#6f6c86"/>
+    <text x="1738" y="249" font-size="14" font-weight="600" fill="#15131f">Todo</text>
+    <text x="1940" y="249" font-size="12" fill="#7a7791" text-anchor="end">6 · 21 pts</text>
+
+    <rect x="1720" y="264" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1732" y="286" font-size="11" font-weight="600" fill="#7a7791">ENG-145</text>
+    <text x="1732" y="306" font-size="13" fill="#15131f">Empty state for filters</text>
+    <rect x="1732" y="338" width="4" height="5" fill="#ef9d0b"/>
+    <rect x="1738" y="335" width="4" height="8" fill="#ef9d0b"/>
+    <rect x="1744" y="332" width="4" height="11" fill="#ef9d0b"/>
+    <rect x="1754" y="328" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1767" y="341" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="1786" y="328" width="52" height="18" rx="9" fill="#ff6fae" fill-opacity="0.14"/>
+    <text x="1812" y="341" font-size="11" fill="#ff6fae" text-anchor="middle">design</text>
+    <circle cx="1922" cy="337" r="10" fill="#2fd4a7"/>
+    <text x="1922" y="341" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <rect x="1720" y="366" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1732" y="388" font-size="11" font-weight="600" fill="#7a7791">ENG-121</text>
+    <text x="1732" y="408" font-size="13" fill="#15131f">Keyboard column nav</text>
+    <rect x="1732" y="440" width="4" height="5" fill="#3f82f6"/>
+    <rect x="1738" y="437" width="4" height="8" fill="#3f82f6"/>
+    <rect x="1744" y="434" width="4" height="11" fill="#3f82f6"/>
+    <rect x="1754" y="430" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1767" y="443" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="1786" y="430" width="44" height="18" rx="9" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="1808" y="443" font-size="11" fill="#8b5cf6" text-anchor="middle">a11y</text>
+    <circle cx="1922" cy="439" r="10" fill="#ffb648"/>
+    <text x="1922" y="443" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+
+    <rect x="1720" y="468" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1732" y="490" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="1732" y="510" font-size="13" fill="#15131f">Team switcher deep link</text>
+    <rect x="1732" y="542" width="4" height="5" fill="#f2721c"/>
+    <rect x="1738" y="539" width="4" height="8" fill="#f2721c"/>
+    <rect x="1744" y="536" width="4" height="11" fill="#f2721c"/>
+    <rect x="1754" y="532" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1767" y="545" font-size="11" fill="#514e66" text-anchor="middle">1</text>
+    <rect x="1786" y="532" width="52" height="18" rx="9" fill="#6342db" fill-opacity="0.14"/>
+    <text x="1812" y="545" font-size="11" fill="#6342db" text-anchor="middle">mobile</text>
+    <circle cx="1922" cy="541" r="10" fill="#ff6fae"/>
+    <text x="1922" y="545" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SB</text>
+
+    <text x="1732" y="592" font-size="12" fill="#7a7791">+ 3 more</text>
+
+    <!-- column 3: In Progress -->
+    <rect x="1970" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1988" cy="244" r="5" fill="#f29d0b"/>
+    <text x="2000" y="249" font-size="14" font-weight="600" fill="#15131f">In Progress</text>
+    <text x="2202" y="249" font-size="12" fill="#7a7791" text-anchor="end">4 · 13 pts</text>
+
+    <rect x="1982" y="264" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1994" y="286" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+    <text x="1994" y="306" font-size="13" fill="#15131f">Debounce board search</text>
+    <rect x="1994" y="338" width="4" height="5" fill="#ef9d0b"/>
+    <rect x="2000" y="335" width="4" height="8" fill="#ef9d0b"/>
+    <rect x="2006" y="332" width="4" height="11" fill="#ef9d0b"/>
+    <rect x="2016" y="328" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2029" y="341" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="2048" y="328" width="62" height="18" rx="9" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="2079" y="341" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <circle cx="2184" cy="337" r="10" fill="#2fd4a7"/>
+    <text x="2184" y="341" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <rect x="1982" y="366" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1994" y="388" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="1994" y="408" font-size="13" fill="#15131f">Fix drag ghost on Safari</text>
+    <rect x="1994" y="440" width="4" height="5" fill="#f2721c"/>
+    <rect x="2000" y="437" width="4" height="8" fill="#f2721c"/>
+    <rect x="2006" y="434" width="4" height="11" fill="#f2721c"/>
+    <rect x="2016" y="430" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2029" y="443" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="2048" y="430" width="40" height="18" rx="9" fill="#f2647d" fill-opacity="0.14"/>
+    <text x="2068" y="443" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+    <circle cx="2184" cy="439" r="10" fill="#4f8cff"/>
+    <text x="2184" y="443" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+
+    <rect x="1982" y="468" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1994" y="490" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+    <text x="1994" y="510" font-size="13" fill="#15131f">Sync conflict toast</text>
+    <rect x="1994" y="542" width="4" height="5" fill="#e0424a"/>
+    <rect x="2000" y="539" width="4" height="8" fill="#e0424a"/>
+    <rect x="2006" y="536" width="4" height="11" fill="#e0424a"/>
+    <rect x="2016" y="532" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2029" y="545" font-size="11" fill="#514e66" text-anchor="middle">5</text>
+    <rect x="2048" y="532" width="60" height="18" rx="9" fill="#12a474" fill-opacity="0.14"/>
+    <text x="2078" y="545" font-size="11" fill="#12a474" text-anchor="middle">backend</text>
+    <circle cx="2184" cy="541" r="10" fill="#ffb648"/>
+    <text x="2184" y="545" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LR</text>
+
+    <text x="1994" y="592" font-size="12" fill="#7a7791">+ 1 more</text>
+
+    <!-- column 4: Done -->
+    <rect x="2232" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="2250" cy="244" r="5" fill="#12a474"/>
+    <text x="2262" y="249" font-size="14" font-weight="600" fill="#15131f">Done</text>
+    <text x="2464" y="249" font-size="12" fill="#7a7791" text-anchor="end">8 · 26 pts</text>
+
+    <rect x="2244" y="264" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="2256" y="286" font-size="11" font-weight="600" fill="#7a7791">ENG-112</text>
+    <text x="2256" y="306" font-size="13" fill="#15131f">Avatar a11y labels</text>
+    <rect x="2256" y="338" width="4" height="5" fill="#f2721c"/>
+    <rect x="2262" y="335" width="4" height="8" fill="#f2721c"/>
+    <rect x="2268" y="332" width="4" height="11" fill="#f2721c"/>
+    <rect x="2278" y="328" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2291" y="341" font-size="11" fill="#514e66" text-anchor="middle">2</text>
+    <rect x="2310" y="328" width="44" height="18" rx="9" fill="#8b5cf6" fill-opacity="0.14"/>
+    <text x="2332" y="341" font-size="11" fill="#8b5cf6" text-anchor="middle">a11y</text>
+    <circle cx="2446" cy="337" r="10" fill="#6342db"/>
+    <text x="2446" y="341" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">NR</text>
+
+    <rect x="2244" y="366" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="2256" y="388" font-size="11" font-weight="600" fill="#7a7791">ENG-109</text>
+    <text x="2256" y="408" font-size="13" fill="#15131f">Auto-link issue IDs</text>
+    <rect x="2256" y="440" width="4" height="5" fill="#ef9d0b"/>
+    <rect x="2262" y="437" width="4" height="8" fill="#ef9d0b"/>
+    <rect x="2268" y="434" width="4" height="11" fill="#ef9d0b"/>
+    <rect x="2278" y="430" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2291" y="443" font-size="11" fill="#514e66" text-anchor="middle">3</text>
+    <rect x="2310" y="430" width="50" height="18" rx="9" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="2335" y="443" font-size="11" fill="#3f82f6" text-anchor="middle">editor</text>
+    <circle cx="2446" cy="439" r="10" fill="#4f8cff"/>
+    <text x="2446" y="443" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+
+    <rect x="2244" y="468" width="222" height="92" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="2256" y="490" font-size="11" font-weight="600" fill="#7a7791">ENG-104</text>
+    <text x="2256" y="510" font-size="13" fill="#15131f">Cross-team issue links</text>
+    <rect x="2256" y="542" width="4" height="5" fill="#f2721c"/>
+    <rect x="2262" y="539" width="4" height="8" fill="#f2721c"/>
+    <rect x="2268" y="536" width="4" height="11" fill="#f2721c"/>
+    <rect x="2278" y="532" width="26" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2291" y="545" font-size="11" fill="#514e66" text-anchor="middle">5</text>
+    <rect x="2310" y="532" width="42" height="18" rx="9" fill="#12a474" fill-opacity="0.14"/>
+    <text x="2331" y="545" font-size="11" fill="#12a474" text-anchor="middle">core</text>
+    <circle cx="2446" cy="541" r="10" fill="#2fd4a7"/>
+    <text x="2446" y="545" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+
+    <text x="2256" y="592" font-size="12" fill="#7a7791">+ 5 more</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Columns per viewport: 1 on phone (horizontal swipe between columns), 2 on foldable with the hinge as the column gutter, 4+ on tablet with persistent view and filter controls.</text>
+</svg>

--- a/docs/design/mobile/143-new-issue.svg
+++ b/docs/design/mobile/143-new-issue.svg
@@ -1,0 +1,417 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cpP"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cpF"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="cpT"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Issue creation &amp; editing</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE FRAME ============ -->
+  <rect x="64" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpP)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="396" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="401" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="406" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="417" cy="128" r="4" fill="#514e66"/>
+    <rect x="424" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="440" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- app bar -->
+    <text x="84" y="182" font-size="18" fill="#514e66">×</text>
+    <text x="255" y="181" font-size="17" font-weight="600" fill="#15131f" text-anchor="middle">New issue</text>
+    <rect x="386" y="158" width="48" height="26" rx="13" fill="#6342db" fill-opacity="0.12"/>
+    <text x="410" y="176" font-size="12" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+
+    <!-- title input -->
+    <rect x="76" y="200" width="358" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="92" y="229" font-size="15" fill="#15131f">Fix drag ghost offset on Safari</text>
+
+    <!-- description -->
+    <rect x="76" y="260" width="358" height="100" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="92" y="288" font-size="14" fill="#b6b3c8">Add a description — markdown supported</text>
+
+    <!-- property rows -->
+    <text x="88" y="405" font-size="14" fill="#514e66">Status</text>
+    <circle cx="318" cy="400" r="5" fill="#f29d0b"/>
+    <text x="404" y="405" font-size="14" fill="#15131f" text-anchor="end">In Progress</text>
+    <text x="420" y="406" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="424" x2="434" y2="424" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="453" font-size="14" fill="#514e66">Priority</text>
+    <rect x="348" y="451" width="4" height="5" fill="#f2721c"/>
+    <rect x="354" y="447" width="4" height="9" fill="#f2721c"/>
+    <rect x="360" y="443" width="4" height="13" fill="#f2721c"/>
+    <text x="404" y="453" font-size="14" fill="#15131f" text-anchor="end">High</text>
+    <text x="420" y="454" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="472" x2="434" y2="472" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="501" font-size="14" fill="#514e66">Estimate</text>
+    <text x="404" y="501" font-size="14" fill="#15131f" text-anchor="end">3</text>
+    <text x="420" y="502" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="520" x2="434" y2="520" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="549" font-size="14" fill="#514e66">Cycle</text>
+    <text x="404" y="549" font-size="14" fill="#15131f" text-anchor="end">Cycle 7</text>
+    <text x="420" y="550" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="568" x2="434" y2="568" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="597" font-size="14" fill="#514e66">Project</text>
+    <text x="404" y="597" font-size="14" fill="#15131f" text-anchor="end">Mobile app</text>
+    <text x="420" y="598" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="616" x2="434" y2="616" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="645" font-size="14" fill="#514e66">Assignee</text>
+    <circle cx="330" cy="640" r="11" fill="#4f8cff"/>
+    <text x="330" y="644" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="404" y="645" font-size="14" fill="#15131f" text-anchor="end">Amina K.</text>
+    <text x="420" y="646" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="76" y1="664" x2="434" y2="664" stroke="#eeedf5" stroke-width="1"/>
+    <text x="88" y="693" font-size="14" fill="#514e66">Labels</text>
+    <rect x="286" y="677" width="42" height="22" rx="11" fill="#f2647d" fill-opacity="0.14"/>
+    <text x="307" y="692" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+    <rect x="336" y="677" width="68" height="22" rx="11" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="370" y="692" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <text x="420" y="694" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="76" y1="712" x2="434" y2="712" stroke="#eeedf5" stroke-width="1"/>
+
+    <!-- create button -->
+    <rect x="76" y="736" width="358" height="44" rx="10" fill="#6342db"/>
+    <text x="255" y="764" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create issue</text>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="99" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="166" y="838" width="6" height="20" fill="#6342db"/>
+    <rect x="174" y="842" width="6" height="16" fill="#6342db"/>
+    <rect x="182" y="845" width="6" height="13" fill="#6342db"/>
+    <text x="177" y="878" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="253" cy="847" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="259" y1="853" x2="264" y2="858" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="255" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="333" y="878" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#7a7791"/>
+    <text x="411" y="878" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE FRAME ============ -->
+  <rect x="534" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpF)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1216" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="1221" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="1226" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="1237" cy="128" r="4" fill="#514e66"/>
+    <rect x="1244" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="1260" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail (left pane, will be dimmed) -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="210" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="568" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="557" y="282" width="6" height="20" fill="#6342db"/>
+    <rect x="565" y="286" width="6" height="16" fill="#6342db"/>
+    <rect x="573" y="289" width="6" height="13" fill="#6342db"/>
+    <text x="568" y="316" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="566" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="572" y1="366" x2="577" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="568" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="568" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="501" r="11" fill="#7a7791"/>
+    <text x="568" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- left pane: board behind -->
+    <text x="626" y="182" font-size="20" font-weight="700" fill="#15131f">ENG · Board</text>
+    <rect x="618" y="204" width="266" height="656" rx="12" fill="#f7f6fb"/>
+    <circle cx="636" cy="232" r="5" fill="#f29d0b"/>
+    <text x="648" y="237" font-size="15" font-weight="600" fill="#15131f">In Progress</text>
+    <text x="868" y="237" font-size="12" fill="#7a7791" text-anchor="end">4 · 13 pts</text>
+
+    <rect x="630" y="256" width="242" height="92" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="280" font-size="12" font-weight="600" fill="#7a7791">ENG-138</text>
+    <rect x="644" y="292" width="150" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="310" width="90" height="10" rx="5" fill="#eeedf5"/>
+    <circle cx="846" cy="326" r="11" fill="#eeedf5"/>
+
+    <rect x="630" y="360" width="242" height="92" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="384" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <rect x="644" y="396" width="170" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="414" width="110" height="10" rx="5" fill="#eeedf5"/>
+    <circle cx="846" cy="430" r="11" fill="#eeedf5"/>
+
+    <rect x="630" y="464" width="242" height="92" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="488" font-size="12" font-weight="600" fill="#7a7791">ENG-131</text>
+    <rect x="644" y="500" width="140" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="518" width="180" height="10" rx="5" fill="#eeedf5"/>
+    <circle cx="846" cy="534" r="11" fill="#eeedf5"/>
+
+    <rect x="630" y="568" width="242" height="92" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="644" y="592" font-size="12" font-weight="600" fill="#7a7791">ENG-127</text>
+    <rect x="644" y="604" width="160" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="644" y="622" width="100" height="10" rx="5" fill="#eeedf5"/>
+    <circle cx="846" cy="638" r="11" fill="#eeedf5"/>
+
+    <!-- scrim over the left pane only -->
+    <rect x="530" y="110" width="372" height="780" fill="#15131f" opacity="0.32"/>
+
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- right pane sheet: new issue -->
+    <rect x="894" y="138" width="8" height="752" fill="#26243a" opacity="0.08"/>
+    <rect x="902" y="138" width="368" height="752" fill="#ffffff"/>
+    <line x1="902" y1="138" x2="902" y2="890" stroke="#dedcea" stroke-width="2"/>
+
+    <text x="926" y="181" font-size="18" font-weight="700" fill="#15131f">New issue</text>
+    <rect x="1026" y="162" width="44" height="24" rx="12" fill="#6342db" fill-opacity="0.12"/>
+    <text x="1048" y="179" font-size="11" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="1238" y="181" font-size="16" fill="#7a7791" text-anchor="middle">×</text>
+
+    <rect x="926" y="200" width="320" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="940" y="227" font-size="14" fill="#15131f">Fix drag ghost offset on Safari</text>
+
+    <rect x="926" y="256" width="320" height="80" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="940" y="283" font-size="13" fill="#b6b3c8">Add a description — markdown supported</text>
+
+    <text x="934" y="383" font-size="13" fill="#514e66">Status</text>
+    <circle cx="1131" cy="378" r="5" fill="#f29d0b"/>
+    <text x="1218" y="383" font-size="14" fill="#15131f" text-anchor="end">In Progress</text>
+    <text x="1234" y="384" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="400" x2="1246" y2="400" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="427" font-size="13" fill="#514e66">Priority</text>
+    <rect x="1162" y="425" width="4" height="5" fill="#f2721c"/>
+    <rect x="1168" y="421" width="4" height="9" fill="#f2721c"/>
+    <rect x="1174" y="417" width="4" height="13" fill="#f2721c"/>
+    <text x="1218" y="427" font-size="14" fill="#15131f" text-anchor="end">High</text>
+    <text x="1234" y="428" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="444" x2="1246" y2="444" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="471" font-size="13" fill="#514e66">Estimate</text>
+    <text x="1218" y="471" font-size="14" fill="#15131f" text-anchor="end">3</text>
+    <text x="1234" y="472" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="488" x2="1246" y2="488" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="515" font-size="13" fill="#514e66">Cycle</text>
+    <text x="1218" y="515" font-size="14" fill="#15131f" text-anchor="end">Cycle 7</text>
+    <text x="1234" y="516" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="532" x2="1246" y2="532" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="559" font-size="13" fill="#514e66">Project</text>
+    <text x="1218" y="559" font-size="14" fill="#15131f" text-anchor="end">Mobile app</text>
+    <text x="1234" y="560" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="576" x2="1246" y2="576" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="603" font-size="13" fill="#514e66">Assignee</text>
+    <circle cx="1146" cy="598" r="10" fill="#4f8cff"/>
+    <text x="1146" y="602" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="1218" y="603" font-size="14" fill="#15131f" text-anchor="end">Amina K.</text>
+    <text x="1234" y="604" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <line x1="926" y1="620" x2="1246" y2="620" stroke="#eeedf5" stroke-width="1"/>
+    <text x="934" y="647" font-size="13" fill="#514e66">Labels</text>
+    <rect x="1100" y="631" width="42" height="22" rx="11" fill="#f2647d" fill-opacity="0.14"/>
+    <text x="1121" y="646" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+    <rect x="1150" y="631" width="68" height="22" rx="11" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="1184" y="646" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <text x="1234" y="648" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="926" y1="664" x2="1246" y2="664" stroke="#eeedf5" stroke-width="1"/>
+
+    <rect x="926" y="690" width="320" height="44" rx="10" fill="#6342db"/>
+    <text x="1086" y="718" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create issue</text>
+
+    <text x="926" y="768" font-size="13" fill="#514e66">Create more</text>
+    <rect x="1198" y="752" width="44" height="24" rx="12" fill="#eeedf5"/>
+    <circle cx="1210" cy="764" r="9" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET FRAME ============ -->
+  <rect x="1354" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cpT)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2446" y="127" width="3" height="7" fill="#514e66"/>
+    <rect x="2451" y="125" width="3" height="9" fill="#514e66"/>
+    <rect x="2456" y="123" width="3" height="11" fill="#514e66"/>
+    <circle cx="2467" cy="128" r="4" fill="#514e66"/>
+    <rect x="2474" y="122" width="16" height="9" rx="2" fill="#514e66"/>
+    <rect x="2490" y="124" width="2" height="5" fill="#514e66"/>
+
+    <!-- nav rail (stays undimmed) -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="210" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="1388" y="246" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1377" y="282" width="6" height="20" fill="#6342db"/>
+    <rect x="1385" y="286" width="6" height="16" fill="#6342db"/>
+    <rect x="1393" y="289" width="6" height="13" fill="#6342db"/>
+    <text x="1388" y="316" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="360" r="8" stroke="#7a7791" stroke-width="2.5" fill="none"/>
+    <line x1="1392" y1="366" x2="1397" y2="371" stroke="#7a7791" stroke-width="2.5"/>
+    <text x="1388" y="386" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="420" width="22" height="22" rx="6" fill="#7a7791"/>
+    <text x="1388" y="456" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="501" r="11" fill="#7a7791"/>
+    <text x="1388" y="526" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- board behind (low-fi) -->
+    <text x="1462" y="182" font-size="20" font-weight="700" fill="#15131f">ENG · Engineering</text>
+    <rect x="2028" y="154" width="300" height="40" rx="10" fill="#f7f6fb" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2032" y="158" width="96" height="32" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2080" y="179" font-size="13" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <text x="2178" y="179" font-size="13" fill="#7a7791" text-anchor="middle">List</text>
+    <text x="2278" y="179" font-size="13" fill="#7a7791" text-anchor="middle">Reports</text>
+    <rect x="2348" y="154" width="104" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <rect x="2366" y="167" width="16" height="2.5" fill="#514e66"/>
+    <rect x="2370" y="173" width="8" height="2.5" fill="#514e66"/>
+    <rect x="2373" y="179" width="3" height="2.5" fill="#514e66"/>
+    <text x="2392" y="179" font-size="13" font-weight="600" fill="#514e66">Filter</text>
+
+    <rect x="1446" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1464" cy="244" r="5" fill="#9b98b0"/>
+    <text x="1476" y="249" font-size="14" font-weight="600" fill="#15131f">Backlog</text>
+    <rect x="1458" y="264" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1470" y="284" width="130" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1470" y="302" width="170" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1458" y="358" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1470" y="378" width="150" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1470" y="396" width="100" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1458" y="452" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1470" y="472" width="120" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1470" y="490" width="160" height="10" rx="5" fill="#eeedf5"/>
+
+    <rect x="1708" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1726" cy="244" r="5" fill="#6f6c86"/>
+    <text x="1738" y="249" font-size="14" font-weight="600" fill="#15131f">Todo</text>
+    <rect x="1720" y="264" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1732" y="284" width="140" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1732" y="302" width="180" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1720" y="358" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1732" y="378" width="160" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1732" y="396" width="110" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1720" y="452" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1732" y="472" width="130" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1732" y="490" width="150" height="10" rx="5" fill="#eeedf5"/>
+
+    <rect x="1970" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="1988" cy="244" r="5" fill="#f29d0b"/>
+    <text x="2000" y="249" font-size="14" font-weight="600" fill="#15131f">In Progress</text>
+    <rect x="1982" y="264" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1994" y="284" width="150" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1994" y="302" width="90" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1982" y="358" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1994" y="378" width="170" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1994" y="396" width="120" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1982" y="452" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1994" y="472" width="140" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1994" y="490" width="100" height="10" rx="5" fill="#eeedf5"/>
+
+    <rect x="2232" y="216" width="246" height="650" rx="12" fill="#f7f6fb"/>
+    <circle cx="2250" cy="244" r="5" fill="#12a474"/>
+    <text x="2262" y="249" font-size="14" font-weight="600" fill="#15131f">Done</text>
+    <rect x="2244" y="264" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2256" y="284" width="120" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="2256" y="302" width="160" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="2244" y="358" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2256" y="378" width="140" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="2256" y="396" width="180" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="2244" y="452" width="222" height="84" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2256" y="472" width="150" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="2256" y="490" width="110" height="10" rx="5" fill="#eeedf5"/>
+
+    <!-- scrim over content (rail stays) -->
+    <rect x="1428" y="110" width="1072" height="780" fill="#15131f" opacity="0.32"/>
+
+    <!-- centered modal: new issue -->
+    <rect x="1631" y="210" width="680" height="600" rx="16" fill="#26243a" opacity="0.18"/>
+    <rect x="1623" y="200" width="680" height="600" rx="16" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+
+    <text x="1655" y="250" font-size="20" font-weight="700" fill="#15131f">New issue</text>
+    <rect x="1772" y="230" width="48" height="26" rx="13" fill="#6342db" fill-opacity="0.12"/>
+    <text x="1796" y="248" font-size="12" font-weight="700" fill="#6342db" text-anchor="middle">ENG</text>
+    <text x="2258" y="250" font-size="18" fill="#7a7791" text-anchor="middle">×</text>
+
+    <rect x="1655" y="272" width="616" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1671" y="301" font-size="15" fill="#15131f">Fix drag ghost offset on Safari</text>
+
+    <rect x="1655" y="336" width="616" height="112" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1671" y="364" font-size="14" fill="#b6b3c8">Add a description — markdown, @mentions, and #issue links supported</text>
+
+    <!-- two-column property grid -->
+    <text x="1655" y="482" font-size="12" fill="#514e66">Status</text>
+    <rect x="1655" y="490" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="1673" cy="510" r="5" fill="#f29d0b"/>
+    <text x="1686" y="515" font-size="14" fill="#15131f">In Progress</text>
+    <text x="1939" y="516" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1971" y="482" font-size="12" fill="#514e66">Priority</text>
+    <rect x="1971" y="490" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <rect x="1987" y="512" width="4" height="5" fill="#f2721c"/>
+    <rect x="1993" y="508" width="4" height="9" fill="#f2721c"/>
+    <rect x="1999" y="504" width="4" height="13" fill="#f2721c"/>
+    <text x="2013" y="515" font-size="14" fill="#15131f">High</text>
+    <text x="2255" y="516" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1655" y="554" font-size="12" fill="#514e66">Estimate</text>
+    <rect x="1655" y="562" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1671" y="587" font-size="14" fill="#15131f">3 points</text>
+    <text x="1939" y="588" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1971" y="554" font-size="12" fill="#514e66">Cycle</text>
+    <rect x="1971" y="562" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1987" y="587" font-size="14" fill="#15131f">Cycle 7</text>
+    <text x="2255" y="588" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1655" y="626" font-size="12" fill="#514e66">Project</text>
+    <rect x="1655" y="634" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <rect x="1671" y="648" width="12" height="12" rx="3" fill="#6342db" fill-opacity="0.35"/>
+    <text x="1691" y="659" font-size="14" fill="#15131f">Mobile app</text>
+    <text x="1939" y="660" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1971" y="626" font-size="12" fill="#514e66">Assignee</text>
+    <rect x="1971" y="634" width="300" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="1993" cy="654" r="10" fill="#4f8cff"/>
+    <text x="1993" y="658" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="2010" y="659" font-size="14" fill="#15131f">Amina K.</text>
+    <text x="2255" y="660" font-size="15" fill="#b6b3c8" text-anchor="middle">›</text>
+
+    <text x="1655" y="702" font-size="12" fill="#514e66">Labels</text>
+    <rect x="1655" y="710" width="44" height="24" rx="12" fill="#f2647d" fill-opacity="0.14"/>
+    <text x="1677" y="726" font-size="11" fill="#f2647d" text-anchor="middle">bug</text>
+    <rect x="1707" y="710" width="72" height="24" rx="12" fill="#3f82f6" fill-opacity="0.14"/>
+    <text x="1743" y="726" font-size="11" fill="#3f82f6" text-anchor="middle">frontend</text>
+    <rect x="1787" y="710" width="90" height="24" rx="12" fill="none" stroke="#dedcea" stroke-dasharray="4 3"/>
+    <text x="1832" y="726" font-size="11" fill="#7a7791" text-anchor="middle">+ Add label</text>
+
+    <text x="2110" y="772" font-size="14" fill="#7a7791" text-anchor="end">Cancel</text>
+    <rect x="2131" y="744" width="140" height="44" rx="10" fill="#6342db"/>
+    <text x="2201" y="772" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create issue</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Issue creation scales from a full-screen flow on phone, to a right-pane sheet beside the dimmed board on foldable, to a centered 680px modal with a two-column property grid on tablet.</text>
+</svg>

--- a/docs/design/mobile/144-issue-detail.svg
+++ b/docs/design/mobile/144-issue-detail.svg
@@ -1,0 +1,423 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+<rect width="2560" height="1000" fill="#eef0f8"/>
+<defs>
+<clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+<clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+<clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+</defs>
+
+<!-- Title block -->
+<text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Issue detail: sub-issues, links, development</text>
+<text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+<!-- Frame labels -->
+<text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+<text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+<text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+<!-- Frame shadows + fills -->
+<rect x="60" y="115" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="530" y="115" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="1350" y="115" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff"/>
+
+<!-- ============ PHONE ============ -->
+<g clip-path="url(#cp)">
+  <!-- status bar -->
+  <text x="84" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="368" y="124" width="3" height="4" fill="#514e66"/><rect x="373" y="122" width="3" height="6" fill="#514e66"/><rect x="378" y="120" width="3" height="8" fill="#514e66"/><rect x="383" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="392,128 404,128 398,119" fill="#514e66"/>
+  <rect x="406" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="427" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- header -->
+  <text x="80" y="172" font-size="20" fill="#514e66">‹</text>
+  <text x="102" y="170" font-size="13" font-weight="600" fill="#7a7791">ENG-142</text>
+  <circle cx="414" cy="166" r="2" fill="#514e66"/><circle cx="421" cy="166" r="2" fill="#514e66"/><circle cx="428" cy="166" r="2" fill="#514e66"/>
+  <text x="80" y="208" font-size="20" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+
+  <!-- property chips -->
+  <rect x="80" y="228" width="110" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="96" cy="241" r="4" fill="#f29d0b"/>
+  <text x="106" y="245" font-size="12" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="198" y="228" width="72" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+  <rect x="210" y="238" width="3" height="7" fill="#f2721c"/><rect x="215" y="235" width="3" height="10" fill="#f2721c"/><rect x="220" y="232" width="3" height="13" fill="#f2721c"/>
+  <text x="230" y="245" font-size="12" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="294" cy="241" r="13" fill="#4f8cff"/>
+  <text x="294" y="245" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <rect x="316" y="228" width="64" height="26" rx="13" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="330" y="245" font-size="12" font-weight="600" fill="#514e66">3 pts</text>
+
+  <line x1="60" y1="274" x2="450" y2="274" stroke="#eeedf5" stroke-width="2"/>
+
+  <!-- Description row -->
+  <text x="80" y="302" font-size="15" font-weight="600" fill="#15131f">Description</text>
+  <rect x="80" y="314" width="300" height="8" rx="4" fill="#eeedf5"/>
+  <rect x="80" y="328" width="220" height="8" rx="4" fill="#eeedf5"/>
+  <text x="424" y="316" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="60" y1="344" x2="450" y2="344" stroke="#eeedf5"/>
+
+  <!-- Sub-issues row -->
+  <text x="80" y="372" font-size="15" font-weight="600" fill="#15131f">Sub-issues</text>
+  <text x="262" y="372" font-size="12" fill="#7a7791">2 of 4 done</text>
+  <rect x="80" y="384" width="160" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="80" y="384" width="80" height="6" rx="3" fill="#6342db"/>
+  <text x="424" y="382" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="60" y1="410" x2="450" y2="410" stroke="#eeedf5"/>
+
+  <!-- Links row -->
+  <text x="80" y="436" font-size="15" font-weight="600" fill="#15131f">Links</text>
+  <circle cx="90" cy="456" r="8" stroke="#e0424a" stroke-width="2" fill="none"/>
+  <line x1="84.4" y1="450.4" x2="95.6" y2="461.6" stroke="#e0424a" stroke-width="2"/>
+  <text x="106" y="460" font-size="13" fill="#514e66">Blocked by</text>
+  <text x="180" y="460" font-size="13" font-weight="600" fill="#6342db">ENG-131</text>
+  <circle cx="256" cy="456" r="4" fill="#6f6c86"/>
+  <text x="266" y="460" font-size="12" fill="#7a7791">Todo</text>
+  <text x="424" y="454" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="60" y1="476" x2="450" y2="476" stroke="#eeedf5"/>
+
+  <!-- Development row -->
+  <text x="80" y="502" font-size="15" font-weight="600" fill="#15131f">Development</text>
+  <rect x="80" y="512" width="196" height="28" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <circle cx="94" cy="526" r="3.5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <text x="104" y="530" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">eng-142-drag-ghost</text>
+  <rect x="286" y="512" width="86" height="28" rx="8" fill="#12a474" fill-opacity="0.15"/>
+  <circle cx="300" cy="526" r="4" fill="#12a474"/>
+  <text x="310" y="530" font-size="12" font-weight="600" fill="#12a474">PR #87</text>
+  <text x="424" y="530" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="60" y1="552" x2="450" y2="552" stroke="#eeedf5"/>
+
+  <!-- Attachments row -->
+  <text x="80" y="588" font-size="15" font-weight="600" fill="#15131f">Attachments</text>
+  <rect x="184" y="572" width="26" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="197" y="586" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">2</text>
+  <text x="424" y="588" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="60" y1="614" x2="450" y2="614" stroke="#eeedf5"/>
+
+  <!-- Watch row -->
+  <text x="80" y="642" font-size="15" font-weight="600" fill="#15131f">Watch</text>
+  <text x="80" y="662" font-size="12" fill="#7a7791">Notify me on all activity</text>
+  <rect x="376" y="634" width="46" height="26" rx="13" fill="#6342db"/>
+  <circle cx="409" cy="647" r="10" fill="#ffffff"/>
+  <line x1="60" y1="678" x2="450" y2="678" stroke="#eeedf5"/>
+
+  <!-- Activity preview (low-fi) -->
+  <text x="80" y="706" font-size="13" font-weight="600" fill="#7a7791">Activity</text>
+  <circle cx="92" cy="736" r="11" fill="#2fd4a7"/>
+  <text x="92" y="740" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <rect x="112" y="726" width="240" height="8" rx="4" fill="#eeedf5"/>
+  <rect x="112" y="740" width="170" height="8" rx="4" fill="#eeedf5"/>
+  <circle cx="92" cy="782" r="11" fill="#ffb648"/>
+  <text x="92" y="786" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SR</text>
+  <rect x="112" y="772" width="260" height="8" rx="4" fill="#eeedf5"/>
+  <rect x="112" y="786" width="140" height="8" rx="4" fill="#eeedf5"/>
+
+  <!-- bottom nav -->
+  <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="99" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="166" y="838" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="177" y="876" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="244" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="255" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="333" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="411" cy="849" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="411" y="876" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+</g>
+
+<!-- ============ FOLDABLE ============ -->
+<g clip-path="url(#cf)">
+  <!-- status bar -->
+  <text x="554" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1188" y="124" width="3" height="4" fill="#514e66"/><rect x="1193" y="122" width="3" height="6" fill="#514e66"/><rect x="1198" y="120" width="3" height="8" fill="#514e66"/><rect x="1203" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="1212,128 1224,128 1218,119" fill="#514e66"/>
+  <rect x="1226" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="1247" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="557" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="568" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="557" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="568" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+
+  <!-- left pane: board list -->
+  <text x="622" y="175" font-size="15" font-weight="700" fill="#15131f">ENG · Active issues</text>
+  <text x="622" y="193" font-size="12" fill="#7a7791">Cycle 14 · 12 issues</text>
+
+  <text x="622" y="236" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+  <text x="622" y="256" font-size="13" fill="#15131f">Board swimlanes for cycles</text>
+  <circle cx="878" cy="242" r="5" fill="#8b5cf6"/>
+  <line x1="622" y1="282" x2="892" y2="282" stroke="#eeedf5"/>
+  <text x="622" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-140</text>
+  <text x="622" y="328" font-size="13" fill="#15131f">Offline queue for mutations</text>
+  <circle cx="878" cy="314" r="5" fill="#f29d0b"/>
+  <line x1="622" y1="354" x2="892" y2="354" stroke="#eeedf5"/>
+  <rect x="606" y="354" width="294" height="72" fill="#6342db" fill-opacity="0.08"/>
+  <rect x="606" y="354" width="4" height="72" fill="#6342db"/>
+  <text x="622" y="380" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="622" y="400" font-size="13" font-weight="600" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <circle cx="878" cy="386" r="5" fill="#f29d0b"/>
+  <line x1="622" y1="426" x2="892" y2="426" stroke="#eeedf5"/>
+  <text x="622" y="452" font-size="11" font-weight="600" fill="#7a7791">ENG-143</text>
+  <text x="622" y="472" font-size="13" fill="#15131f">Keyboard shortcuts palette</text>
+  <circle cx="878" cy="458" r="5" fill="#6f6c86"/>
+  <line x1="622" y1="498" x2="892" y2="498" stroke="#eeedf5"/>
+  <text x="622" y="524" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+  <text x="622" y="544" font-size="13" fill="#15131f">Safari transform regression</text>
+  <circle cx="878" cy="530" r="5" fill="#6f6c86"/>
+  <line x1="622" y1="570" x2="892" y2="570" stroke="#eeedf5"/>
+  <text x="622" y="596" font-size="11" font-weight="600" fill="#7a7791">ENG-145</text>
+  <text x="622" y="616" font-size="13" fill="#15131f">Sub-issue reorder jank on iPad</text>
+  <circle cx="878" cy="602" r="5" fill="#9b98b0"/>
+  <line x1="622" y1="642" x2="892" y2="642" stroke="#eeedf5"/>
+  <text x="622" y="668" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+  <text x="622" y="688" font-size="13" fill="#15131f">Empty state illustrations</text>
+  <circle cx="878" cy="674" r="5" fill="#9b98b0"/>
+  <line x1="622" y1="714" x2="892" y2="714" stroke="#eeedf5"/>
+  <text x="622" y="740" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+  <text x="622" y="760" font-size="13" fill="#15131f">Pointer capture on drag start</text>
+  <circle cx="878" cy="746" r="5" fill="#12a474"/>
+  <line x1="622" y1="786" x2="892" y2="786" stroke="#eeedf5"/>
+  <text x="622" y="812" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+  <text x="622" y="832" font-size="13" fill="#15131f">Regression test on Safari</text>
+  <circle cx="878" cy="818" r="5" fill="#6f6c86"/>
+
+  <!-- right pane: detail -->
+  <text x="916" y="172" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+  <rect x="1204" y="158" width="40" height="22" rx="11" fill="#6342db"/>
+  <circle cx="1233" cy="169" r="8" fill="#ffffff"/>
+  <text x="916" y="200" font-size="17" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <rect x="916" y="216" width="104" height="24" rx="12" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="930" cy="228" r="3.5" fill="#f29d0b"/>
+  <text x="939" y="232" font-size="11" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="1028" y="216" width="58" height="24" rx="12" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="1044" y="232" font-size="11" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="1112" cy="228" r="11" fill="#4f8cff"/>
+  <text x="1112" y="232" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <rect x="1134" y="216" width="56" height="24" rx="12" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="1146" y="232" font-size="11" font-weight="600" fill="#514e66">3 pts</text>
+
+  <line x1="900" y1="256" x2="1270" y2="256" stroke="#eeedf5"/>
+  <text x="916" y="284" font-size="14" font-weight="600" fill="#15131f">Description</text>
+  <rect x="916" y="296" width="250" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="916" y="308" width="180" height="7" rx="3.5" fill="#eeedf5"/>
+  <text x="1240" y="296" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="916" y1="326" x2="1254" y2="326" stroke="#eeedf5"/>
+
+  <text x="916" y="352" font-size="14" font-weight="600" fill="#15131f">Sub-issues</text>
+  <text x="1150" y="352" font-size="11" fill="#7a7791">2 of 4 done</text>
+  <rect x="916" y="362" width="150" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="916" y="362" width="75" height="6" rx="3" fill="#6342db"/>
+  <text x="1240" y="356" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="916" y1="384" x2="1254" y2="384" stroke="#eeedf5"/>
+
+  <text x="916" y="410" font-size="14" font-weight="600" fill="#15131f">Links</text>
+  <circle cx="925" cy="430" r="7" stroke="#e0424a" stroke-width="2" fill="none"/>
+  <line x1="920" y1="425" x2="930" y2="435" stroke="#e0424a" stroke-width="2"/>
+  <text x="940" y="434" font-size="12" fill="#514e66">Blocked by</text>
+  <text x="1010" y="434" font-size="12" font-weight="600" fill="#6342db">ENG-131</text>
+  <text x="1240" y="426" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="916" y1="450" x2="1254" y2="450" stroke="#eeedf5"/>
+
+  <text x="916" y="476" font-size="14" font-weight="600" fill="#15131f">Development</text>
+  <rect x="916" y="486" width="172" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <circle cx="928" cy="499" r="3" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <text x="936" y="503" font-size="11" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">eng-142-drag-ghost</text>
+  <rect x="1096" y="486" width="78" height="26" rx="8" fill="#12a474" fill-opacity="0.15"/>
+  <circle cx="1109" cy="499" r="3.5" fill="#12a474"/>
+  <text x="1118" y="503" font-size="11" font-weight="600" fill="#12a474">PR #87</text>
+  <line x1="916" y1="524" x2="1254" y2="524" stroke="#eeedf5"/>
+
+  <text x="916" y="550" font-size="14" font-weight="600" fill="#15131f">Attachments</text>
+  <rect x="1016" y="536" width="24" height="18" rx="9" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="1028" y="549" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">2</text>
+  <text x="1240" y="550" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="916" y1="566" x2="1254" y2="566" stroke="#eeedf5"/>
+
+  <text x="916" y="596" font-size="12" font-weight="600" fill="#7a7791">Activity</text>
+  <circle cx="928" cy="626" r="10" fill="#2fd4a7"/>
+  <text x="928" y="630" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <rect x="946" y="616" width="220" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="946" y="629" width="150" height="7" rx="3.5" fill="#eeedf5"/>
+  <circle cx="928" cy="668" r="10" fill="#ffb648"/>
+  <text x="928" y="672" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SR</text>
+  <rect x="946" y="658" width="240" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="946" y="671" width="120" height="7" rx="3.5" fill="#eeedf5"/>
+  <circle cx="928" cy="710" r="10" fill="#4f8cff"/>
+  <text x="928" y="714" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <rect x="946" y="700" width="200" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="946" y="713" width="170" height="7" rx="3.5" fill="#eeedf5"/>
+
+  <rect x="916" y="820" width="338" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="932" y="849" font-size="14" fill="#b6b3c8">Leave a comment…</text>
+</g>
+
+<!-- ============ TABLET ============ -->
+<g clip-path="url(#ct)">
+  <!-- status bar -->
+  <text x="1374" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2418" y="124" width="3" height="4" fill="#514e66"/><rect x="2423" y="122" width="3" height="6" fill="#514e66"/><rect x="2428" y="120" width="3" height="8" fill="#514e66"/><rect x="2433" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="2442,128 2454,128 2448,119" fill="#514e66"/>
+  <rect x="2456" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="2477" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="1377" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="1388" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="1377" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="1388" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- board region -->
+  <text x="1446" y="175" font-size="16" font-weight="700" fill="#15131f">ENG · Board</text>
+  <text x="1446" y="194" font-size="12" fill="#7a7791">Cycle 14 · 12 issues</text>
+
+  <rect x="1446" y="212" width="214" height="610" rx="12" fill="#f7f6fb"/>
+  <circle cx="1462" cy="234" r="4" fill="#f29d0b"/>
+  <text x="1472" y="238" font-size="13" font-weight="600" fill="#514e66">In Progress · 3</text>
+  <rect x="1458" y="254" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1470" y="276" font-size="11" font-weight="600" fill="#7a7791">ENG-140</text>
+  <text x="1470" y="296" font-size="12" fill="#15131f">Offline mutation queue</text>
+  <circle cx="1630" cy="310" r="9" fill="#2fd4a7"/>
+  <text x="1630" y="314" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <rect x="1458" y="342" width="190" height="76" rx="10" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+  <text x="1470" y="364" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="1470" y="384" font-size="12" font-weight="600" fill="#15131f">Fix drag ghost offset</text>
+  <text x="1470" y="400" font-size="12" font-weight="600" fill="#15131f">on Safari</text>
+  <circle cx="1630" cy="398" r="9" fill="#4f8cff"/>
+  <text x="1630" y="402" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <rect x="1458" y="430" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1470" y="452" font-size="11" font-weight="600" fill="#7a7791">ENG-152</text>
+  <text x="1470" y="472" font-size="12" fill="#15131f">Cycle burndown widget</text>
+  <circle cx="1630" cy="486" r="9" fill="#ffb648"/>
+  <text x="1630" y="490" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SR</text>
+  <rect x="1458" y="518" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="1470" y="538" width="60" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="1470" y="556" width="150" height="8" rx="4" fill="#eeedf5"/>
+  <rect x="1470" y="572" width="110" height="8" rx="4" fill="#eeedf5"/>
+
+  <rect x="1676" y="212" width="214" height="610" rx="12" fill="#f7f6fb"/>
+  <circle cx="1692" cy="234" r="4" fill="#8b5cf6"/>
+  <text x="1702" y="238" font-size="13" font-weight="600" fill="#514e66">In Review · 2</text>
+  <rect x="1688" y="254" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1700" y="276" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+  <text x="1700" y="296" font-size="12" fill="#15131f">Board swimlanes for</text>
+  <text x="1700" y="312" font-size="12" fill="#15131f">cycles</text>
+  <circle cx="1860" cy="310" r="9" fill="#ff6fae"/>
+  <text x="1860" y="314" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">MB</text>
+  <rect x="1688" y="342" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <text x="1700" y="364" font-size="11" font-weight="600" fill="#7a7791">ENG-133</text>
+  <text x="1700" y="384" font-size="12" fill="#15131f">Avatar upload crop</text>
+  <circle cx="1860" cy="398" r="9" fill="#2fd4a7"/>
+  <text x="1860" y="402" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <rect x="1688" y="430" width="190" height="76" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+  <rect x="1700" y="450" width="60" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="1700" y="468" width="150" height="8" rx="4" fill="#eeedf5"/>
+  <rect x="1700" y="484" width="100" height="8" rx="4" fill="#eeedf5"/>
+
+  <!-- detail panel -->
+  <line x1="1910" y1="110" x2="1910" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <text x="1934" y="172" font-size="13" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="2322" y="172" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">Watching</text>
+  <rect x="2330" y="156" width="46" height="24" rx="12" fill="#6342db"/>
+  <circle cx="2364" cy="168" r="9" fill="#ffffff"/>
+  <circle cx="2444" cy="168" r="2" fill="#514e66"/><circle cx="2452" cy="168" r="2" fill="#514e66"/><circle cx="2460" cy="168" r="2" fill="#514e66"/>
+  <text x="1934" y="206" font-size="21" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+
+  <!-- properties: two-column grid -->
+  <text x="1934" y="248" font-size="12" fill="#7a7791">Status</text>
+  <rect x="1934" y="258" width="110" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="1950" cy="271" r="4" fill="#f29d0b"/>
+  <text x="1960" y="275" font-size="12" font-weight="600" fill="#f29d0b">In Progress</text>
+  <text x="2210" y="248" font-size="12" fill="#7a7791">Priority</text>
+  <rect x="2210" y="258" width="70" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+  <rect x="2222" y="268" width="3" height="7" fill="#f2721c"/><rect x="2227" y="265" width="3" height="10" fill="#f2721c"/><rect x="2232" y="262" width="3" height="13" fill="#f2721c"/>
+  <text x="2240" y="275" font-size="12" font-weight="600" fill="#f2721c">High</text>
+  <text x="1934" y="316" font-size="12" fill="#7a7791">Assignee</text>
+  <circle cx="1947" cy="335" r="12" fill="#4f8cff"/>
+  <text x="1947" y="339" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="1966" y="340" font-size="13" fill="#15131f">Amina K.</text>
+  <text x="2210" y="316" font-size="12" fill="#7a7791">Estimate</text>
+  <rect x="2210" y="324" width="76" height="24" rx="12" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2222" y="340" font-size="12" font-weight="600" fill="#514e66">3 points</text>
+
+  <line x1="1934" y1="366" x2="2476" y2="366" stroke="#eeedf5"/>
+
+  <!-- description expanded -->
+  <text x="1934" y="392" font-size="14" font-weight="600" fill="#15131f">Description</text>
+  <text x="1934" y="414" font-size="13" fill="#514e66">Dragging a card in board view on Safari 17 offsets the drag</text>
+  <text x="1934" y="434" font-size="13" fill="#514e66">ghost by the container scroll position. Repro with two or</text>
+  <text x="1934" y="454" font-size="13" fill="#514e66">more columns scrolled horizontally.</text>
+
+  <!-- sub-issues expanded -->
+  <text x="1934" y="486" font-size="14" font-weight="600" fill="#15131f">Sub-issues</text>
+  <rect x="2246" y="478" width="140" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="2246" y="478" width="70" height="6" rx="3" fill="#6342db"/>
+  <text x="2476" y="486" font-size="12" fill="#7a7791" text-anchor="end">2 of 4 done</text>
+  <rect x="1944" y="500" width="16" height="16" rx="4" fill="#12a474"/>
+  <text x="1952" y="512" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="1970" y="513" font-size="13" fill="#7a7791">ENG-148 · Correct ghost offset math</text>
+  <rect x="1944" y="532" width="16" height="16" rx="4" fill="#12a474"/>
+  <text x="1952" y="544" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="1970" y="545" font-size="13" fill="#7a7791">ENG-149 · Pointer capture on drag start</text>
+  <rect x="1944" y="564" width="16" height="16" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="1970" y="577" font-size="13" fill="#514e66">ENG-150 · Regression test on Safari</text>
+  <rect x="1944" y="596" width="16" height="16" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="1970" y="609" font-size="13" fill="#514e66">ENG-151 · QA pass on iPad split view</text>
+
+  <!-- links -->
+  <text x="1934" y="648" font-size="14" font-weight="600" fill="#15131f">Links</text>
+  <circle cx="1943" cy="668" r="8" stroke="#e0424a" stroke-width="2" fill="none"/>
+  <line x1="1937.4" y1="662.4" x2="1948.6" y2="673.6" stroke="#e0424a" stroke-width="2"/>
+  <text x="1960" y="672" font-size="13" fill="#514e66">Blocked by</text>
+  <text x="2034" y="672" font-size="13" font-weight="600" fill="#6342db">ENG-131</text>
+  <circle cx="2108" cy="668" r="4" fill="#6f6c86"/>
+  <text x="2118" y="672" font-size="12" fill="#7a7791">Todo</text>
+
+  <!-- development -->
+  <text x="1934" y="704" font-size="14" font-weight="600" fill="#15131f">Development</text>
+  <rect x="1934" y="714" width="190" height="28" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <circle cx="1948" cy="728" r="3.5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <text x="1958" y="732" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">eng-142-drag-ghost</text>
+  <rect x="2134" y="714" width="88" height="28" rx="8" fill="#12a474" fill-opacity="0.15"/>
+  <circle cx="2148" cy="728" r="4" fill="#12a474"/>
+  <text x="2158" y="732" font-size="12" font-weight="600" fill="#12a474">PR #87</text>
+  <text x="2236" y="732" font-size="12" fill="#7a7791">2 commits · updated 1h ago</text>
+
+  <!-- attachments -->
+  <text x="1934" y="776" font-size="14" font-weight="600" fill="#15131f">Attachments (2)</text>
+  <rect x="1934" y="788" width="96" height="64" rx="8" fill="#eeedf5"/>
+  <polygon points="1946,842 1964,814 1974,828 1984,812 2018,842" fill="#b6b3c8"/>
+  <circle cx="1956" cy="804" r="5" fill="#b6b3c8"/>
+  <rect x="2042" y="788" width="96" height="64" rx="8" fill="#eeedf5"/>
+  <circle cx="2090" cy="820" r="18" stroke="#b6b3c8" stroke-width="3" fill="none"/>
+</g>
+
+<!-- Frame borders on top -->
+<rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+<!-- Footer -->
+<text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Issue detail pushes as a full screen on phone; on foldable and tablet it docks as a persistent split pane beside the board list.</text>
+</svg>

--- a/docs/design/mobile/145-comments.svg
+++ b/docs/design/mobile/145-comments.svg
@@ -1,0 +1,404 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+<rect width="2560" height="1000" fill="#eef0f8"/>
+<defs>
+<clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+<clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+<clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+</defs>
+
+<!-- Title block -->
+<text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Comments &amp; markdown</text>
+<text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+<!-- Frame labels -->
+<text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+<text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+<text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+<!-- Frame shadows + fills -->
+<rect x="60" y="115" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="530" y="115" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="1350" y="115" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff"/>
+
+<!-- ============ PHONE ============ -->
+<g clip-path="url(#cp)">
+  <!-- status bar -->
+  <text x="84" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="368" y="124" width="3" height="4" fill="#514e66"/><rect x="373" y="122" width="3" height="6" fill="#514e66"/><rect x="378" y="120" width="3" height="8" fill="#514e66"/><rect x="383" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="392,128 404,128 398,119" fill="#514e66"/>
+  <rect x="406" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="427" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- header -->
+  <text x="80" y="174" font-size="20" fill="#514e66">‹</text>
+  <text x="255" y="168" font-size="16" font-weight="600" fill="#15131f" text-anchor="middle">Comments</text>
+  <text x="255" y="187" font-size="11" fill="#7a7791" text-anchor="middle">ENG-142 · Fix drag ghost offset on Safari</text>
+  <line x1="60" y1="200" x2="450" y2="200" stroke="#eeedf5" stroke-width="2"/>
+
+  <!-- comment 1: rendered markdown -->
+  <circle cx="94" cy="228" r="14" fill="#4f8cff"/>
+  <text x="94" y="232" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="118" y="226" font-size="13" font-weight="600" fill="#15131f">Amina K.</text>
+  <text x="186" y="226" font-size="12" fill="#b6b3c8">2h ago</text>
+  <text x="118" y="258" font-size="15" font-weight="700" fill="#15131f">Repro steps</text>
+  <rect x="118" y="274" width="16" height="16" rx="4" fill="#12a474"/>
+  <text x="126" y="286" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="142" y="286" font-size="13" fill="#7a7791">Reproduce with two columns scrolled</text>
+  <rect x="118" y="300" width="16" height="16" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="142" y="312" font-size="13" fill="#514e66">Verify ghost stays under pointer</text>
+  <rect x="118" y="328" width="92" height="22" rx="11" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="130" y="343" font-size="11" font-weight="600" fill="#7a7791">2 of 4 tasks</text>
+  <text x="118" y="373" font-size="13" fill="#514e66">Offset comes from</text>
+  <rect x="240" y="358" width="160" height="22" rx="5" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="248" y="373" font-size="11" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">transform: translate()</text>
+  <text x="118" y="397" font-size="13" fill="#514e66">applied before layout on Safari.</text>
+  <line x1="80" y1="412" x2="430" y2="412" stroke="#eeedf5"/>
+
+  <!-- automation comment -->
+  <circle cx="94" cy="438" r="12" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="94" cy="438" r="5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <rect x="92.5" y="428" width="3" height="4" fill="#7a7791"/>
+  <rect x="92.5" y="444" width="3" height="4" fill="#7a7791"/>
+  <rect x="84" y="436.5" width="4" height="3" fill="#7a7791"/>
+  <rect x="100" y="436.5" width="4" height="3" fill="#7a7791"/>
+  <text x="116" y="436" font-size="13" font-style="italic" fill="#7a7791">Automation moved this to In Progress</text>
+  <text x="116" y="454" font-size="11" fill="#b6b3c8">1h ago</text>
+  <line x1="80" y1="470" x2="430" y2="470" stroke="#eeedf5"/>
+
+  <!-- comment 2 -->
+  <circle cx="94" cy="496" r="14" fill="#2fd4a7"/>
+  <text x="94" y="500" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <text x="118" y="494" font-size="13" font-weight="600" fill="#15131f">Dev P.</text>
+  <text x="168" y="494" font-size="12" fill="#b6b3c8">45m ago</text>
+  <text x="118" y="520" font-size="13" fill="#514e66">Pushed a candidate fix — ghost now anchors</text>
+  <text x="118" y="540" font-size="13" fill="#514e66">to the pointer. Verified on Safari 17.4.</text>
+
+  <!-- day divider -->
+  <line x1="80" y1="580" x2="225" y2="580" stroke="#eeedf5"/>
+  <line x1="285" y1="580" x2="430" y2="580" stroke="#eeedf5"/>
+  <text x="255" y="585" font-size="11" fill="#b6b3c8" text-anchor="middle">Today</text>
+
+  <!-- @mention autocomplete popup -->
+  <rect x="80" y="632" width="310" height="108" rx="12" fill="#26243a" opacity="0.08"/>
+  <rect x="80" y="628" width="310" height="108" rx="12" fill="#ffffff" stroke="#dedcea"/>
+  <text x="96" y="652" font-size="11" fill="#b6b3c8">Members matching “@am”</text>
+  <rect x="88" y="662" width="294" height="32" rx="8" fill="#f7f6fb"/>
+  <circle cx="106" cy="678" r="11" fill="#4f8cff"/>
+  <text x="106" y="682" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="124" y="682" font-size="13" font-weight="600" fill="#15131f">Amina K.</text>
+  <text x="202" y="682" font-size="12" fill="#b6b3c8">@amina</text>
+  <circle cx="106" cy="712" r="11" fill="#2fd4a7"/>
+  <text x="106" y="716" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AD</text>
+  <text x="124" y="716" font-size="13" font-weight="600" fill="#15131f">Amir D.</text>
+  <text x="192" y="716" font-size="12" fill="#b6b3c8">@amir</text>
+
+  <!-- composer -->
+  <circle cx="96" cy="778" r="16" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="96" y="784" font-size="16" fill="#514e66" text-anchor="middle">+</text>
+  <rect x="122" y="754" width="244" height="48" rx="10" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+  <text x="138" y="784" font-size="15" fill="#15131f">@am</text>
+  <line x1="174" y1="766" x2="174" y2="790" stroke="#6342db" stroke-width="2"/>
+  <circle cx="402" cy="778" r="20" fill="#6342db"/>
+  <polygon points="395,769 413,778 395,787" fill="#ffffff"/>
+
+  <!-- bottom nav -->
+  <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="99" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="166" y="838" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="177" y="876" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="244" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="255" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="333" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="411" cy="849" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="411" y="876" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+</g>
+
+<!-- ============ FOLDABLE ============ -->
+<g clip-path="url(#cf)">
+  <!-- status bar -->
+  <text x="554" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1188" y="124" width="3" height="4" fill="#514e66"/><rect x="1193" y="122" width="3" height="6" fill="#514e66"/><rect x="1198" y="120" width="3" height="8" fill="#514e66"/><rect x="1203" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="1212,128 1224,128 1218,119" fill="#514e66"/>
+  <rect x="1226" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="1247" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="557" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="568" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="557" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="568" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+
+  <!-- left pane: issue description + properties -->
+  <text x="622" y="172" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="622" y="198" font-size="17" font-weight="700" fill="#15131f">Fix drag ghost offset</text>
+  <text x="622" y="220" font-size="17" font-weight="700" fill="#15131f">on Safari</text>
+  <rect x="622" y="240" width="100" height="24" rx="12" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="636" cy="252" r="3.5" fill="#f29d0b"/>
+  <text x="645" y="256" font-size="11" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="730" y="240" width="54" height="24" rx="12" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="744" y="256" font-size="11" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="806" cy="252" r="11" fill="#4f8cff"/>
+  <text x="806" y="256" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <line x1="622" y1="284" x2="884" y2="284" stroke="#eeedf5"/>
+  <text x="622" y="310" font-size="13" font-weight="600" fill="#15131f">Description</text>
+  <text x="622" y="332" font-size="12" fill="#514e66">Dragging a card in board view on</text>
+  <text x="622" y="350" font-size="12" fill="#514e66">Safari 17 offsets the ghost by the</text>
+  <text x="622" y="368" font-size="12" fill="#514e66">container scroll position.</text>
+  <line x1="622" y1="392" x2="884" y2="392" stroke="#eeedf5"/>
+  <text x="622" y="418" font-size="12" fill="#7a7791">Estimate</text>
+  <text x="884" y="418" font-size="12" fill="#514e66" text-anchor="end">3 points</text>
+  <text x="622" y="446" font-size="12" fill="#7a7791">Cycle</text>
+  <text x="884" y="446" font-size="12" fill="#514e66" text-anchor="end">Cycle 14</text>
+  <text x="622" y="474" font-size="12" fill="#7a7791">Labels</text>
+  <rect x="836" y="460" width="48" height="20" rx="10" fill="#f2647d" fill-opacity="0.15"/>
+  <text x="850" y="474" font-size="11" font-weight="600" fill="#f2647d">bug</text>
+  <line x1="622" y1="500" x2="884" y2="500" stroke="#eeedf5"/>
+  <text x="622" y="526" font-size="13" font-weight="600" fill="#15131f">Sub-issues</text>
+  <text x="884" y="526" font-size="11" fill="#7a7791" text-anchor="end">2 of 4 done</text>
+  <rect x="622" y="538" width="262" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="622" y="538" width="131" height="6" rx="3" fill="#6342db"/>
+  <text x="622" y="580" font-size="13" font-weight="600" fill="#15131f">Links</text>
+  <circle cx="630" cy="600" r="7" stroke="#e0424a" stroke-width="2" fill="none"/>
+  <line x1="625" y1="595" x2="635" y2="605" stroke="#e0424a" stroke-width="2"/>
+  <text x="644" y="604" font-size="12" fill="#514e66">Blocked by</text>
+  <text x="714" y="604" font-size="12" font-weight="600" fill="#6342db">ENG-131</text>
+  <text x="622" y="646" font-size="13" font-weight="600" fill="#15131f">Development</text>
+  <rect x="622" y="658" width="170" height="24" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="632" y="674" font-size="11" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">eng-142-drag-ghost</text>
+  <rect x="622" y="690" width="76" height="24" rx="8" fill="#12a474" fill-opacity="0.15"/>
+  <circle cx="635" cy="702" r="3.5" fill="#12a474"/>
+  <text x="644" y="706" font-size="11" font-weight="600" fill="#12a474">PR #87</text>
+  <text x="622" y="748" font-size="12" font-weight="600" fill="#7a7791">Activity</text>
+  <rect x="622" y="762" width="230" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="622" y="778" width="180" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="622" y="794" width="210" height="7" rx="3.5" fill="#eeedf5"/>
+
+  <!-- right pane: comment thread -->
+  <text x="916" y="172" font-size="15" font-weight="700" fill="#15131f">Comments · 4</text>
+  <line x1="900" y1="188" x2="1270" y2="188" stroke="#eeedf5"/>
+  <circle cx="930" cy="214" r="13" fill="#4f8cff"/>
+  <text x="930" y="218" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="952" y="212" font-size="13" font-weight="600" fill="#15131f">Amina K.</text>
+  <text x="1022" y="212" font-size="11" fill="#b6b3c8">2h ago</text>
+  <text x="952" y="244" font-size="14" font-weight="700" fill="#15131f">Repro steps</text>
+  <rect x="952" y="258" width="15" height="15" rx="4" fill="#12a474"/>
+  <text x="959.5" y="269.5" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="974" y="270" font-size="12" fill="#7a7791">Reproduce with two columns scrolled</text>
+  <rect x="952" y="282" width="15" height="15" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="974" y="294" font-size="12" fill="#514e66">Verify ghost stays under pointer</text>
+  <rect x="952" y="306" width="88" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="964" y="320" font-size="11" font-weight="600" fill="#7a7791">2 of 4 tasks</text>
+  <text x="952" y="352" font-size="12" fill="#514e66">Offset comes from</text>
+  <rect x="1064" y="338" width="158" height="20" rx="5" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="1071" y="352" font-size="11" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">transform: translate()</text>
+  <line x1="916" y1="378" x2="1254" y2="378" stroke="#eeedf5"/>
+  <circle cx="930" cy="404" r="11" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="930" cy="404" r="4.5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <rect x="928.5" y="395" width="3" height="4" fill="#7a7791"/>
+  <rect x="928.5" y="409" width="3" height="4" fill="#7a7791"/>
+  <rect x="921" y="402.5" width="4" height="3" fill="#7a7791"/>
+  <rect x="935" y="402.5" width="4" height="3" fill="#7a7791"/>
+  <text x="950" y="402" font-size="12" font-style="italic" fill="#7a7791">Automation moved this to In Progress</text>
+  <text x="950" y="418" font-size="11" fill="#b6b3c8">1h ago</text>
+  <line x1="916" y1="436" x2="1254" y2="436" stroke="#eeedf5"/>
+  <circle cx="930" cy="462" r="13" fill="#2fd4a7"/>
+  <text x="930" y="466" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <text x="952" y="460" font-size="13" font-weight="600" fill="#15131f">Dev P.</text>
+  <text x="1004" y="460" font-size="11" fill="#b6b3c8">45m ago</text>
+  <text x="952" y="490" font-size="12" fill="#514e66">Pushed a candidate fix — ghost now</text>
+  <text x="952" y="508" font-size="12" fill="#514e66">anchors to the pointer. Verified on</text>
+  <text x="952" y="526" font-size="12" fill="#514e66">Safari 17.4.</text>
+  <circle cx="930" cy="564" r="13" fill="#ffb648"/>
+  <text x="930" y="568" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SR</text>
+  <text x="952" y="562" font-size="13" font-weight="600" fill="#15131f">Sara R.</text>
+  <text x="1008" y="562" font-size="11" fill="#b6b3c8">12m ago</text>
+  <text x="952" y="592" font-size="12" fill="#514e66">Nice — retesting on the iPad build now.</text>
+
+  <!-- composer -->
+  <rect x="916" y="812" width="274" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="932" y="842" font-size="14" fill="#b6b3c8">Leave a comment…</text>
+  <circle cx="1224" cy="836" r="20" fill="#6342db"/>
+  <polygon points="1217,827 1235,836 1217,845" fill="#ffffff"/>
+</g>
+
+<!-- ============ TABLET ============ -->
+<g clip-path="url(#ct)">
+  <!-- status bar -->
+  <text x="1374" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2418" y="124" width="3" height="4" fill="#514e66"/><rect x="2423" y="122" width="3" height="6" fill="#514e66"/><rect x="2428" y="120" width="3" height="8" fill="#514e66"/><rect x="2433" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="2442,128 2454,128 2448,119" fill="#514e66"/>
+  <rect x="2456" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="2477" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="1377" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="1388" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="1377" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="1388" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- left region: issue detail -->
+  <text x="1450" y="172" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+  <rect x="1930" y="158" width="46" height="24" rx="12" fill="#6342db"/>
+  <circle cx="1964" cy="170" r="9" fill="#ffffff"/>
+  <text x="1450" y="206" font-size="20" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <rect x="1450" y="226" width="110" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="1466" cy="239" r="4" fill="#f29d0b"/>
+  <text x="1476" y="243" font-size="12" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="1568" y="226" width="64" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="1584" y="243" font-size="12" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="1660" cy="239" r="12" fill="#4f8cff"/>
+  <text x="1660" y="243" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="1680" y="243" font-size="13" fill="#15131f">Amina K.</text>
+  <rect x="1770" y="226" width="64" height="26" rx="13" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="1784" y="243" font-size="12" font-weight="600" fill="#514e66">3 pts</text>
+  <line x1="1450" y1="272" x2="1976" y2="272" stroke="#eeedf5"/>
+
+  <text x="1450" y="300" font-size="14" font-weight="600" fill="#15131f">Description</text>
+  <text x="1450" y="324" font-size="13" fill="#514e66">Dragging a card in board view on Safari 17 offsets the</text>
+  <text x="1450" y="344" font-size="13" fill="#514e66">drag ghost by the container scroll position. Repro with</text>
+  <text x="1450" y="364" font-size="13" fill="#514e66">two or more columns scrolled horizontally.</text>
+
+  <text x="1450" y="400" font-size="14" font-weight="600" fill="#15131f">Sub-issues</text>
+  <rect x="1690" y="392" width="140" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="1690" y="392" width="70" height="6" rx="3" fill="#6342db"/>
+  <text x="1976" y="400" font-size="12" fill="#7a7791" text-anchor="end">2 of 4 done</text>
+  <rect x="1458" y="414" width="15" height="15" rx="4" fill="#12a474"/>
+  <text x="1465.5" y="425.5" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="1482" y="426" font-size="13" fill="#7a7791">ENG-148 · Correct ghost offset math</text>
+  <rect x="1458" y="442" width="15" height="15" rx="4" fill="#12a474"/>
+  <text x="1465.5" y="453.5" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="1482" y="454" font-size="13" fill="#7a7791">ENG-149 · Pointer capture on drag start</text>
+  <rect x="1458" y="470" width="15" height="15" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="1482" y="482" font-size="13" fill="#514e66">ENG-150 · Regression test on Safari</text>
+  <rect x="1458" y="498" width="15" height="15" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="1482" y="510" font-size="13" fill="#514e66">ENG-151 · QA pass on iPad split view</text>
+
+  <text x="1450" y="556" font-size="14" font-weight="600" fill="#15131f">Links</text>
+  <circle cx="1459" cy="578" r="8" stroke="#e0424a" stroke-width="2" fill="none"/>
+  <line x1="1453.4" y1="572.4" x2="1464.6" y2="583.6" stroke="#e0424a" stroke-width="2"/>
+  <text x="1476" y="582" font-size="13" fill="#514e66">Blocked by</text>
+  <text x="1550" y="582" font-size="13" font-weight="600" fill="#6342db">ENG-131</text>
+  <circle cx="1624" cy="578" r="4" fill="#6f6c86"/>
+  <text x="1634" y="582" font-size="12" fill="#7a7791">Todo</text>
+
+  <text x="1450" y="626" font-size="14" font-weight="600" fill="#15131f">Development</text>
+  <rect x="1450" y="638" width="190" height="28" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <circle cx="1464" cy="652" r="3.5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <text x="1474" y="656" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">eng-142-drag-ghost</text>
+  <rect x="1650" y="638" width="86" height="28" rx="8" fill="#12a474" fill-opacity="0.15"/>
+  <circle cx="1664" cy="652" r="4" fill="#12a474"/>
+  <text x="1674" y="656" font-size="12" font-weight="600" fill="#12a474">PR #87</text>
+
+  <text x="1450" y="708" font-size="14" font-weight="600" fill="#15131f">Attachments (2)</text>
+  <rect x="1450" y="720" width="92" height="62" rx="8" fill="#eeedf5"/>
+  <polygon points="1461,776 1478,750 1488,763 1497,748 1530,776" fill="#b6b3c8"/>
+  <circle cx="1471" cy="736" r="5" fill="#b6b3c8"/>
+  <rect x="1556" y="720" width="92" height="62" rx="8" fill="#eeedf5"/>
+  <circle cx="1602" cy="751" r="17" stroke="#b6b3c8" stroke-width="3" fill="none"/>
+  <text x="1450" y="824" font-size="12" font-weight="600" fill="#7a7791">Activity</text>
+  <rect x="1450" y="838" width="300" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="1450" y="854" width="220" height="7" rx="3.5" fill="#eeedf5"/>
+
+  <!-- divider between detail and comments -->
+  <line x1="2000" y1="110" x2="2000" y2="890" stroke="#eeedf5" stroke-width="2"/>
+
+  <!-- right region: comments -->
+  <text x="2024" y="172" font-size="15" font-weight="700" fill="#15131f">Comments · 5</text>
+  <line x1="2000" y1="188" x2="2500" y2="188" stroke="#eeedf5"/>
+
+  <!-- comment with autolinked issue id -->
+  <circle cx="2038" cy="214" r="13" fill="#2fd4a7"/>
+  <text x="2038" y="218" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+  <text x="2060" y="212" font-size="13" font-weight="600" fill="#15131f">Dev P.</text>
+  <text x="2112" y="212" font-size="11" fill="#b6b3c8">3h ago</text>
+  <text x="2060" y="242" font-size="13" fill="#514e66">Likely a regression from</text>
+  <text x="2226" y="242" font-size="13" font-weight="600" fill="#6342db">ENG-131</text>
+  <text x="2288" y="242" font-size="13" fill="#514e66">— same</text>
+  <text x="2060" y="262" font-size="13" fill="#514e66">transform path on Safari.</text>
+  <line x1="2024" y1="286" x2="2476" y2="286" stroke="#eeedf5"/>
+
+  <!-- markdown comment -->
+  <circle cx="2038" cy="312" r="13" fill="#4f8cff"/>
+  <text x="2038" y="316" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="2060" y="310" font-size="13" font-weight="600" fill="#15131f">Amina K.</text>
+  <text x="2132" y="310" font-size="11" fill="#b6b3c8">2h ago</text>
+  <text x="2060" y="342" font-size="14" font-weight="700" fill="#15131f">Repro steps</text>
+  <rect x="2060" y="356" width="15" height="15" rx="4" fill="#12a474"/>
+  <text x="2067.5" y="367.5" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+  <text x="2082" y="368" font-size="12" fill="#7a7791">Reproduce with two columns scrolled</text>
+  <rect x="2060" y="380" width="15" height="15" rx="4" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+  <text x="2082" y="392" font-size="12" fill="#514e66">Verify ghost stays under pointer</text>
+  <rect x="2060" y="404" width="88" height="20" rx="10" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2072" y="418" font-size="11" font-weight="600" fill="#7a7791">2 of 4 tasks</text>
+  <text x="2060" y="450" font-size="12" fill="#514e66">Offset comes from</text>
+  <rect x="2172" y="436" width="158" height="20" rx="5" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2179" y="450" font-size="11" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66">transform: translate()</text>
+  <line x1="2024" y1="474" x2="2476" y2="474" stroke="#eeedf5"/>
+
+  <!-- automation -->
+  <circle cx="2038" cy="500" r="11" fill="#f7f6fb" stroke="#dedcea"/>
+  <circle cx="2038" cy="500" r="4.5" stroke="#7a7791" stroke-width="1.5" fill="none"/>
+  <rect x="2036.5" y="491" width="3" height="4" fill="#7a7791"/>
+  <rect x="2036.5" y="505" width="3" height="4" fill="#7a7791"/>
+  <rect x="2029" y="498.5" width="4" height="3" fill="#7a7791"/>
+  <rect x="2043" y="498.5" width="4" height="3" fill="#7a7791"/>
+  <text x="2058" y="498" font-size="12" font-style="italic" fill="#7a7791">Automation moved this to In Progress</text>
+  <text x="2058" y="514" font-size="11" fill="#b6b3c8">1h ago</text>
+  <line x1="2024" y1="532" x2="2476" y2="532" stroke="#eeedf5"/>
+
+  <!-- comment -->
+  <circle cx="2038" cy="558" r="13" fill="#ffb648"/>
+  <text x="2038" y="562" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SR</text>
+  <text x="2060" y="556" font-size="13" font-weight="600" fill="#15131f">Sara R.</text>
+  <text x="2116" y="556" font-size="11" fill="#b6b3c8">12m ago</text>
+  <text x="2060" y="586" font-size="12" fill="#514e66">Nice — retesting on the iPad build now.</text>
+
+  <!-- markdown toolbar -->
+  <rect x="2024" y="748" width="34" height="30" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2041" y="769" font-size="15" font-weight="700" fill="#514e66" text-anchor="middle">B</text>
+  <rect x="2066" y="748" width="34" height="30" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2083" y="769" font-size="15" font-style="italic" fill="#514e66" text-anchor="middle">i</text>
+  <rect x="2108" y="748" width="34" height="30" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <text x="2125" y="768" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, monospace" fill="#514e66" text-anchor="middle">&lt;&gt;</text>
+  <rect x="2150" y="748" width="34" height="30" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+  <rect x="2161" y="757" width="12" height="12" rx="3" stroke="#514e66" stroke-width="1.5" fill="none"/>
+  <text x="2167" y="767" font-size="9" font-weight="700" fill="#514e66" text-anchor="middle">✓</text>
+
+  <!-- composer -->
+  <rect x="2024" y="792" width="396" height="52" rx="10" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2040" y="824" font-size="14" fill="#b6b3c8">Leave a comment… @ to mention</text>
+  <circle cx="2452" cy="818" r="22" fill="#6342db"/>
+  <polygon points="2444,808 2464,818 2444,828" fill="#ffffff"/>
+</g>
+
+<!-- Frame borders on top -->
+<rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+<!-- Footer -->
+<text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Rendered markdown stays interactive on every size class — task-list checkboxes toggle in place and sync back to the comment source.</text>
+</svg>

--- a/docs/design/mobile/146-attachments.svg
+++ b/docs/design/mobile/146-attachments.svg
@@ -1,0 +1,317 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+<rect width="2560" height="1000" fill="#eef0f8"/>
+<defs>
+<clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+<clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+<clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+</defs>
+
+<!-- Title block -->
+<text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Attachments: camera, library, files</text>
+<text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+<!-- Frame labels -->
+<text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+<text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+<text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+<!-- Frame shadows + fills -->
+<rect x="60" y="115" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="530" y="115" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="1350" y="115" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+<rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff"/>
+
+<!-- ============ PHONE ============ -->
+<g clip-path="url(#cp)">
+  <!-- status bar -->
+  <text x="84" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="368" y="124" width="3" height="4" fill="#514e66"/><rect x="373" y="122" width="3" height="6" fill="#514e66"/><rect x="378" y="120" width="3" height="8" fill="#514e66"/><rect x="383" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="392,128 404,128 398,119" fill="#514e66"/>
+  <rect x="406" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="427" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- header -->
+  <text x="80" y="172" font-size="20" fill="#514e66">‹</text>
+  <text x="102" y="170" font-size="12" font-weight="600" fill="#7a7791">ENG-142 · Fix drag ghost offset on Safari</text>
+  <text x="80" y="210" font-size="20" font-weight="700" fill="#15131f">Attachments</text>
+  <text x="222" y="208" font-size="13" fill="#7a7791">4 files</text>
+
+  <!-- inline image thumbnails -->
+  <rect x="80" y="232" width="170" height="116" rx="12" fill="#eeedf5"/>
+  <polygon points="96,332 140,262 166,300 190,266 234,332" fill="#b6b3c8"/>
+  <circle cx="118" cy="264" r="8" fill="#b6b3c8"/>
+  <rect x="260" y="232" width="170" height="116" rx="12" fill="#eeedf5"/>
+  <circle cx="345" cy="290" r="30" stroke="#b6b3c8" stroke-width="3" fill="none"/>
+  <text x="80" y="368" font-size="11" fill="#7a7791">board-before.png</text>
+  <text x="260" y="368" font-size="11" fill="#7a7791">drag-ghost-repro.png</text>
+
+  <!-- file row -->
+  <rect x="80" y="388" width="38" height="48" rx="6" fill="#ffffff" stroke="#dedcea"/>
+  <polygon points="106,388 118,388 118,400" fill="#eeedf5"/>
+  <text x="99" y="426" font-size="10" font-weight="700" fill="#e0424a" text-anchor="middle">PDF</text>
+  <text x="130" y="408" font-size="14" fill="#15131f">design-spec.pdf</text>
+  <text x="235" y="408" font-size="14" fill="#7a7791">· 1.2 MB</text>
+  <text x="130" y="428" font-size="12" fill="#7a7791">Added 2d ago by Sara R.</text>
+  <text x="424" y="416" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+  <line x1="80" y1="452" x2="430" y2="452" stroke="#eeedf5"/>
+
+  <!-- upload in progress row -->
+  <rect x="80" y="466" width="38" height="48" rx="6" fill="#f7f6fb" stroke="#dedcea"/>
+  <text x="99" y="496" font-size="10" font-weight="700" fill="#7a7791" text-anchor="middle">MOV</text>
+  <text x="130" y="486" font-size="14" fill="#15131f">screen-capture.mov</text>
+  <text x="130" y="506" font-size="12" fill="#7a7791">Uploading…</text>
+  <rect x="130" y="516" width="240" height="6" rx="3" fill="#eeedf5"/>
+  <rect x="130" y="516" width="144" height="6" rx="3" fill="#6342db"/>
+  <text x="382" y="522" font-size="11" fill="#7a7791">60%</text>
+
+  <!-- bottom nav (under scrim) -->
+  <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="88" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="99" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="166" y="838" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="177" y="876" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="244" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="255" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="322" y="838" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="333" y="876" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="411" cy="849" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="411" y="876" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- scrim + bottom sheet -->
+  <rect x="60" y="110" width="390" height="780" fill="#15131f" opacity="0.3"/>
+  <rect x="60" y="612" width="390" height="278" rx="18" fill="#ffffff"/>
+  <rect x="237" y="626" width="36" height="5" rx="2.5" fill="#dedcea"/>
+  <text x="80" y="660" font-size="15" font-weight="700" fill="#15131f">Add attachment</text>
+
+  <!-- take photo -->
+  <rect x="82" y="692" width="30" height="22" rx="5" stroke="#514e66" stroke-width="2" fill="none"/>
+  <rect x="90" y="686" width="10" height="5" rx="2" fill="#514e66"/>
+  <circle cx="97" cy="703" r="6" stroke="#514e66" stroke-width="2" fill="none"/>
+  <text x="126" y="709" font-size="15" fill="#15131f">Take photo</text>
+  <line x1="80" y1="736" x2="430" y2="736" stroke="#eeedf5"/>
+
+  <!-- photo library -->
+  <rect x="82" y="750" width="26" height="26" rx="5" stroke="#514e66" stroke-width="2" fill="none"/>
+  <polygon points="86,772 94,762 99,767 103,760 105,772" fill="#514e66"/>
+  <circle cx="90" cy="757" r="2.5" fill="#514e66"/>
+  <text x="126" y="769" font-size="15" fill="#15131f">Photo library</text>
+  <line x1="80" y1="796" x2="430" y2="796" stroke="#eeedf5"/>
+
+  <!-- browse files -->
+  <rect x="82" y="814" width="28" height="18" rx="3" stroke="#514e66" stroke-width="2" fill="none"/>
+  <rect x="82" y="809" width="12" height="6" rx="2" fill="#514e66"/>
+  <text x="126" y="829" font-size="15" fill="#15131f">Browse files</text>
+</g>
+
+<!-- ============ FOLDABLE ============ -->
+<g clip-path="url(#cf)">
+  <!-- status bar -->
+  <text x="554" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="1188" y="124" width="3" height="4" fill="#514e66"/><rect x="1193" y="122" width="3" height="6" fill="#514e66"/><rect x="1198" y="120" width="3" height="8" fill="#514e66"/><rect x="1203" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="1212,128 1224,128 1218,119" fill="#514e66"/>
+  <rect x="1226" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="1247" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="557" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="557" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="568" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="557" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="557" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="568" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="568" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- hinge -->
+  <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6"/>
+
+  <!-- left pane: issue with attachment list -->
+  <text x="622" y="172" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="622" y="198" font-size="17" font-weight="700" fill="#15131f">Fix drag ghost offset</text>
+  <text x="622" y="220" font-size="17" font-weight="700" fill="#15131f">on Safari</text>
+  <rect x="622" y="240" width="100" height="24" rx="12" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="636" cy="252" r="3.5" fill="#f29d0b"/>
+  <text x="645" y="256" font-size="11" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="730" y="240" width="54" height="24" rx="12" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="744" y="256" font-size="11" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="806" cy="252" r="11" fill="#4f8cff"/>
+  <text x="806" y="256" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <line x1="622" y1="284" x2="884" y2="284" stroke="#eeedf5"/>
+  <text x="622" y="310" font-size="13" font-weight="600" fill="#15131f">Attachments · 4</text>
+
+  <rect x="622" y="326" width="64" height="44" rx="8" fill="#eeedf5"/>
+  <polygon points="629,364 645,340 653,350 660,340 679,364" fill="#b6b3c8"/>
+  <text x="698" y="344" font-size="12" fill="#15131f">board-before.png</text>
+  <text x="698" y="362" font-size="11" fill="#7a7791">1.8 MB</text>
+
+  <rect x="606" y="388" width="294" height="62" fill="#6342db" fill-opacity="0.08"/>
+  <rect x="606" y="388" width="4" height="62" fill="#6342db"/>
+  <rect x="622" y="396" width="64" height="44" rx="8" fill="#eeedf5"/>
+  <circle cx="654" cy="418" r="14" stroke="#b6b3c8" stroke-width="3" fill="none"/>
+  <text x="698" y="414" font-size="12" font-weight="600" fill="#15131f">drag-ghost-repro.png</text>
+  <text x="698" y="432" font-size="11" fill="#7a7791">2.1 MB · viewing</text>
+
+  <rect x="622" y="466" width="34" height="44" rx="6" fill="#ffffff" stroke="#dedcea"/>
+  <text x="639" y="494" font-size="10" font-weight="700" fill="#e0424a" text-anchor="middle">PDF</text>
+  <text x="672" y="484" font-size="12" fill="#15131f">design-spec.pdf</text>
+  <text x="672" y="502" font-size="11" fill="#7a7791">1.2 MB</text>
+
+  <rect x="622" y="536" width="34" height="44" rx="6" fill="#f7f6fb" stroke="#dedcea"/>
+  <text x="639" y="564" font-size="10" font-weight="700" fill="#7a7791" text-anchor="middle">MOV</text>
+  <text x="672" y="554" font-size="12" fill="#15131f">screen-capture.mov</text>
+  <rect x="672" y="564" width="160" height="5" rx="2.5" fill="#eeedf5"/>
+  <rect x="672" y="564" width="96" height="5" rx="2.5" fill="#6342db"/>
+  <text x="842" y="570" font-size="11" fill="#7a7791">60%</text>
+
+  <line x1="622" y1="610" x2="884" y2="610" stroke="#eeedf5"/>
+  <text x="622" y="640" font-size="12" font-weight="600" fill="#7a7791">Description</text>
+  <rect x="622" y="654" width="240" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="622" y="670" width="190" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="622" y="686" width="210" height="7" rx="3.5" fill="#eeedf5"/>
+  <text x="622" y="734" font-size="12" font-weight="600" fill="#7a7791">Activity</text>
+  <rect x="622" y="748" width="230" height="7" rx="3.5" fill="#eeedf5"/>
+  <rect x="622" y="764" width="170" height="7" rx="3.5" fill="#eeedf5"/>
+
+  <!-- right pane: full-screen image viewer -->
+  <rect x="900" y="138" width="370" height="752" fill="#15131f"/>
+  <text x="1236" y="178" font-size="22" fill="#eef0f8" text-anchor="middle">×</text>
+  <rect x="966" y="330" width="240" height="170" rx="10" fill="#26243a" stroke="#514e66"/>
+  <polygon points="992,478 1042,400 1068,438 1096,404 1180,478" fill="#7a7791"/>
+  <circle cx="1010" cy="372" r="9" fill="#7a7791"/>
+  <text x="930" y="424" font-size="26" fill="#7a7791" text-anchor="middle">‹</text>
+  <text x="1242" y="424" font-size="26" fill="#7a7791" text-anchor="middle">›</text>
+  <text x="1086" y="838" font-size="13" fill="#eef0f8" text-anchor="middle">drag-ghost-repro.png</text>
+  <text x="1086" y="858" font-size="11" fill="#7a7791" text-anchor="middle">2 of 4 · 2.1 MB</text>
+</g>
+
+<!-- ============ TABLET ============ -->
+<g clip-path="url(#ct)">
+  <!-- status bar -->
+  <text x="1374" y="129" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+  <rect x="2418" y="124" width="3" height="4" fill="#514e66"/><rect x="2423" y="122" width="3" height="6" fill="#514e66"/><rect x="2428" y="120" width="3" height="8" fill="#514e66"/><rect x="2433" y="118" width="3" height="10" fill="#514e66"/>
+  <polygon points="2442,128 2454,128 2448,119" fill="#514e66"/>
+  <rect x="2456" y="118" width="20" height="10" rx="3" fill="#514e66"/><rect x="2477" y="121" width="3" height="5" rx="1" fill="#514e66"/>
+
+  <!-- nav rail -->
+  <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+  <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+  <rect x="1377" y="212" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+  <rect x="1377" y="290" width="22" height="22" rx="6" fill="#6342db"/>
+  <text x="1388" y="328" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+  <rect x="1377" y="368" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="406" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+  <rect x="1377" y="446" width="22" height="22" rx="6" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="484" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+  <circle cx="1388" cy="535" r="11" fill="#eeedf5" stroke="#7a7791"/>
+  <text x="1388" y="562" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+  <!-- left region: issue list -->
+  <text x="1446" y="175" font-size="15" font-weight="700" fill="#15131f">ENG · Active issues</text>
+  <text x="1446" y="193" font-size="12" fill="#7a7791">Cycle 14 · 12 issues</text>
+  <text x="1446" y="236" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+  <text x="1446" y="256" font-size="13" fill="#15131f">Board swimlanes for cycles</text>
+  <circle cx="1808" cy="242" r="5" fill="#8b5cf6"/>
+  <line x1="1446" y1="282" x2="1816" y2="282" stroke="#eeedf5"/>
+  <text x="1446" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-140</text>
+  <text x="1446" y="328" font-size="13" fill="#15131f">Offline queue for mutations</text>
+  <circle cx="1808" cy="314" r="5" fill="#f29d0b"/>
+  <line x1="1446" y1="354" x2="1816" y2="354" stroke="#eeedf5"/>
+  <rect x="1426" y="354" width="410" height="72" fill="#6342db" fill-opacity="0.08"/>
+  <rect x="1426" y="354" width="4" height="72" fill="#6342db"/>
+  <text x="1446" y="380" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+  <text x="1446" y="400" font-size="13" font-weight="600" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <circle cx="1808" cy="386" r="5" fill="#f29d0b"/>
+  <line x1="1446" y1="426" x2="1816" y2="426" stroke="#eeedf5"/>
+  <text x="1446" y="452" font-size="11" font-weight="600" fill="#7a7791">ENG-143</text>
+  <text x="1446" y="472" font-size="13" fill="#15131f">Keyboard shortcuts palette</text>
+  <circle cx="1808" cy="458" r="5" fill="#6f6c86"/>
+  <line x1="1446" y1="498" x2="1816" y2="498" stroke="#eeedf5"/>
+  <text x="1446" y="524" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+  <text x="1446" y="544" font-size="13" fill="#15131f">Safari transform regression</text>
+  <circle cx="1808" cy="530" r="5" fill="#6f6c86"/>
+  <line x1="1446" y1="570" x2="1816" y2="570" stroke="#eeedf5"/>
+  <text x="1446" y="596" font-size="11" font-weight="600" fill="#7a7791">ENG-145</text>
+  <text x="1446" y="616" font-size="13" fill="#15131f">Sub-issue reorder jank on iPad</text>
+  <circle cx="1808" cy="602" r="5" fill="#9b98b0"/>
+  <line x1="1446" y1="642" x2="1816" y2="642" stroke="#eeedf5"/>
+  <text x="1446" y="668" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+  <text x="1446" y="688" font-size="13" fill="#15131f">Empty state illustrations</text>
+  <circle cx="1808" cy="674" r="5" fill="#9b98b0"/>
+  <line x1="1446" y1="714" x2="1816" y2="714" stroke="#eeedf5"/>
+  <text x="1446" y="740" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+  <text x="1446" y="760" font-size="13" fill="#15131f">Pointer capture on drag start</text>
+  <circle cx="1808" cy="746" r="5" fill="#12a474"/>
+  <line x1="1446" y1="786" x2="1816" y2="786" stroke="#eeedf5"/>
+  <text x="1446" y="812" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+  <text x="1446" y="832" font-size="13" fill="#15131f">Regression test on Safari</text>
+  <circle cx="1808" cy="818" r="5" fill="#6f6c86"/>
+
+  <!-- detail panel -->
+  <line x1="1836" y1="110" x2="1836" y2="890" stroke="#eeedf5" stroke-width="2"/>
+  <text x="1860" y="172" font-size="13" font-weight="600" fill="#7a7791">ENG-142</text>
+  <rect x="2404" y="156" width="46" height="24" rx="12" fill="#6342db"/>
+  <circle cx="2438" cy="168" r="9" fill="#ffffff"/>
+  <text x="1860" y="206" font-size="20" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+  <rect x="1860" y="226" width="110" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+  <circle cx="1876" cy="239" r="4" fill="#f29d0b"/>
+  <text x="1886" y="243" font-size="12" font-weight="600" fill="#f29d0b">In Progress</text>
+  <rect x="1978" y="226" width="64" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+  <text x="1994" y="243" font-size="12" font-weight="600" fill="#f2721c">High</text>
+  <circle cx="2070" cy="239" r="12" fill="#4f8cff"/>
+  <text x="2070" y="243" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+  <text x="2090" y="243" font-size="13" fill="#15131f">Amina K.</text>
+  <line x1="1860" y1="272" x2="2476" y2="272" stroke="#eeedf5"/>
+
+  <text x="1860" y="304" font-size="15" font-weight="700" fill="#15131f">Attachments</text>
+  <text x="2476" y="304" font-size="12" fill="#7a7791" text-anchor="end">4 files · 25 MB max per file</text>
+
+  <!-- grid row 1 -->
+  <rect x="1860" y="318" width="190" height="116" rx="12" fill="#eeedf5"/>
+  <polygon points="1878,420 1928,354 1954,388 1978,358 2032,420" fill="#b6b3c8"/>
+  <circle cx="1902" cy="350" r="8" fill="#b6b3c8"/>
+  <rect x="2072" y="318" width="190" height="116" rx="12" fill="#eeedf5"/>
+  <circle cx="2167" cy="376" r="30" stroke="#b6b3c8" stroke-width="3" fill="none"/>
+  <rect x="2284" y="318" width="190" height="116" rx="12" fill="#eeedf5"/>
+  <rect x="2354" y="340" width="50" height="64" rx="6" fill="#ffffff" stroke="#dedcea"/>
+  <text x="2379" y="378" font-size="11" font-weight="700" fill="#e0424a" text-anchor="middle">PDF</text>
+  <text x="1860" y="454" font-size="11" fill="#7a7791">board-before.png</text>
+  <text x="2072" y="454" font-size="11" fill="#7a7791">drag-ghost-repro.png</text>
+  <text x="2284" y="454" font-size="11" fill="#7a7791">design-spec.pdf</text>
+
+  <!-- grid row 2: video thumb + add tile -->
+  <rect x="1860" y="470" width="190" height="116" rx="12" fill="#eeedf5"/>
+  <circle cx="1955" cy="528" r="22" fill="#ffffff" stroke="#dedcea"/>
+  <polygon points="1948,517 1968,528 1948,539" fill="#514e66"/>
+  <rect x="2072" y="470" width="190" height="116" rx="12" fill="#ffffff" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="6 6"/>
+  <text x="2167" y="528" font-size="26" fill="#7a7791" text-anchor="middle">+</text>
+  <text x="2167" y="554" font-size="12" fill="#7a7791" text-anchor="middle">Add file</text>
+  <text x="1860" y="606" font-size="11" fill="#7a7791">screen-capture.mov</text>
+
+  <line x1="1860" y1="632" x2="2476" y2="632" stroke="#eeedf5"/>
+  <text x="1860" y="666" font-size="12" fill="#b6b3c8">Drag files here or paste from clipboard — 25 MB max per file</text>
+
+  <!-- toast bottom-right -->
+  <rect x="2160" y="806" width="316" height="60" rx="12" fill="#26243a" opacity="0.08"/>
+  <rect x="2156" y="800" width="316" height="60" rx="12" fill="#ffffff" stroke="#dedcea"/>
+  <circle cx="2184" cy="830" r="12" fill="#e0424a"/>
+  <text x="2184" y="835" font-size="13" font-weight="700" fill="#ffffff" text-anchor="middle">!</text>
+  <text x="2206" y="826" font-size="14" font-weight="600" fill="#15131f">Upload failed</text>
+  <text x="2206" y="846" font-size="11" fill="#7a7791">screen-capture.mov</text>
+  <text x="2440" y="836" font-size="14" font-weight="600" fill="#6342db" text-anchor="middle">Retry</text>
+</g>
+
+<!-- Frame borders on top -->
+<rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+<rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+<!-- Footer -->
+<text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Attachments cap at 25 MB per file; images load inline over the authenticated session, with camera, library, and file-picker capture everywhere.</text>
+</svg>

--- a/docs/design/mobile/147-notifications.svg
+++ b/docs/design/mobile/147-notifications.svg
@@ -1,0 +1,335 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Notifications: inbox &amp; push</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pc"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="fc"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="tc"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- ================= PHONE ================= -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pc)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="360" y="127" width="3" height="4"/><rect x="365" y="125" width="3" height="6"/><rect x="370" y="123" width="3" height="8"/><rect x="375" y="121" width="3" height="10"/>
+      <path d="M384 129 A8 8 0 0 1 398 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="391" cy="131" r="1.5"/>
+      <rect x="406" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="408" y="123" width="11" height="5" rx="1"/><rect x="425" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+
+    <!-- push banner (lock-screen style) -->
+    <rect x="78" y="156" width="354" height="92" rx="14" fill="#26243a" opacity="0.06"/>
+    <rect x="76" y="152" width="358" height="92" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <rect x="92" y="168" width="24" height="24" rx="6" fill="#6342db"/>
+    <text x="104" y="185" font-size="13" font-weight="700" fill="#ffffff" text-anchor="middle">S</text>
+    <text x="128" y="180" font-size="12" fill="#7a7791">SoftTrack · now</text>
+    <text x="128" y="201" font-size="14" font-weight="600" fill="#15131f">Amina mentioned you in ENG-142</text>
+    <text x="128" y="221" font-size="12" fill="#7a7791">@waleed can you check the drag ghost offset?</text>
+
+    <!-- inbox header -->
+    <text x="76" y="284" font-size="18" font-weight="700" fill="#15131f">Inbox</text>
+    <text x="434" y="284" font-size="13" font-weight="600" fill="#6342db" text-anchor="end">Mark all read</text>
+
+    <!-- row 1: assigned, unread -->
+    <circle cx="86" cy="338" r="4" fill="#6342db"/>
+    <circle cx="114" cy="338" r="14" fill="#4f8cff"/>
+    <text x="114" y="342" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="142" y="332" font-size="14" font-weight="600" fill="#15131f">Assigned to you · ENG-150</text>
+    <text x="142" y="352" font-size="12" fill="#7a7791">Dev P. assigned · Fix column reorder jank</text>
+    <text x="434" y="332" font-size="11" fill="#b6b3c8" text-anchor="end">2m</text>
+    <line x1="76" y1="376" x2="434" y2="376" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- row 2: commented, unread -->
+    <circle cx="86" cy="414" r="4" fill="#6342db"/>
+    <rect x="102" y="402" width="24" height="17" rx="5" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <path d="M109 419 l4 7 l4 -7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="142" y="408" font-size="14" font-weight="600" fill="#15131f">Sara commented on ENG-142</text>
+    <text x="142" y="428" font-size="12" fill="#7a7791">“Repro on Safari 17 too — video attached”</text>
+    <text x="434" y="408" font-size="11" fill="#b6b3c8" text-anchor="end">18m</text>
+    <line x1="76" y1="452" x2="434" y2="452" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- row 3: status changed, read -->
+    <circle cx="114" cy="490" r="14" fill="#12a474"/>
+    <text x="114" y="495" font-size="13" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+    <text x="142" y="484" font-size="14" fill="#514e66">Status changed · ENG-131 → <tspan font-weight="600" fill="#12a474">Done</tspan></text>
+    <text x="142" y="504" font-size="12" fill="#7a7791">Moved to Done by Amina K.</text>
+    <text x="434" y="484" font-size="11" fill="#b6b3c8" text-anchor="end">1h</text>
+    <line x1="76" y1="528" x2="434" y2="528" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- row 4: mentioned, unread -->
+    <circle cx="86" cy="566" r="4" fill="#6342db"/>
+    <circle cx="114" cy="566" r="14" fill="#6342db" fill-opacity="0.15"/>
+    <text x="114" y="571" font-size="14" font-weight="700" fill="#6342db" text-anchor="middle">@</text>
+    <text x="142" y="560" font-size="14" font-weight="600" fill="#15131f">Mentioned in DES-12</text>
+    <text x="142" y="580" font-size="12" fill="#7a7791">Amina K.: “final icon set attached”</text>
+    <text x="434" y="560" font-size="11" fill="#b6b3c8" text-anchor="end">3h</text>
+    <line x1="76" y1="604" x2="434" y2="604" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- earlier (low-fi) -->
+    <text x="76" y="640" font-size="12" font-weight="600" fill="#7a7791">EARLIER</text>
+    <circle cx="114" cy="678" r="14" fill="#eeedf5"/>
+    <rect x="142" y="662" width="200" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="142" y="682" width="150" height="10" rx="5" fill="#f2f1f8"/>
+    <circle cx="114" cy="740" r="14" fill="#eeedf5"/>
+    <rect x="142" y="724" width="230" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="142" y="744" width="120" height="10" rx="5" fill="#f2f1f8"/>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="89" y="837" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="168" y="837" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="180" y="837" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="177" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="253" cy="845" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="258" y1="850" x2="264" y2="856" stroke="#7a7791" stroke-width="2"/>
+    <text x="255" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="323" y="838" width="20" height="16" rx="4" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="323" y1="847" x2="343" y2="847" stroke="#6342db" stroke-width="2"/>
+    <circle cx="344" cy="837" r="4.5" fill="#e0424a"/>
+    <text x="333" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="847" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="411" y="879" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= FOLDABLE ================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fc)">
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6" stroke-width="2"/>
+    <!-- status bar -->
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="1180" y="127" width="3" height="4"/><rect x="1185" y="125" width="3" height="6"/><rect x="1190" y="123" width="3" height="8"/><rect x="1195" y="121" width="3" height="10"/>
+      <path d="M1204 129 A8 8 0 0 1 1218 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="1211" cy="131" r="1.5"/>
+      <rect x="1226" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1228" y="123" width="11" height="5" rx="1"/><rect x="1245" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="558" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="559" y="290" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="571" y="290" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="326" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="566" cy="373" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="571" y1="378" x2="577" y2="384" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="402" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="558" y="443" width="20" height="16" rx="4" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="558" y1="452" x2="578" y2="452" stroke="#6342db" stroke-width="2"/>
+    <circle cx="579" cy="442" r="4.5" fill="#e0424a"/>
+    <text x="568" y="478" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: inbox list -->
+    <text x="622" y="180" font-size="18" font-weight="700" fill="#15131f">Inbox</text>
+    <text x="884" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">Mark all read</text>
+
+    <!-- row 1 -->
+    <circle cx="620" cy="238" r="3.5" fill="#6342db"/>
+    <circle cx="640" cy="238" r="12" fill="#4f8cff"/>
+    <text x="640" y="242" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="660" y="234" font-size="13" font-weight="600" fill="#15131f">Assigned · ENG-150</text>
+    <text x="660" y="253" font-size="11" fill="#7a7791">Dev P. · Fix column reorder jank</text>
+    <text x="884" y="234" font-size="11" fill="#b6b3c8" text-anchor="end">2m</text>
+    <line x1="618" y1="280" x2="888" y2="280" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 2 (selected) -->
+    <rect x="607" y="281" width="292" height="83" fill="#f7f6fb"/>
+    <rect x="607" y="281" width="3" height="83" fill="#6342db"/>
+    <circle cx="620" cy="322" r="3.5" fill="#6342db"/>
+    <rect x="629" y="312" width="21" height="15" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <path d="M635 327 l4 6 l3 -6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="660" y="318" font-size="13" font-weight="600" fill="#15131f">Sara commented on ENG-142</text>
+    <text x="660" y="337" font-size="11" fill="#7a7791">“Repro on Safari 17 too”</text>
+    <text x="884" y="318" font-size="11" fill="#b6b3c8" text-anchor="end">18m</text>
+    <line x1="618" y1="364" x2="888" y2="364" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 3 -->
+    <circle cx="640" cy="406" r="12" fill="#12a474"/>
+    <text x="640" y="411" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+    <text x="660" y="402" font-size="13" fill="#514e66">Status changed · ENG-131</text>
+    <text x="660" y="421" font-size="11" fill="#7a7791">→ Done · by Amina K.</text>
+    <text x="884" y="402" font-size="11" fill="#b6b3c8" text-anchor="end">1h</text>
+    <line x1="618" y1="448" x2="888" y2="448" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 4 -->
+    <circle cx="620" cy="490" r="3.5" fill="#6342db"/>
+    <circle cx="640" cy="490" r="12" fill="#6342db" fill-opacity="0.15"/>
+    <text x="640" y="495" font-size="13" font-weight="700" fill="#6342db" text-anchor="middle">@</text>
+    <text x="660" y="486" font-size="13" font-weight="600" fill="#15131f">Mentioned in DES-12</text>
+    <text x="660" y="505" font-size="11" fill="#7a7791">Amina K.: “final icons attached”</text>
+    <text x="884" y="486" font-size="11" fill="#b6b3c8" text-anchor="end">3h</text>
+    <line x1="618" y1="532" x2="888" y2="532" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- earlier low-fi -->
+    <text x="618" y="566" font-size="11" font-weight="600" fill="#7a7791">EARLIER</text>
+    <circle cx="640" cy="602" r="12" fill="#eeedf5"/>
+    <rect x="660" y="588" width="160" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="660" y="606" width="110" height="9" rx="4.5" fill="#f2f1f8"/>
+    <circle cx="640" cy="658" r="12" fill="#eeedf5"/>
+    <rect x="660" y="644" width="180" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="660" y="662" width="90" height="9" rx="4.5" fill="#f2f1f8"/>
+
+    <!-- RIGHT PANE: issue detail -->
+    <text x="916" y="178" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="916" y="206" font-size="18" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="916" y="222" width="92" height="24" rx="12" fill="#f29d0b" fill-opacity="0.15"/>
+    <text x="962" y="238" font-size="12" font-weight="600" fill="#f29d0b" text-anchor="middle">In Progress</text>
+    <rect x="1018" y="222" width="52" height="24" rx="12" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="1044" y="238" font-size="12" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="1094" cy="234" r="12" fill="#ff6fae"/>
+    <text x="1094" y="238" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="1112" y="238" font-size="12" fill="#514e66">Amina K.</text>
+    <rect x="916" y="272" width="320" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="916" y="292" width="300" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="916" y="312" width="200" height="10" rx="5" fill="#eeedf5"/>
+    <line x1="916" y1="348" x2="1254" y2="348" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="916" y="378" font-size="13" font-weight="600" fill="#514e66">Activity</text>
+    <rect x="916" y="392" width="338" height="96" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="944" cy="422" r="12" fill="#2fd4a7"/>
+    <text x="944" y="426" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">S</text>
+    <text x="964" y="418" font-size="12" font-weight="600" fill="#514e66">Sara N. <tspan font-weight="400" fill="#7a7791">· 18m</tspan></text>
+    <text x="964" y="440" font-size="13" fill="#15131f">Repro on Safari 17 too —</text>
+    <text x="964" y="458" font-size="13" fill="#15131f">video attached.</text>
+    <rect x="916" y="504" width="338" height="80" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="944" cy="534" r="12" fill="#ffb648"/>
+    <rect x="964" y="528" width="150" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="964" y="548" width="240" height="9" rx="4.5" fill="#f2f1f8"/>
+    <rect x="916" y="816" width="338" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="932" y="846" font-size="15" fill="#b6b3c8">Leave a comment…</text>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= TABLET ================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tc)">
+    <!-- status bar -->
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="2410" y="127" width="3" height="4"/><rect x="2415" y="125" width="3" height="6"/><rect x="2420" y="123" width="3" height="8"/><rect x="2425" y="121" width="3" height="10"/>
+      <path d="M2434 129 A8 8 0 0 1 2448 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="2441" cy="131" r="1.5"/>
+      <rect x="2456" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2458" y="123" width="11" height="5" rx="1"/><rect x="2475" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="1378" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1379" y="290" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="1391" y="290" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="326" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="373" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="1391" y1="378" x2="1397" y2="384" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="402" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1378" y="443" width="20" height="16" rx="4" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="1378" y1="452" x2="1398" y2="452" stroke="#6342db" stroke-width="2"/>
+    <circle cx="1399" cy="442" r="4.5" fill="#e0424a"/>
+    <text x="1388" y="478" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- LIST REGION -->
+    <line x1="1856" y1="138" x2="1856" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <text x="1450" y="180" font-size="18" font-weight="700" fill="#15131f">Inbox</text>
+    <text x="1832" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">Mark all read</text>
+    <!-- filter row: segmented All / Unread -->
+    <rect x="1450" y="196" width="200" height="36" rx="10" fill="#f7f6fb"/>
+    <rect x="1454" y="200" width="94" height="28" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1501" y="219" font-size="13" font-weight="600" fill="#15131f" text-anchor="middle">All</text>
+    <text x="1598" y="219" font-size="13" fill="#7a7791" text-anchor="middle">Unread</text>
+
+    <!-- row 1 -->
+    <circle cx="1460" cy="296" r="4" fill="#6342db"/>
+    <circle cx="1482" cy="296" r="13" fill="#4f8cff"/>
+    <text x="1482" y="300" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="1506" y="290" font-size="14" font-weight="600" fill="#15131f">Assigned to you · ENG-150</text>
+    <text x="1506" y="310" font-size="12" fill="#7a7791">Dev P. assigned · Fix column reorder jank</text>
+    <text x="1832" y="290" font-size="11" fill="#b6b3c8" text-anchor="end">2m</text>
+    <line x1="1450" y1="336" x2="1832" y2="336" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 2 (selected) -->
+    <rect x="1427" y="337" width="429" height="83" fill="#f7f6fb"/>
+    <rect x="1427" y="337" width="3" height="83" fill="#6342db"/>
+    <circle cx="1460" cy="380" r="4" fill="#6342db"/>
+    <rect x="1470" y="370" width="23" height="16" rx="5" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <path d="M1477 386 l4 7 l4 -7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1506" y="374" font-size="14" font-weight="600" fill="#15131f">Sara commented on ENG-142</text>
+    <text x="1506" y="394" font-size="12" fill="#7a7791">“Repro on Safari 17 too — video attached”</text>
+    <text x="1832" y="374" font-size="11" fill="#b6b3c8" text-anchor="end">18m</text>
+    <line x1="1450" y1="420" x2="1832" y2="420" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 3 -->
+    <circle cx="1482" cy="464" r="13" fill="#12a474"/>
+    <text x="1482" y="469" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+    <text x="1506" y="458" font-size="14" fill="#514e66">Status changed · ENG-131 → <tspan font-weight="600" fill="#12a474">Done</tspan></text>
+    <text x="1506" y="478" font-size="12" fill="#7a7791">Moved to Done by Amina K.</text>
+    <text x="1832" y="458" font-size="11" fill="#b6b3c8" text-anchor="end">1h</text>
+    <line x1="1450" y1="504" x2="1832" y2="504" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 4 -->
+    <circle cx="1460" cy="548" r="4" fill="#6342db"/>
+    <circle cx="1482" cy="548" r="13" fill="#6342db" fill-opacity="0.15"/>
+    <text x="1482" y="553" font-size="14" font-weight="700" fill="#6342db" text-anchor="middle">@</text>
+    <text x="1506" y="542" font-size="14" font-weight="600" fill="#15131f">Mentioned in DES-12</text>
+    <text x="1506" y="562" font-size="12" fill="#7a7791">Amina K.: “final icon set attached”</text>
+    <text x="1832" y="542" font-size="11" fill="#b6b3c8" text-anchor="end">3h</text>
+    <line x1="1450" y1="588" x2="1832" y2="588" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- earlier low-fi -->
+    <text x="1450" y="622" font-size="12" font-weight="600" fill="#7a7791">EARLIER</text>
+    <circle cx="1482" cy="660" r="13" fill="#eeedf5"/>
+    <rect x="1506" y="646" width="220" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1506" y="666" width="150" height="10" rx="5" fill="#f2f1f8"/>
+    <circle cx="1482" cy="722" r="13" fill="#eeedf5"/>
+    <rect x="1506" y="708" width="250" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1506" y="728" width="120" height="10" rx="5" fill="#f2f1f8"/>
+
+    <!-- DETAIL REGION (wider) -->
+    <text x="1888" y="178" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="1888" y="210" font-size="22" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="1888" y="230" width="96" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+    <text x="1936" y="247" font-size="12" font-weight="600" fill="#f29d0b" text-anchor="middle">In Progress</text>
+    <rect x="1996" y="230" width="54" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="2023" y="247" font-size="12" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <rect x="2062" y="230" width="52" height="26" rx="13" fill="#6342db" fill-opacity="0.15"/>
+    <text x="2088" y="247" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">ENG</text>
+    <circle cx="2142" cy="243" r="12" fill="#ff6fae"/>
+    <text x="2142" y="247" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="2160" y="247" font-size="12" fill="#514e66">Amina K.</text>
+    <rect x="1888" y="286" width="520" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1888" y="306" width="480" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1888" y="326" width="320" height="10" rx="5" fill="#eeedf5"/>
+    <line x1="1888" y1="360" x2="2468" y2="360" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1888" y="390" font-size="13" font-weight="600" fill="#514e66">Activity</text>
+    <rect x="1888" y="404" width="580" height="88" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="1916" cy="434" r="12" fill="#2fd4a7"/>
+    <text x="1916" y="438" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">S</text>
+    <text x="1936" y="430" font-size="12" font-weight="600" fill="#514e66">Sara N. <tspan font-weight="400" fill="#7a7791">· 18m</tspan></text>
+    <text x="1936" y="454" font-size="13" fill="#15131f">Repro on Safari 17 too — video attached. Ghost sits 12px below the cursor.</text>
+    <rect x="1888" y="508" width="580" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="1916" cy="538" r="12" fill="#ffb648"/>
+    <rect x="1936" y="530" width="180" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="1936" y="550" width="360" height="9" rx="4.5" fill="#f2f1f8"/>
+    <rect x="1888" y="608" width="580" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="1916" cy="638" r="12" fill="#6342db"/>
+    <text x="1916" y="642" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">W</text>
+    <rect x="1936" y="630" width="140" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="1936" y="650" width="300" height="9" rx="4.5" fill="#f2f1f8"/>
+    <rect x="1888" y="812" width="580" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1904" y="842" font-size="15" fill="#b6b3c8">Leave a comment…</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Tapping a push notification deep-links straight to the issue; at medium and expanded widths the inbox stays docked while the issue opens beside it.</text>
+</svg>

--- a/docs/design/mobile/148-search.svg
+++ b/docs/design/mobile/148-search.svg
@@ -1,0 +1,306 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Search</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pc"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="fc"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="tc"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- ================= PHONE ================= -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pc)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="360" y="127" width="3" height="4"/><rect x="365" y="125" width="3" height="6"/><rect x="370" y="123" width="3" height="8"/><rect x="375" y="121" width="3" height="10"/>
+      <path d="M384 129 A8 8 0 0 1 398 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="391" cy="131" r="1.5"/>
+      <rect x="406" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="408" y="123" width="11" height="5" rx="1"/><rect x="425" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+
+    <!-- search input -->
+    <rect x="76" y="152" width="358" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="100" cy="174" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="105" y1="179" x2="111" y2="185" stroke="#7a7791" stroke-width="2"/>
+    <text x="124" y="181" font-size="15" fill="#15131f">drag ghost</text>
+    <line x1="200" y1="164" x2="200" y2="188" stroke="#6342db" stroke-width="2"/>
+    <text x="418" y="182" font-size="18" fill="#b6b3c8" text-anchor="end">×</text>
+
+    <!-- scope chips -->
+    <rect x="76" y="216" width="104" height="30" rx="15" fill="#6342db" fill-opacity="0.15"/>
+    <text x="128" y="236" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">All teams ✓</text>
+    <rect x="190" y="216" width="56" height="30" rx="15" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="218" y="236" font-size="12" fill="#514e66" text-anchor="middle">ENG</text>
+    <rect x="256" y="216" width="56" height="30" rx="15" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="284" y="236" font-size="12" fill="#514e66" text-anchor="middle">DES</text>
+
+    <!-- result 1 -->
+    <text x="76" y="286" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="76" y="308" font-size="15" fill="#15131f">Fix <tspan font-weight="600" fill="#6342db">drag ghost</tspan> offset on Safari</text>
+    <text x="76" y="328" font-size="12" fill="#7a7791">…the drag ghost renders 12px off under the cursor…</text>
+    <line x1="76" y1="356" x2="434" y2="356" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 2 -->
+    <text x="76" y="374" font-size="12" font-weight="600" fill="#7a7791">ENG-118</text>
+    <text x="76" y="396" font-size="15" fill="#15131f"><tspan font-weight="600" fill="#6342db">Drag ghost</tspan> flickers when dropping fast</text>
+    <text x="76" y="416" font-size="12" fill="#7a7791">…flicker happens when the ghost is re-created…</text>
+    <line x1="76" y1="444" x2="434" y2="444" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 3 (in comments) -->
+    <text x="76" y="462" font-size="12" font-weight="600" fill="#7a7791">DES-31</text>
+    <rect x="140" y="448" width="92" height="19" rx="9.5" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="186" y="461" font-size="11" fill="#7a7791" text-anchor="middle">in comments</text>
+    <text x="76" y="484" font-size="15" fill="#15131f">Refine <tspan font-weight="600" fill="#6342db">drag ghost</tspan> outline style</text>
+    <text x="76" y="504" font-size="12" fill="#7a7791">Amina K.: “new ghost outline works on dark…”</text>
+    <line x1="76" y1="532" x2="434" y2="532" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 4 -->
+    <text x="76" y="550" font-size="12" font-weight="600" fill="#7a7791">ENG-97</text>
+    <text x="76" y="572" font-size="15" fill="#15131f">Reduce <tspan font-weight="600" fill="#6342db">ghost</tspan> repaints while <tspan font-weight="600" fill="#6342db">drag</tspan>ging</text>
+    <text x="76" y="592" font-size="12" fill="#7a7791">…repaint storm while dragging large cards…</text>
+    <line x1="76" y1="620" x2="434" y2="620" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- recent searches -->
+    <text x="76" y="656" font-size="12" font-weight="600" fill="#7a7791">RECENT SEARCHES</text>
+    <text x="76" y="682" font-size="13" fill="#514e66">column limits · sprint velocity · offline sync</text>
+    <text x="76" y="708" font-size="12" fill="#b6b3c8">Tip: use team:ENG to scope a query</text>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="89" y="837" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="168" y="837" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="180" y="837" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="177" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="253" cy="845" r="7" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="258" y1="850" x2="264" y2="856" stroke="#6342db" stroke-width="2"/>
+    <text x="255" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Search</text>
+    <rect x="323" y="838" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="323" y1="847" x2="343" y2="847" stroke="#7a7791" stroke-width="2"/>
+    <text x="333" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="847" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="411" y="879" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= FOLDABLE ================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fc)">
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6" stroke-width="2"/>
+    <!-- status bar -->
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="1180" y="127" width="3" height="4"/><rect x="1185" y="125" width="3" height="6"/><rect x="1190" y="123" width="3" height="8"/><rect x="1195" y="121" width="3" height="10"/>
+      <path d="M1204 129 A8 8 0 0 1 1218 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="1211" cy="131" r="1.5"/>
+      <rect x="1226" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1228" y="123" width="11" height="5" rx="1"/><rect x="1245" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="558" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="559" y="290" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="571" y="290" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="326" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="566" cy="373" r="7" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="571" y1="378" x2="577" y2="384" stroke="#6342db" stroke-width="2"/>
+    <text x="568" y="402" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Search</text>
+    <rect x="558" y="443" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="558" y1="452" x2="578" y2="452" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="478" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: search + results -->
+    <rect x="618" y="152" width="270" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="640" cy="172" r="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="644" y1="176" x2="650" y2="182" stroke="#7a7791" stroke-width="2"/>
+    <text x="660" y="179" font-size="14" fill="#15131f">drag ghost</text>
+    <text x="874" y="180" font-size="16" fill="#b6b3c8" text-anchor="end">×</text>
+    <rect x="618" y="210" width="94" height="26" rx="13" fill="#6342db" fill-opacity="0.15"/>
+    <text x="665" y="227" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">All teams ✓</text>
+    <rect x="720" y="210" width="48" height="26" rx="13" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="744" y="227" font-size="11" fill="#514e66" text-anchor="middle">ENG</text>
+    <rect x="776" y="210" width="48" height="26" rx="13" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="800" y="227" font-size="11" fill="#514e66" text-anchor="middle">DES</text>
+
+    <!-- result 1 (selected) -->
+    <rect x="607" y="254" width="292" height="82" fill="#f7f6fb"/>
+    <rect x="607" y="254" width="3" height="82" fill="#6342db"/>
+    <text x="622" y="276" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="622" y="297" font-size="13" fill="#15131f">Fix <tspan font-weight="600" fill="#6342db">drag ghost</tspan> offset on Safari</text>
+    <text x="622" y="316" font-size="11" fill="#7a7791">…ghost renders 12px off under cursor…</text>
+    <line x1="618" y1="336" x2="888" y2="336" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 2 -->
+    <text x="622" y="358" font-size="11" font-weight="600" fill="#7a7791">ENG-118</text>
+    <text x="622" y="379" font-size="13" fill="#15131f"><tspan font-weight="600" fill="#6342db">Drag ghost</tspan> flickers on fast drop</text>
+    <text x="622" y="398" font-size="11" fill="#7a7791">…flicker when ghost is re-created…</text>
+    <line x1="618" y1="418" x2="888" y2="418" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 3 -->
+    <text x="622" y="440" font-size="11" font-weight="600" fill="#7a7791">DES-31</text>
+    <rect x="678" y="427" width="84" height="18" rx="9" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="720" y="440" font-size="11" fill="#7a7791" text-anchor="middle">in comments</text>
+    <text x="622" y="461" font-size="13" fill="#15131f">Refine <tspan font-weight="600" fill="#6342db">drag ghost</tspan> outline style</text>
+    <text x="622" y="480" font-size="11" fill="#7a7791">Amina K.: “new ghost outline works…”</text>
+    <line x1="618" y1="500" x2="888" y2="500" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 4 -->
+    <text x="622" y="522" font-size="11" font-weight="600" fill="#7a7791">ENG-97</text>
+    <text x="622" y="543" font-size="13" fill="#15131f">Reduce <tspan font-weight="600" fill="#6342db">ghost</tspan> repaints on <tspan font-weight="600" fill="#6342db">drag</tspan></text>
+    <text x="622" y="562" font-size="11" fill="#7a7791">…repaint storm on large cards…</text>
+    <line x1="618" y1="582" x2="888" y2="582" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- recent searches -->
+    <text x="618" y="616" font-size="11" font-weight="600" fill="#7a7791">RECENT SEARCHES</text>
+    <text x="618" y="640" font-size="12" fill="#514e66">column limits · sprint velocity</text>
+    <text x="618" y="662" font-size="12" fill="#514e66">offline sync · burndown</text>
+
+    <!-- RIGHT PANE: issue preview -->
+    <text x="916" y="178" font-size="12" font-weight="600" fill="#7a7791">ENG-142 · PREVIEW</text>
+    <text x="916" y="206" font-size="18" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="916" y="222" width="92" height="24" rx="12" fill="#f29d0b" fill-opacity="0.15"/>
+    <text x="962" y="238" font-size="12" font-weight="600" fill="#f29d0b" text-anchor="middle">In Progress</text>
+    <rect x="1018" y="222" width="52" height="24" rx="12" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="1044" y="238" font-size="12" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="1094" cy="234" r="12" fill="#ff6fae"/>
+    <text x="1094" y="238" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="1112" y="238" font-size="12" fill="#514e66">Amina K.</text>
+    <rect x="916" y="272" width="320" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="916" y="292" width="300" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="916" y="312" width="210" height="10" rx="5" fill="#eeedf5"/>
+    <!-- matched snippet card -->
+    <text x="916" y="366" font-size="13" font-weight="600" fill="#514e66">Matched in description</text>
+    <rect x="916" y="380" width="338" height="76" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="932" y="410" font-size="13" fill="#514e66">…the <tspan font-weight="600" fill="#6342db">drag ghost</tspan> renders 12px off</text>
+    <text x="932" y="432" font-size="13" fill="#514e66">under the cursor on Safari 17…</text>
+    <rect x="916" y="480" width="140" height="44" rx="10" fill="#6342db"/>
+    <text x="986" y="508" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Open issue</text>
+    <!-- secondary low-fi -->
+    <text x="916" y="566" font-size="11" font-weight="600" fill="#7a7791">RECENT ACTIVITY</text>
+    <circle cx="928" cy="600" r="10" fill="#eeedf5"/>
+    <rect x="948" y="588" width="170" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="948" y="606" width="120" height="9" rx="4.5" fill="#f2f1f8"/>
+    <circle cx="928" cy="650" r="10" fill="#eeedf5"/>
+    <rect x="948" y="638" width="200" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="948" y="656" width="90" height="9" rx="4.5" fill="#f2f1f8"/>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= TABLET ================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tc)">
+    <!-- status bar -->
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="2410" y="127" width="3" height="4"/><rect x="2415" y="125" width="3" height="6"/><rect x="2420" y="123" width="3" height="8"/><rect x="2425" y="121" width="3" height="10"/>
+      <path d="M2434 129 A8 8 0 0 1 2448 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="2441" cy="131" r="1.5"/>
+      <rect x="2456" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2458" y="123" width="11" height="5" rx="1"/><rect x="2475" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="1378" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1379" y="290" width="8" height="20" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <rect x="1391" y="290" width="8" height="14" rx="2" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="326" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="373" r="7" fill="none" stroke="#6342db" stroke-width="2"/>
+    <line x1="1391" y1="378" x2="1397" y2="384" stroke="#6342db" stroke-width="2"/>
+    <text x="1388" y="402" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Search</text>
+    <rect x="1378" y="443" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="1378" y1="452" x2="1398" y2="452" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="478" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- wide centered search bar spanning content -->
+    <rect x="1463" y="156" width="1000" height="52" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="1491" cy="180" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="1496" y1="185" x2="1502" y2="191" stroke="#7a7791" stroke-width="2"/>
+    <text x="1516" y="188" font-size="15" fill="#15131f">drag ghost</text>
+    <line x1="1594" y1="169" x2="1594" y2="195" stroke="#6342db" stroke-width="2"/>
+    <text x="2447" y="188" font-size="18" fill="#b6b3c8" text-anchor="end">×</text>
+    <!-- scope chips -->
+    <rect x="1463" y="224" width="100" height="28" rx="14" fill="#6342db" fill-opacity="0.15"/>
+    <text x="1513" y="242" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">All teams ✓</text>
+    <rect x="1573" y="224" width="54" height="28" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1600" y="242" font-size="12" fill="#514e66" text-anchor="middle">ENG</text>
+    <rect x="1637" y="224" width="54" height="28" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1664" y="242" font-size="12" fill="#514e66" text-anchor="middle">DES</text>
+    <text x="2463" y="243" font-size="12" fill="#7a7791" text-anchor="end">4 results · ranked</text>
+
+    <!-- divider between results (40%) and preview -->
+    <line x1="1856" y1="272" x2="1856" y2="890" stroke="#eeedf5" stroke-width="2"/>
+
+    <!-- RESULTS (left, 40%) -->
+    <!-- result 1 (selected) -->
+    <rect x="1427" y="280" width="429" height="88" fill="#f7f6fb"/>
+    <rect x="1427" y="280" width="3" height="88" fill="#6342db"/>
+    <text x="1450" y="304" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="1450" y="327" font-size="15" fill="#15131f">Fix <tspan font-weight="600" fill="#6342db">drag ghost</tspan> offset on Safari</text>
+    <text x="1450" y="348" font-size="12" fill="#7a7791">…the drag ghost renders 12px off under the cursor…</text>
+    <line x1="1450" y1="368" x2="1832" y2="368" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 2 -->
+    <text x="1450" y="392" font-size="12" font-weight="600" fill="#7a7791">ENG-118</text>
+    <text x="1450" y="415" font-size="15" fill="#15131f"><tspan font-weight="600" fill="#6342db">Drag ghost</tspan> flickers when dropping fast</text>
+    <text x="1450" y="436" font-size="12" fill="#7a7791">…flicker happens when the ghost is re-created…</text>
+    <line x1="1450" y1="456" x2="1832" y2="456" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 3 -->
+    <text x="1450" y="480" font-size="12" font-weight="600" fill="#7a7791">DES-31</text>
+    <rect x="1514" y="466" width="92" height="19" rx="9.5" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="1560" y="479" font-size="11" fill="#7a7791" text-anchor="middle">in comments</text>
+    <text x="1450" y="503" font-size="15" fill="#15131f">Refine <tspan font-weight="600" fill="#6342db">drag ghost</tspan> outline style</text>
+    <text x="1450" y="524" font-size="12" fill="#7a7791">Amina K.: “new ghost outline works on dark…”</text>
+    <line x1="1450" y1="544" x2="1832" y2="544" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- result 4 -->
+    <text x="1450" y="568" font-size="12" font-weight="600" fill="#7a7791">ENG-97</text>
+    <text x="1450" y="591" font-size="15" fill="#15131f">Reduce <tspan font-weight="600" fill="#6342db">ghost</tspan> repaints while <tspan font-weight="600" fill="#6342db">drag</tspan>ging</text>
+    <text x="1450" y="612" font-size="12" fill="#7a7791">…repaint storm while dragging large cards…</text>
+    <line x1="1450" y1="632" x2="1832" y2="632" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- recent searches -->
+    <text x="1450" y="668" font-size="12" font-weight="600" fill="#7a7791">RECENT SEARCHES</text>
+    <text x="1450" y="694" font-size="13" fill="#514e66">column limits · sprint velocity · offline sync</text>
+    <text x="1450" y="720" font-size="12" fill="#b6b3c8">Tip: use team:ENG to scope a query</text>
+
+    <!-- PREVIEW (right) -->
+    <text x="1888" y="304" font-size="12" font-weight="600" fill="#7a7791">ENG-142 · PREVIEW</text>
+    <text x="1888" y="336" font-size="20" font-weight="700" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="1888" y="354" width="96" height="26" rx="13" fill="#f29d0b" fill-opacity="0.15"/>
+    <text x="1936" y="371" font-size="12" font-weight="600" fill="#f29d0b" text-anchor="middle">In Progress</text>
+    <rect x="1996" y="354" width="54" height="26" rx="13" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="2023" y="371" font-size="12" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <rect x="2062" y="354" width="52" height="26" rx="13" fill="#6342db" fill-opacity="0.15"/>
+    <text x="2088" y="371" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">ENG</text>
+    <circle cx="2142" cy="367" r="12" fill="#ff6fae"/>
+    <text x="2142" y="371" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="2160" y="371" font-size="12" fill="#514e66">Amina K.</text>
+    <rect x="1888" y="404" width="520" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1888" y="424" width="480" height="10" rx="5" fill="#eeedf5"/>
+    <rect x="1888" y="444" width="330" height="10" rx="5" fill="#eeedf5"/>
+    <text x="1888" y="494" font-size="13" font-weight="600" fill="#514e66">Matched in description</text>
+    <rect x="1888" y="508" width="580" height="62" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1904" y="545" font-size="13" fill="#514e66">…the <tspan font-weight="600" fill="#6342db">drag ghost</tspan> renders 12px off under the cursor on Safari 17…</text>
+    <text x="1888" y="608" font-size="13" font-weight="600" fill="#514e66">Matched in comments</text>
+    <rect x="1888" y="622" width="580" height="62" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="1916" cy="653" r="12" fill="#2fd4a7"/>
+    <text x="1916" y="657" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">S</text>
+    <text x="1936" y="658" font-size="13" fill="#514e66">Sara N.: “repro when the <tspan font-weight="600" fill="#6342db">ghost</tspan> spawns during scroll”</text>
+    <rect x="1888" y="716" width="140" height="44" rx="10" fill="#6342db"/>
+    <text x="1958" y="744" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Open issue</text>
+    <text x="2048" y="744" font-size="13" font-weight="600" fill="#6342db">Copy link ›</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Queries are ranked server-side across every team the user can see; medium and expanded widths keep results and a live issue preview side by side.</text>
+</svg>

--- a/docs/design/mobile/149-cycles.svg
+++ b/docs/design/mobile/149-cycles.svg
@@ -1,0 +1,340 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Cycles (sprints)</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pc"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="fc"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="tc"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- ================= PHONE ================= -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pc)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="360" y="127" width="3" height="4"/><rect x="365" y="125" width="3" height="6"/><rect x="370" y="123" width="3" height="8"/><rect x="375" y="121" width="3" height="10"/>
+      <path d="M384 129 A8 8 0 0 1 398 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="391" cy="131" r="1.5"/>
+      <rect x="406" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="408" y="123" width="11" height="5" rx="1"/><rect x="425" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+
+    <!-- header -->
+    <text x="76" y="174" font-size="20" font-weight="700" fill="#15131f">Cycles</text>
+    <rect x="382" y="156" width="52" height="26" rx="13" fill="#6342db" fill-opacity="0.15"/>
+    <text x="408" y="173" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">ENG</text>
+
+    <!-- current cycle banner card -->
+    <rect x="78" y="196" width="354" height="104" rx="14" fill="#26243a" opacity="0.06"/>
+    <rect x="76" y="192" width="358" height="104" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="92" y="222" font-size="16" font-weight="700" fill="#15131f">Cycle 7 · <tspan fill="#6342db">Active</tspan></text>
+    <text x="418" y="222" font-size="13" fill="#7a7791" text-anchor="end">Sep 1 – Sep 14</text>
+    <rect x="92" y="238" width="310" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="92" y="238" width="198" height="8" rx="4" fill="#6342db"/>
+    <text x="92" y="272" font-size="12" fill="#7a7791">21 of 34 pts · 3 unsized</text>
+    <text x="402" y="272" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">64%</text>
+
+    <!-- cycle list rows -->
+    <text x="76" y="342" font-size="15" font-weight="600" fill="#15131f">Cycle 8 · <tspan fill="#6f6c86" font-weight="400">Upcoming</tspan></text>
+    <text x="76" y="362" font-size="12" fill="#7a7791">Sep 15 – Sep 28 · 12 issues planned</text>
+    <text x="434" y="354" font-size="18" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="76" y1="380" x2="434" y2="380" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="76" y="406" font-size="15" font-weight="600" fill="#15131f">Cycle 6 · <tspan fill="#12a474" font-weight="600">Completed ✓</tspan></text>
+    <text x="76" y="426" font-size="12" fill="#7a7791">Aug 18 – Aug 29 · 29 pts shipped</text>
+    <text x="434" y="418" font-size="18" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="76" y1="444" x2="434" y2="444" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="76" y="470" font-size="15" font-weight="600" fill="#15131f">Cycle 5 · <tspan fill="#12a474" font-weight="600">Completed ✓</tspan></text>
+    <text x="76" y="490" font-size="12" fill="#7a7791">Aug 4 – Aug 15 · 31 pts shipped</text>
+    <text x="434" y="482" font-size="18" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="76" y1="508" x2="434" y2="508" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- complete cycle button -->
+    <rect x="76" y="536" width="358" height="44" rx="10" fill="#6342db"/>
+    <text x="255" y="564" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Complete cycle</text>
+
+    <!-- confirmation card mock -->
+    <rect x="78" y="604" width="354" height="108" rx="14" fill="#26243a" opacity="0.06"/>
+    <rect x="76" y="600" width="358" height="108" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="92" y="630" font-size="14" font-weight="600" fill="#15131f">Complete Cycle 7?</text>
+    <text x="92" y="654" font-size="12" fill="#514e66">Completing moves 4 unfinished issues → Cycle 8</text>
+    <text x="342" y="690" font-size="13" font-weight="600" fill="#7a7791" text-anchor="end">Cancel</text>
+    <text x="418" y="690" font-size="13" font-weight="600" fill="#6342db" text-anchor="end">Confirm</text>
+
+    <!-- footnote -->
+    <text x="255" y="756" font-size="12" fill="#b6b3c8" text-anchor="middle">Cycles run 2 weeks · auto-start Mondays</text>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="89" y="837" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="168" y="837" width="8" height="20" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <rect x="180" y="837" width="8" height="14" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <text x="177" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="253" cy="845" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="258" y1="850" x2="264" y2="856" stroke="#7a7791" stroke-width="2"/>
+    <text x="255" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="323" y="838" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="323" y1="847" x2="343" y2="847" stroke="#7a7791" stroke-width="2"/>
+    <text x="333" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="411" cy="847" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="411" y="879" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= FOLDABLE ================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fc)">
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-dasharray="4 6" opacity="0.6" stroke-width="2"/>
+    <!-- status bar -->
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="1180" y="127" width="3" height="4"/><rect x="1185" y="125" width="3" height="6"/><rect x="1190" y="123" width="3" height="8"/><rect x="1195" y="121" width="3" height="10"/>
+      <path d="M1204 129 A8 8 0 0 1 1218 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="1211" cy="131" r="1.5"/>
+      <rect x="1226" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1228" y="123" width="11" height="5" rx="1"/><rect x="1245" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="558" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="559" y="290" width="8" height="20" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <rect x="571" y="290" width="8" height="14" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <text x="568" y="326" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="566" cy="373" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="571" y1="378" x2="577" y2="384" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="402" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="558" y="443" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="558" y1="452" x2="578" y2="452" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="478" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="568" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="568" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: cycles list -->
+    <text x="618" y="180" font-size="18" font-weight="700" fill="#15131f">Cycles</text>
+    <text x="884" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">ENG</text>
+    <!-- current cycle card (selected) -->
+    <rect x="618" y="196" width="270" height="96" rx="14" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+    <text x="634" y="224" font-size="14" font-weight="700" fill="#15131f">Cycle 7 · <tspan fill="#6342db">Active</tspan></text>
+    <text x="874" y="224" font-size="11" fill="#7a7791" text-anchor="end">Sep 1 – Sep 14</text>
+    <rect x="634" y="238" width="238" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="634" y="238" width="152" height="8" rx="4" fill="#6342db"/>
+    <text x="634" y="272" font-size="11" fill="#7a7791">21 of 34 pts · 3 unsized · 64%</text>
+    <!-- rows -->
+    <text x="618" y="334" font-size="14" font-weight="600" fill="#15131f">Cycle 8 · <tspan fill="#6f6c86" font-weight="400">Upcoming</tspan></text>
+    <text x="618" y="353" font-size="11" fill="#7a7791">Sep 15 – Sep 28</text>
+    <text x="884" y="344" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="618" y1="368" x2="888" y2="368" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="618" y="394" font-size="14" font-weight="600" fill="#15131f">Cycle 6 · <tspan fill="#12a474">Completed ✓</tspan></text>
+    <text x="618" y="413" font-size="11" fill="#7a7791">Aug 18 – Aug 29 · 29 pts</text>
+    <text x="884" y="404" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="618" y1="428" x2="888" y2="428" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="618" y="454" font-size="14" font-weight="600" fill="#15131f">Cycle 5 · <tspan fill="#12a474">Completed ✓</tspan></text>
+    <text x="618" y="473" font-size="11" fill="#7a7791">Aug 4 – Aug 15 · 31 pts</text>
+    <text x="884" y="464" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="618" y1="488" x2="888" y2="488" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- complete button -->
+    <rect x="618" y="512" width="270" height="40" rx="10" fill="#6342db"/>
+    <text x="753" y="538" font-size="14" font-weight="600" fill="#ffffff" text-anchor="middle">Complete cycle</text>
+    <text x="753" y="580" font-size="11" fill="#7a7791" text-anchor="middle">Moves 4 unfinished issues → Cycle 8</text>
+    <!-- low-fi older cycles -->
+    <text x="618" y="622" font-size="11" font-weight="600" fill="#7a7791">OLDER</text>
+    <rect x="618" y="640" width="180" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="618" y="662" width="140" height="9" rx="4.5" fill="#f2f1f8"/>
+
+    <!-- RIGHT PANE: cycle detail -->
+    <text x="916" y="182" font-size="18" font-weight="700" fill="#15131f">Cycle 7</text>
+    <rect x="996" y="164" width="64" height="24" rx="12" fill="#6342db" fill-opacity="0.15"/>
+    <text x="1028" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Active</text>
+    <text x="916" y="218" font-size="13" fill="#514e66">Name</text>
+    <rect x="916" y="228" width="338" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="932" y="258" font-size="15" fill="#15131f">Cycle 7</text>
+    <text x="916" y="304" font-size="13" fill="#514e66">Dates</text>
+    <rect x="916" y="314" width="338" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="932" y="344" font-size="15" fill="#15131f">Sep 1 – Sep 14</text>
+    <text x="1238" y="344" font-size="14" fill="#b6b3c8" text-anchor="end">›</text>
+    <text x="916" y="392" font-size="13" fill="#514e66">State</text>
+    <rect x="916" y="402" width="76" height="28" rx="14" fill="#6342db" fill-opacity="0.15"/>
+    <text x="954" y="420" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Active</text>
+    <rect x="1000" y="402" width="92" height="28" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1046" y="420" font-size="12" fill="#7a7791" text-anchor="middle">Upcoming</text>
+    <!-- burndown card -->
+    <rect x="916" y="452" width="338" height="180" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="932" y="480" font-size="13" font-weight="600" fill="#514e66">Burndown</text>
+    <text x="1238" y="480" font-size="11" fill="#7a7791" text-anchor="end">13 pts remaining</text>
+    <line x1="936" y1="606" x2="1234" y2="606" stroke="#eeedf5" stroke-width="1.5"/>
+    <line x1="936" y1="500" x2="936" y2="606" stroke="#eeedf5" stroke-width="1.5"/>
+    <line x1="936" y1="504" x2="1234" y2="602" stroke="#dedcea" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <polyline points="936,504 972,508 1008,524 1044,528 1080,548 1116,552 1152,570 1188,578 1216,588" fill="none" stroke="#6342db" stroke-width="2.5"/>
+    <circle cx="1216" cy="588" r="3.5" fill="#6342db"/>
+    <!-- complete button -->
+    <rect x="916" y="660" width="180" height="44" rx="10" fill="#6342db"/>
+    <text x="1006" y="688" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Complete cycle</text>
+    <text x="916" y="736" font-size="11" fill="#7a7791">4 unfinished issues will move → Cycle 8</text>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ================= TABLET ================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tc)">
+    <!-- status bar -->
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <g fill="#514e66">
+      <rect x="2410" y="127" width="3" height="4"/><rect x="2415" y="125" width="3" height="6"/><rect x="2420" y="123" width="3" height="8"/><rect x="2425" y="121" width="3" height="10"/>
+      <path d="M2434 129 A8 8 0 0 1 2448 129" fill="none" stroke="#514e66" stroke-width="2"/><circle cx="2441" cy="131" r="1.5"/>
+      <rect x="2456" y="121" width="18" height="9" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2458" y="123" width="11" height="5" rx="1"/><rect x="2475" y="123.5" width="2" height="4" rx="1"/>
+    </g>
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="154" width="24" height="24" rx="6" fill="#6342db"/>
+    <rect x="1378" y="214" width="20" height="20" rx="6" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="250" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1379" y="290" width="8" height="20" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <rect x="1391" y="290" width="8" height="14" rx="2" fill="none" stroke="#6342db" stroke-width="2"/>
+    <text x="1388" y="326" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <circle cx="1386" cy="373" r="7" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="1391" y1="378" x2="1397" y2="384" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="402" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1378" y="443" width="20" height="16" rx="4" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <line x1="1378" y1="452" x2="1398" y2="452" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="478" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <circle cx="1388" cy="528" r="10" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="1388" y="554" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- region dividers -->
+    <line x1="1746" y1="138" x2="1746" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <line x1="2136" y1="138" x2="2136" y2="890" stroke="#eeedf5" stroke-width="2"/>
+
+    <!-- REGION 1: cycles list -->
+    <text x="1450" y="180" font-size="18" font-weight="700" fill="#15131f">Cycles</text>
+    <text x="1722" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="end">ENG</text>
+    <rect x="1450" y="196" width="272" height="96" rx="14" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+    <text x="1466" y="224" font-size="14" font-weight="700" fill="#15131f">Cycle 7 · <tspan fill="#6342db">Active</tspan></text>
+    <text x="1708" y="224" font-size="11" fill="#7a7791" text-anchor="end">Sep 1 – Sep 14</text>
+    <rect x="1466" y="238" width="240" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="1466" y="238" width="154" height="8" rx="4" fill="#6342db"/>
+    <text x="1466" y="272" font-size="11" fill="#7a7791">21 of 34 pts · 3 unsized · 64%</text>
+    <text x="1450" y="334" font-size="14" font-weight="600" fill="#15131f">Cycle 8 · <tspan fill="#6f6c86" font-weight="400">Upcoming</tspan></text>
+    <text x="1450" y="353" font-size="11" fill="#7a7791">Sep 15 – Sep 28</text>
+    <text x="1722" y="344" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="1450" y1="368" x2="1722" y2="368" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1450" y="394" font-size="14" font-weight="600" fill="#15131f">Cycle 6 · <tspan fill="#12a474">Completed ✓</tspan></text>
+    <text x="1450" y="413" font-size="11" fill="#7a7791">Aug 18 – Aug 29 · 29 pts</text>
+    <text x="1722" y="404" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="1450" y1="428" x2="1722" y2="428" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1450" y="454" font-size="14" font-weight="600" fill="#15131f">Cycle 5 · <tspan fill="#12a474">Completed ✓</tspan></text>
+    <text x="1450" y="473" font-size="11" fill="#7a7791">Aug 4 – Aug 15 · 31 pts</text>
+    <text x="1722" y="464" font-size="16" fill="#b6b3c8" text-anchor="end">›</text>
+    <line x1="1450" y1="488" x2="1722" y2="488" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1450" y="512" width="272" height="40" rx="10" fill="#6342db"/>
+    <text x="1586" y="538" font-size="14" font-weight="600" fill="#ffffff" text-anchor="middle">Complete cycle</text>
+    <text x="1586" y="580" font-size="11" fill="#7a7791" text-anchor="middle">Moves 4 unfinished issues → Cycle 8</text>
+    <text x="1450" y="626" font-size="11" font-weight="600" fill="#7a7791">OLDER</text>
+    <rect x="1450" y="644" width="190" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="1450" y="666" width="150" height="9" rx="4.5" fill="#f2f1f8"/>
+
+    <!-- REGION 2: cycle detail (center) -->
+    <text x="1778" y="182" font-size="18" font-weight="700" fill="#15131f">Cycle 7</text>
+    <rect x="1858" y="164" width="64" height="24" rx="12" fill="#6342db" fill-opacity="0.15"/>
+    <text x="1890" y="180" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Active</text>
+    <text x="1778" y="218" font-size="13" fill="#514e66">Name</text>
+    <rect x="1778" y="228" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1794" y="258" font-size="15" fill="#15131f">Cycle 7</text>
+    <text x="1778" y="304" font-size="13" fill="#514e66">Dates</text>
+    <rect x="1778" y="314" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1794" y="344" font-size="15" fill="#15131f">Sep 1 – Sep 14</text>
+    <text x="2088" y="344" font-size="14" fill="#b6b3c8" text-anchor="end">›</text>
+    <text x="1778" y="392" font-size="13" fill="#514e66">State</text>
+    <rect x="1778" y="402" width="76" height="28" rx="14" fill="#6342db" fill-opacity="0.15"/>
+    <text x="1816" y="420" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Active</text>
+    <rect x="1862" y="402" width="92" height="28" rx="14" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1908" y="420" font-size="12" fill="#7a7791" text-anchor="middle">Upcoming</text>
+    <rect x="1778" y="452" width="326" height="180" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1794" y="480" font-size="13" font-weight="600" fill="#514e66">Burndown</text>
+    <text x="2088" y="480" font-size="11" fill="#7a7791" text-anchor="end">13 pts remaining</text>
+    <line x1="1798" y1="606" x2="2084" y2="606" stroke="#eeedf5" stroke-width="1.5"/>
+    <line x1="1798" y1="500" x2="1798" y2="606" stroke="#eeedf5" stroke-width="1.5"/>
+    <line x1="1798" y1="504" x2="2084" y2="602" stroke="#dedcea" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <polyline points="1798,504 1832,508 1866,524 1900,528 1934,548 1968,552 2002,570 2036,578 2064,588" fill="none" stroke="#6342db" stroke-width="2.5"/>
+    <circle cx="2064" cy="588" r="3.5" fill="#6342db"/>
+    <rect x="1778" y="660" width="180" height="44" rx="10" fill="#6342db"/>
+    <text x="1868" y="688" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Complete cycle</text>
+    <text x="1778" y="736" font-size="11" fill="#7a7791">4 unfinished issues will move → Cycle 8</text>
+
+    <!-- REGION 3: cycle issues side panel -->
+    <text x="2168" y="182" font-size="14" font-weight="600" fill="#15131f">Cycle issues · 12</text>
+    <text x="2468" y="182" font-size="11" fill="#7a7791" text-anchor="end">34 pts</text>
+    <!-- rows -->
+    <circle cx="2174" cy="216" r="5" fill="#f29d0b"/>
+    <text x="2188" y="212" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="2188" y="228" font-size="12" fill="#15131f">Fix column reorder jank</text>
+    <rect x="2440" y="206" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="220" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">3</text>
+    <line x1="2168" y1="240" x2="2468" y2="240" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="268" r="5" fill="#f29d0b"/>
+    <text x="2188" y="264" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="2188" y="280" font-size="12" fill="#15131f">Fix drag ghost offset…</text>
+    <rect x="2440" y="258" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="272" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">5</text>
+    <line x1="2168" y1="292" x2="2468" y2="292" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="320" r="5" fill="#6f6c86"/>
+    <text x="2188" y="316" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+    <text x="2188" y="332" font-size="12" fill="#15131f">Offline queue for status…</text>
+    <rect x="2440" y="310" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="324" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">8</text>
+    <line x1="2168" y1="344" x2="2468" y2="344" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="372" r="5" fill="#12a474"/>
+    <text x="2188" y="368" font-size="11" font-weight="600" fill="#7a7791">ENG-131</text>
+    <text x="2188" y="384" font-size="12" fill="#15131f">Board sync automation</text>
+    <rect x="2440" y="362" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="376" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">2</text>
+    <line x1="2168" y1="396" x2="2468" y2="396" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="424" r="5" fill="#8b5cf6"/>
+    <text x="2188" y="420" font-size="11" font-weight="600" fill="#7a7791">ENG-148</text>
+    <text x="2188" y="436" font-size="12" fill="#15131f">Push token refresh on…</text>
+    <rect x="2440" y="414" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="428" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">3</text>
+    <line x1="2168" y1="448" x2="2468" y2="448" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="476" r="5" fill="#6f6c86"/>
+    <text x="2188" y="472" font-size="11" font-weight="600" fill="#7a7791">ENG-153</text>
+    <text x="2188" y="488" font-size="12" fill="#15131f">Comment mentions auto…</text>
+    <rect x="2440" y="466" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="480" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">5</text>
+    <line x1="2168" y1="500" x2="2468" y2="500" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="528" r="5" fill="#12a474"/>
+    <text x="2188" y="524" font-size="11" font-weight="600" fill="#7a7791">ENG-127</text>
+    <text x="2188" y="540" font-size="12" fill="#15131f">Fix avatar contrast</text>
+    <rect x="2440" y="518" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="532" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">2</text>
+    <line x1="2168" y1="552" x2="2468" y2="552" stroke="#eeedf5" stroke-width="1"/>
+    <circle cx="2174" cy="580" r="5" fill="#9b98b0"/>
+    <text x="2188" y="576" font-size="11" font-weight="600" fill="#7a7791">ENG-139</text>
+    <text x="2188" y="592" font-size="12" fill="#15131f">Empty-state illustrations</text>
+    <rect x="2440" y="570" width="28" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea" stroke-width="1"/>
+    <text x="2454" y="584" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">1</text>
+    <line x1="2168" y1="604" x2="2468" y2="604" stroke="#eeedf5" stroke-width="1"/>
+    <!-- low-fi remainder + summary -->
+    <rect x="2188" y="624" width="180" height="9" rx="4.5" fill="#eeedf5"/>
+    <rect x="2188" y="646" width="140" height="9" rx="4.5" fill="#f2f1f8"/>
+    <rect x="2168" y="684" width="300" height="56" rx="14" fill="#f7f6fb"/>
+    <text x="2184" y="708" font-size="11" font-weight="600" fill="#514e66">4 unfinished · roll forward on complete</text>
+    <text x="2184" y="728" font-size="11" fill="#7a7791">21 of 34 pts done · 3 unsized</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Completing a cycle automatically rolls its unfinished issues forward into the next upcoming cycle, so nothing is silently dropped.</text>
+</svg>

--- a/docs/design/mobile/150-reports.svg
+++ b/docs/design/mobile/150-reports.svg
@@ -1,0 +1,330 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Reports: burndown, velocity, CFD</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pclip"><rect x="62" y="112" width="386" height="776" rx="26"/></clipPath>
+    <clipPath id="fclip"><rect x="532" y="112" width="736" height="776" rx="26"/></clipPath>
+    <clipPath id="tclip"><rect x="1352" y="112" width="1146" height="776" rx="26"/></clipPath>
+  </defs>
+
+  <!-- ======================= PHONE FRAME ======================= -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pclip)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="384" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="389" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="394" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M402 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="418" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="420" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="437" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="84" y="176" font-size="20" font-weight="700" fill="#15131f">Reports</text>
+    <text x="426" y="176" text-anchor="end" font-size="12" fill="#7a7791">ENG · Cycle 7</text>
+
+    <!-- chart-type selector chips (row scrolls; last chip clipped) -->
+    <rect x="80" y="190" width="104" height="30" rx="15" fill="#6342db"/>
+    <text x="132" y="210" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">✓ Burndown</text>
+    <rect x="192" y="190" width="78" height="30" rx="15" fill="#f7f6fb" stroke="#dedcea"/>
+    <text x="231" y="210" text-anchor="middle" font-size="12" fill="#514e66">Velocity</text>
+    <rect x="278" y="190" width="56" height="30" rx="15" fill="#f7f6fb" stroke="#dedcea"/>
+    <text x="306" y="210" text-anchor="middle" font-size="12" fill="#514e66">Flow</text>
+    <rect x="342" y="190" width="126" height="30" rx="15" fill="#f7f6fb" stroke="#dedcea"/>
+    <text x="352" y="210" font-size="12" fill="#514e66">Created/Resolved</text>
+
+    <!-- Burndown card (fully visible) -->
+    <rect x="76" y="236" width="358" height="330" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="96" y="266" font-size="15" font-weight="600" fill="#15131f">Burndown</text>
+    <text x="414" y="266" text-anchor="end" font-size="12" fill="#7a7791">Cycle 7 · Sep 1–14</text>
+    <!-- grid + axes -->
+    <line x1="118" y1="344" x2="414" y2="344" stroke="#eeedf5"/>
+    <line x1="118" y1="400" x2="414" y2="400" stroke="#eeedf5"/>
+    <line x1="118" y1="456" x2="414" y2="456" stroke="#eeedf5"/>
+    <line x1="118" y1="288" x2="118" y2="512" stroke="#dedcea"/>
+    <line x1="118" y1="512" x2="414" y2="512" stroke="#dedcea"/>
+    <text x="110" y="296" text-anchor="end" font-size="11" fill="#b6b3c8">24</text>
+    <text x="110" y="516" text-anchor="end" font-size="11" fill="#b6b3c8">0</text>
+    <!-- ideal line -->
+    <line x1="118" y1="292" x2="414" y2="512" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="7 6"/>
+    <!-- today marker -->
+    <line x1="287" y1="288" x2="287" y2="512" stroke="#f29d0b" stroke-width="1.5" stroke-dasharray="3 5" opacity="0.85"/>
+    <text x="287" y="282" text-anchor="middle" font-size="11" font-weight="600" fill="#f29d0b">Today</text>
+    <!-- actual line, stops at today -->
+    <polyline points="118,292 142,296 166,318 190,318 214,342 238,352 262,384 287,396" fill="none" stroke="#6342db" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="287" cy="396" r="5" fill="#6342db" stroke="#ffffff" stroke-width="2"/>
+    <text x="118" y="530" font-size="11" fill="#b6b3c8">Sep 1</text>
+    <text x="414" y="530" text-anchor="end" font-size="11" fill="#b6b3c8">Sep 14</text>
+    <!-- legend -->
+    <line x1="96" y1="548" x2="120" y2="548" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="6 5"/>
+    <text x="126" y="552" font-size="11" fill="#7a7791">Ideal</text>
+    <line x1="170" y1="548" x2="194" y2="548" stroke="#6342db" stroke-width="3"/>
+    <text x="200" y="552" font-size="11" fill="#7a7791">Actual</text>
+
+    <!-- Velocity card (partially visible below) -->
+    <rect x="76" y="582" width="358" height="290" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="96" y="612" font-size="15" font-weight="600" fill="#15131f">Velocity</text>
+    <rect x="270" y="602" width="10" height="10" rx="2" fill="#b6b3c8"/>
+    <text x="284" y="611" font-size="11" fill="#7a7791">Committed</text>
+    <rect x="352" y="602" width="10" height="10" rx="2" fill="#6342db"/>
+    <text x="366" y="611" font-size="11" fill="#7a7791">Delivered</text>
+    <!-- bars -->
+    <line x1="96" y1="800" x2="414" y2="800" stroke="#dedcea"/>
+    <rect x="116" y="704" width="22" height="96" rx="4" fill="#b6b3c8"/>
+    <rect x="142" y="722" width="22" height="78" rx="4" fill="#6342db"/>
+    <rect x="193" y="692" width="22" height="108" rx="4" fill="#b6b3c8"/>
+    <rect x="219" y="696" width="22" height="104" rx="4" fill="#6342db"/>
+    <rect x="270" y="716" width="22" height="84" rx="4" fill="#b6b3c8"/>
+    <rect x="296" y="704" width="22" height="96" rx="4" fill="#6342db"/>
+    <rect x="347" y="682" width="22" height="118" rx="4" fill="#b6b3c8"/>
+    <rect x="373" y="734" width="22" height="66" rx="4" fill="#6342db"/>
+    <text x="140" y="820" text-anchor="middle" font-size="11" fill="#7a7791">C4</text>
+    <text x="217" y="820" text-anchor="middle" font-size="11" fill="#7a7791">C5</text>
+    <text x="294" y="820" text-anchor="middle" font-size="11" fill="#7a7791">C6</text>
+    <text x="371" y="820" text-anchor="middle" font-size="11" fill="#7a7791">C7</text>
+
+    <!-- bottom nav -->
+    <rect x="62" y="827" width="386" height="61" fill="#ffffff"/>
+    <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="99" y="879" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Home</text>
+    <rect x="166" y="838" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="175" y="838" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="184" y="838" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="177" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="253" cy="847" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="259" y1="853" x2="265" y2="859" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="255" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="333" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#b6b3c8"/>
+    <text x="411" y="879" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+  </g>
+
+  <!-- ======================= FOLDABLE FRAME ======================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fclip)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1204" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="1209" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="1214" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M1222 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="1238" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="1240" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="1257" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <path d="M532 138 L606 138 L606 888 L558 888 Q532 888 532 862 Z" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="230" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="568" y="272" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Home</text>
+    <rect x="558" y="308" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="567" y="308" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="576" y="308" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="568" y="350" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="566" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="572" y1="401" x2="578" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="568" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="557" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="568" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="568" cy="553" r="11" fill="#b6b3c8"/>
+    <text x="568" y="584" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- header -->
+    <text x="630" y="180" font-size="18" font-weight="700" fill="#15131f">Reports</text>
+    <rect x="1156" y="156" width="98" height="32" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="1205" y="177" text-anchor="middle" font-size="13" fill="#514e66">Cycle 7 ▾</text>
+
+    <!-- Burndown card, left of hinge, full height -->
+    <rect x="620" y="200" width="254" height="656" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="640" y="230" font-size="15" font-weight="600" fill="#15131f">Burndown</text>
+    <text x="854" y="230" text-anchor="end" font-size="12" fill="#7a7791">Cycle 7</text>
+    <line x1="660" y1="387" x2="854" y2="387" stroke="#eeedf5"/>
+    <line x1="660" y1="514" x2="854" y2="514" stroke="#eeedf5"/>
+    <line x1="660" y1="641" x2="854" y2="641" stroke="#eeedf5"/>
+    <line x1="660" y1="260" x2="660" y2="768" stroke="#dedcea"/>
+    <line x1="660" y1="768" x2="854" y2="768" stroke="#dedcea"/>
+    <text x="652" y="272" text-anchor="end" font-size="11" fill="#b6b3c8">24</text>
+    <text x="652" y="772" text-anchor="end" font-size="11" fill="#b6b3c8">0</text>
+    <line x1="660" y1="268" x2="854" y2="768" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="7 6"/>
+    <line x1="771" y1="260" x2="771" y2="768" stroke="#f29d0b" stroke-width="1.5" stroke-dasharray="3 5" opacity="0.85"/>
+    <text x="771" y="254" text-anchor="middle" font-size="11" font-weight="600" fill="#f29d0b">Today</text>
+    <polyline points="660,268 682,274 704,306 726,318 748,362 771,398" fill="none" stroke="#6342db" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="771" cy="398" r="5" fill="#6342db" stroke="#ffffff" stroke-width="2"/>
+    <text x="660" y="786" font-size="11" fill="#b6b3c8">Sep 1</text>
+    <text x="854" y="786" text-anchor="end" font-size="11" fill="#b6b3c8">Sep 14</text>
+    <line x1="640" y1="812" x2="662" y2="812" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="6 5"/>
+    <text x="668" y="816" font-size="11" fill="#7a7791">Ideal</text>
+    <line x1="716" y1="812" x2="738" y2="812" stroke="#6342db" stroke-width="3"/>
+    <text x="744" y="816" font-size="11" fill="#7a7791">Actual</text>
+
+    <!-- Velocity card, right of hinge, full height -->
+    <rect x="918" y="200" width="336" height="656" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="938" y="230" font-size="15" font-weight="600" fill="#15131f">Velocity</text>
+    <rect x="938" y="246" width="10" height="10" rx="2" fill="#b6b3c8"/>
+    <text x="952" y="255" font-size="11" fill="#7a7791">Committed</text>
+    <rect x="1030" y="246" width="10" height="10" rx="2" fill="#6342db"/>
+    <text x="1044" y="255" font-size="11" fill="#7a7791">Delivered</text>
+    <line x1="946" y1="448" x2="1234" y2="448" stroke="#eeedf5"/>
+    <line x1="946" y1="604" x2="1234" y2="604" stroke="#eeedf5"/>
+    <line x1="946" y1="290" x2="946" y2="760" stroke="#dedcea"/>
+    <line x1="946" y1="760" x2="1234" y2="760" stroke="#dedcea"/>
+    <text x="938" y="300" text-anchor="end" font-size="11" fill="#b6b3c8">40</text>
+    <text x="938" y="764" text-anchor="end" font-size="11" fill="#b6b3c8">0</text>
+    <rect x="954" y="460" width="26" height="300" rx="4" fill="#b6b3c8"/>
+    <rect x="984" y="510" width="26" height="250" rx="4" fill="#6342db"/>
+    <rect x="1026" y="420" width="26" height="340" rx="4" fill="#b6b3c8"/>
+    <rect x="1056" y="430" width="26" height="330" rx="4" fill="#6342db"/>
+    <rect x="1098" y="490" width="26" height="270" rx="4" fill="#b6b3c8"/>
+    <rect x="1128" y="455" width="26" height="305" rx="4" fill="#6342db"/>
+    <rect x="1170" y="380" width="26" height="380" rx="4" fill="#b6b3c8"/>
+    <rect x="1200" y="550" width="26" height="210" rx="4" fill="#6342db"/>
+    <text x="982" y="782" text-anchor="middle" font-size="12" fill="#7a7791">C4</text>
+    <text x="1054" y="782" text-anchor="middle" font-size="12" fill="#7a7791">C5</text>
+    <text x="1126" y="782" text-anchor="middle" font-size="12" fill="#7a7791">C6</text>
+    <text x="1198" y="782" text-anchor="middle" font-size="12" fill="#7a7791">C7</text>
+    <text x="938" y="816" font-size="11" fill="#b6b3c8">C7 in progress — delivered so far</text>
+  </g>
+
+  <!-- ======================= TABLET FRAME ======================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tclip)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2434" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="2439" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="2444" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M2452 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="2468" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="2470" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="2487" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <path d="M1352 138 L1426 138 L1426 888 L1378 888 Q1352 888 1352 862 Z" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="230" width="22" height="22" rx="6" fill="#6342db"/>
+    <text x="1388" y="272" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Home</text>
+    <rect x="1378" y="308" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="1387" y="308" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="1396" y="308" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="1388" y="350" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="1386" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="1392" y1="401" x2="1398" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="1388" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="1377" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="1388" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="1388" cy="553" r="11" fill="#b6b3c8"/>
+    <text x="1388" y="584" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+
+    <!-- header + cycle picker -->
+    <text x="1454" y="184" font-size="20" font-weight="700" fill="#15131f">Reports</text>
+    <text x="1560" y="184" font-size="13" fill="#7a7791">ENG · last 4 cycles</text>
+    <rect x="2350" y="156" width="120" height="40" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2410" y="181" text-anchor="middle" font-size="14" fill="#514e66">Cycle 7 ▾</text>
+
+    <!-- Card A: Burndown (top-left) -->
+    <rect x="1454" y="210" width="494" height="320" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1474" y="240" font-size="15" font-weight="600" fill="#15131f">Burndown</text>
+    <text x="1928" y="240" text-anchor="end" font-size="12" fill="#7a7791">Cycle 7 · Sep 1–14</text>
+    <line x1="1494" y1="318" x2="1928" y2="318" stroke="#eeedf5"/>
+    <line x1="1494" y1="378" x2="1928" y2="378" stroke="#eeedf5"/>
+    <line x1="1494" y1="438" x2="1928" y2="438" stroke="#eeedf5"/>
+    <line x1="1494" y1="258" x2="1494" y2="500" stroke="#dedcea"/>
+    <line x1="1494" y1="500" x2="1928" y2="500" stroke="#dedcea"/>
+    <text x="1486" y="268" text-anchor="end" font-size="11" fill="#b6b3c8">24</text>
+    <text x="1486" y="504" text-anchor="end" font-size="11" fill="#b6b3c8">0</text>
+    <line x1="1494" y1="264" x2="1928" y2="500" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="7 6"/>
+    <line x1="1742" y1="258" x2="1742" y2="500" stroke="#f29d0b" stroke-width="1.5" stroke-dasharray="3 5" opacity="0.85"/>
+    <text x="1742" y="254" text-anchor="middle" font-size="11" font-weight="600" fill="#f29d0b">Today</text>
+    <polyline points="1494,264 1530,270 1566,296 1602,306 1638,340 1674,352 1706,382 1742,398" fill="none" stroke="#6342db" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="1742" cy="398" r="5" fill="#6342db" stroke="#ffffff" stroke-width="2"/>
+    <text x="1494" y="518" font-size="11" fill="#b6b3c8">Sep 1</text>
+    <text x="1928" y="518" text-anchor="end" font-size="11" fill="#b6b3c8">Sep 14</text>
+
+    <!-- Card B: Velocity (top-right) -->
+    <rect x="1976" y="210" width="494" height="320" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1996" y="240" font-size="15" font-weight="600" fill="#15131f">Velocity</text>
+    <rect x="2270" y="228" width="10" height="10" rx="2" fill="#b6b3c8"/>
+    <text x="2284" y="237" font-size="11" fill="#7a7791">Committed</text>
+    <rect x="2360" y="228" width="10" height="10" rx="2" fill="#6342db"/>
+    <text x="2374" y="237" font-size="11" fill="#7a7791">Delivered</text>
+    <line x1="2016" y1="338" x2="2450" y2="338" stroke="#eeedf5"/>
+    <line x1="2016" y1="415" x2="2450" y2="415" stroke="#eeedf5"/>
+    <line x1="2016" y1="262" x2="2016" y2="492" stroke="#dedcea"/>
+    <line x1="2016" y1="492" x2="2450" y2="492" stroke="#dedcea"/>
+    <text x="2008" y="272" text-anchor="end" font-size="11" fill="#b6b3c8">40</text>
+    <text x="2008" y="496" text-anchor="end" font-size="11" fill="#b6b3c8">0</text>
+    <rect x="2037" y="322" width="30" height="170" rx="4" fill="#b6b3c8"/>
+    <rect x="2073" y="352" width="30" height="140" rx="4" fill="#6342db"/>
+    <rect x="2145" y="297" width="30" height="195" rx="4" fill="#b6b3c8"/>
+    <rect x="2181" y="302" width="30" height="190" rx="4" fill="#6342db"/>
+    <rect x="2253" y="342" width="30" height="150" rx="4" fill="#b6b3c8"/>
+    <rect x="2289" y="320" width="30" height="172" rx="4" fill="#6342db"/>
+    <rect x="2361" y="282" width="30" height="210" rx="4" fill="#b6b3c8"/>
+    <rect x="2397" y="374" width="30" height="118" rx="4" fill="#6342db"/>
+    <text x="2070" y="512" text-anchor="middle" font-size="11" fill="#7a7791">C4</text>
+    <text x="2178" y="512" text-anchor="middle" font-size="11" fill="#7a7791">C5</text>
+    <text x="2286" y="512" text-anchor="middle" font-size="11" fill="#7a7791">C6</text>
+    <text x="2394" y="512" text-anchor="middle" font-size="11" fill="#7a7791">C7</text>
+
+    <!-- Card C: Cumulative flow (bottom-left) -->
+    <rect x="1454" y="550" width="494" height="320" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1474" y="580" font-size="15" font-weight="600" fill="#15131f">Cumulative flow</text>
+    <circle cx="1650" cy="572" r="4" fill="#9b98b0"/>
+    <text x="1658" y="576" font-size="11" fill="#7a7791">Backlog</text>
+    <circle cx="1716" cy="572" r="4" fill="#f29d0b"/>
+    <text x="1724" y="576" font-size="11" fill="#7a7791">In progress</text>
+    <circle cx="1802" cy="572" r="4" fill="#8b5cf6"/>
+    <text x="1810" y="576" font-size="11" fill="#7a7791">Review</text>
+    <circle cx="1866" cy="572" r="4" fill="#12a474"/>
+    <text x="1874" y="576" font-size="11" fill="#7a7791">Done</text>
+    <line x1="1494" y1="598" x2="1494" y2="830" stroke="#dedcea"/>
+    <!-- stacked bands (bottom band = Done) -->
+    <polygon points="1494,640 1580,634 1670,630 1760,626 1840,622 1928,616 1928,830 1494,830" fill="#9b98b0"/>
+    <polygon points="1494,816 1580,794 1670,762 1760,724 1840,690 1928,660 1928,830 1494,830" fill="#f29d0b"/>
+    <polygon points="1494,824 1580,810 1670,788 1760,760 1840,730 1928,700 1928,830 1494,830" fill="#8b5cf6"/>
+    <polygon points="1494,828 1580,820 1670,806 1760,786 1840,764 1928,742 1928,830 1494,830" fill="#12a474"/>
+    <line x1="1494" y1="830" x2="1928" y2="830" stroke="#dedcea"/>
+    <text x="1494" y="848" font-size="11" fill="#b6b3c8">Aug 1</text>
+    <text x="1928" y="848" text-anchor="end" font-size="11" fill="#b6b3c8">Sep 11</text>
+
+    <!-- Card D: Created vs resolved (bottom-right) -->
+    <rect x="1976" y="550" width="494" height="320" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1996" y="580" font-size="15" font-weight="600" fill="#15131f">Created vs resolved</text>
+    <line x1="2270" y1="572" x2="2290" y2="572" stroke="#3f82f6" stroke-width="3"/>
+    <text x="2296" y="576" font-size="11" fill="#7a7791">Created</text>
+    <line x1="2360" y1="572" x2="2380" y2="572" stroke="#2fd4a7" stroke-width="3"/>
+    <text x="2386" y="576" font-size="11" fill="#7a7791">Resolved</text>
+    <line x1="2016" y1="656" x2="2450" y2="656" stroke="#eeedf5"/>
+    <line x1="2016" y1="714" x2="2450" y2="714" stroke="#eeedf5"/>
+    <line x1="2016" y1="772" x2="2450" y2="772" stroke="#eeedf5"/>
+    <line x1="2016" y1="598" x2="2016" y2="830" stroke="#dedcea"/>
+    <line x1="2016" y1="830" x2="2450" y2="830" stroke="#dedcea"/>
+    <polyline points="2016,780 2078,742 2140,756 2202,700 2264,712 2326,668 2388,684 2450,640" fill="none" stroke="#3f82f6" stroke-width="2.5" stroke-linejoin="round"/>
+    <polyline points="2016,806 2078,790 2140,760 2202,742 2264,706 2326,716 2388,672 2450,662" fill="none" stroke="#2fd4a7" stroke-width="2.5" stroke-linejoin="round"/>
+    <text x="2016" y="848" font-size="11" fill="#b6b3c8">Aug 1</text>
+    <text x="2450" y="848" text-anchor="end" font-size="11" fill="#b6b3c8">Sep 11</text>
+  </g>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" text-anchor="middle" font-size="16" fill="#7a7791">Tap any datapoint to see its exact values — charts replay recorded workspace history for the selected cycle.</text>
+</svg>

--- a/docs/design/mobile/151-saved-views.svg
+++ b/docs/design/mobile/151-saved-views.svg
@@ -1,0 +1,367 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Saved views</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pclip"><rect x="62" y="112" width="386" height="776" rx="26"/></clipPath>
+    <clipPath id="fclip"><rect x="532" y="112" width="736" height="776" rx="26"/></clipPath>
+    <clipPath id="tclip"><rect x="1352" y="112" width="1146" height="776" rx="26"/></clipPath>
+  </defs>
+
+  <!-- ======================= PHONE FRAME ======================= -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pclip)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="384" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="389" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="394" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M402 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="418" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="420" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="437" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- board behind (low-fi) -->
+    <text x="84" y="172" font-size="17" font-weight="700" fill="#15131f">Board · ENG</text>
+    <text x="426" y="172" text-anchor="end" font-size="13" fill="#6342db" font-weight="600">Views ▾</text>
+    <rect x="76" y="196" width="180" height="620" rx="12" fill="#f7f6fb"/>
+    <circle cx="94" cy="220" r="5" fill="#f29d0b"/>
+    <text x="106" y="225" font-size="13" font-weight="600" fill="#514e66">In Progress</text>
+    <rect x="88" y="240" width="156" height="82" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="100" y="262" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <rect x="100" y="272" width="132" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="100" y="286" width="92" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="230" cy="304" r="9" fill="#4f8cff"/>
+    <rect x="88" y="334" width="156" height="82" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="100" y="356" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+    <rect x="100" y="366" width="120" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="100" y="380" width="100" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="230" cy="398" r="9" fill="#ff6fae"/>
+    <rect x="88" y="428" width="156" height="82" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="100" y="450" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+    <rect x="100" y="460" width="126" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="100" y="474" width="84" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="230" cy="492" r="9" fill="#2fd4a7"/>
+    <rect x="268" y="196" width="180" height="620" rx="12" fill="#f7f6fb"/>
+    <circle cx="286" cy="220" r="5" fill="#6f6c86"/>
+    <text x="298" y="225" font-size="13" font-weight="600" fill="#514e66">Todo</text>
+    <rect x="280" y="240" width="156" height="82" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="292" y="262" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+    <rect x="292" y="272" width="128" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="292" y="286" width="96" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="422" cy="304" r="9" fill="#ffb648"/>
+    <rect x="280" y="334" width="156" height="82" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="292" y="356" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+    <rect x="292" y="366" width="116" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="292" y="380" width="104" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="422" cy="398" r="9" fill="#6342db"/>
+
+    <!-- bottom nav (under scrim) -->
+    <rect x="62" y="827" width="386" height="61" fill="#ffffff"/>
+    <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="99" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="166" y="838" width="6" height="22" rx="2" fill="#6342db"/>
+    <rect x="175" y="838" width="6" height="16" rx="2" fill="#6342db"/>
+    <rect x="184" y="838" width="6" height="19" rx="2" fill="#6342db"/>
+    <text x="177" y="879" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Board</text>
+    <circle cx="253" cy="847" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="259" y1="853" x2="265" y2="859" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="255" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="333" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#b6b3c8"/>
+    <text x="411" y="879" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+
+    <!-- scrim -->
+    <rect x="62" y="112" width="386" height="776" fill="#15131f" opacity="0.35"/>
+
+    <!-- bottom sheet -->
+    <path d="M62 888 L62 416 Q62 396 82 396 L428 396 Q448 396 448 416 L448 888 Z" fill="#ffffff"/>
+    <rect x="237" y="406" width="36" height="5" rx="2.5" fill="#dedcea"/>
+    <text x="88" y="442" font-size="17" font-weight="700" fill="#15131f">Views</text>
+
+    <!-- row 1: All issues -->
+    <circle cx="104" cy="486" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="126" y="491" font-size="15" fill="#15131f">All issues</text>
+    <line x1="88" y1="514" x2="432" y2="514" stroke="#eeedf5"/>
+    <!-- row 2: My urgent bugs (private, lock) -->
+    <circle cx="104" cy="542" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="126" y="540" font-size="15" fill="#15131f">My urgent bugs</text>
+    <rect x="236" y="530" width="11" height="8" rx="2" fill="#7a7791"/>
+    <path d="M238.5 530 v-3 a3 3 0 0 1 6 0 v3" fill="none" stroke="#7a7791" stroke-width="1.5"/>
+    <text x="126" y="560" font-size="12" fill="#7a7791">Private · only you</text>
+    <line x1="88" y1="570" x2="432" y2="570" stroke="#eeedf5"/>
+    <!-- row 3: Current cycle (selected) -->
+    <circle cx="104" cy="598" r="9" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+    <circle cx="104" cy="598" r="4.5" fill="#6342db"/>
+    <text x="126" y="596" font-size="15" font-weight="600" fill="#15131f">Current cycle</text>
+    <text x="126" y="616" font-size="12" fill="#7a7791">Shared · Team default</text>
+    <polygon points="262,604 264.4,610.4 271,610.7 265.9,614.9 267.6,621.3 262,617.6 256.4,621.3 258.1,614.9 253,610.7 259.6,610.4" fill="#ef9d0b"/>
+    <line x1="88" y1="626" x2="432" y2="626" stroke="#eeedf5"/>
+    <!-- row 4: Design review -->
+    <circle cx="104" cy="654" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="126" y="652" font-size="15" fill="#15131f">Design review</text>
+    <text x="126" y="672" font-size="12" fill="#7a7791">Shared</text>
+    <line x1="88" y1="682" x2="432" y2="682" stroke="#eeedf5"/>
+    <!-- actions row -->
+    <rect x="76" y="698" width="358" height="6" fill="#f7f6fb"/>
+    <text x="104" y="740" text-anchor="middle" font-size="18" font-weight="600" fill="#6342db">+</text>
+    <text x="126" y="738" font-size="15" font-weight="600" fill="#6342db">Save current filters as view…</text>
+  </g>
+
+  <!-- ======================= FOLDABLE FRAME ======================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fclip)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1204" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="1209" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="1214" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M1222 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="1238" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="1240" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="1257" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <path d="M532 138 L606 138 L606 888 L558 888 Q532 888 532 862 Z" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="230" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="568" y="272" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="558" y="308" width="6" height="22" rx="2" fill="#6342db"/>
+    <rect x="567" y="308" width="6" height="16" rx="2" fill="#6342db"/>
+    <rect x="576" y="308" width="6" height="19" rx="2" fill="#6342db"/>
+    <text x="568" y="350" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Board</text>
+    <circle cx="566" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="572" y1="401" x2="578" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="568" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="557" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="568" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="568" cy="553" r="11" fill="#b6b3c8"/>
+    <text x="568" y="584" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- left pane: board with filter chips -->
+    <text x="630" y="180" font-size="17" font-weight="700" fill="#15131f">Board · ENG</text>
+    <rect x="622" y="194" width="72" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="658" y="212" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">Cycle 7</text>
+    <rect x="702" y="194" width="50" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="727" y="212" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">Bug</text>
+    <rect x="760" y="194" width="66" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="793" y="212" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">P1–P2</text>
+    <rect x="622" y="236" width="252" height="620" rx="12" fill="#f7f6fb"/>
+    <circle cx="642" cy="262" r="5" fill="#f29d0b"/>
+    <text x="654" y="267" font-size="13" font-weight="600" fill="#514e66">In Progress</text>
+    <text x="858" y="267" text-anchor="end" font-size="12" fill="#7a7791">3</text>
+    <rect x="634" y="282" width="228" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="648" y="304" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="648" y="322" font-size="12" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="648" y="334" width="46" height="20" rx="10" fill="#e0424a" fill-opacity="0.15"/>
+    <text x="671" y="348" text-anchor="middle" font-size="12" font-weight="600" fill="#e0424a">P1</text>
+    <circle cx="844" cy="356" r="9" fill="#4f8cff"/>
+    <text x="844" y="360" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">A</text>
+    <rect x="634" y="390" width="228" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="648" y="412" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+    <rect x="648" y="422" width="184" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="648" y="436" width="128" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="648" y="454" width="46" height="20" rx="10" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="671" y="468" text-anchor="middle" font-size="12" font-weight="600" fill="#f2721c">P2</text>
+    <circle cx="844" cy="464" r="9" fill="#ff6fae"/>
+    <text x="844" y="468" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">D</text>
+    <rect x="634" y="498" width="228" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="648" y="520" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+    <rect x="648" y="530" width="172" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="648" y="544" width="110" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="648" y="562" width="46" height="20" rx="10" fill="#e0424a" fill-opacity="0.15"/>
+    <text x="671" y="576" text-anchor="middle" font-size="12" font-weight="600" fill="#e0424a">P1</text>
+    <circle cx="844" cy="572" r="9" fill="#2fd4a7"/>
+    <text x="844" y="576" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">M</text>
+
+    <!-- right pane: views list + detail -->
+    <text x="918" y="180" font-size="17" font-weight="700" fill="#15131f">Views</text>
+    <circle cx="934" cy="215" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="956" y="220" font-size="14" fill="#15131f">All issues</text>
+    <circle cx="934" cy="261" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="956" y="266" font-size="14" fill="#15131f">My urgent bugs</text>
+    <rect x="1066" y="254" width="11" height="8" rx="2" fill="#7a7791"/>
+    <path d="M1068.5 254 v-3 a3 3 0 0 1 6 0 v3" fill="none" stroke="#7a7791" stroke-width="1.5"/>
+    <text x="1244" y="266" text-anchor="end" font-size="11" fill="#7a7791">Private</text>
+    <rect x="914" y="286" width="340" height="42" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <circle cx="934" cy="307" r="9" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+    <circle cx="934" cy="307" r="4.5" fill="#6342db"/>
+    <text x="956" y="312" font-size="14" font-weight="600" fill="#15131f">Current cycle</text>
+    <text x="1244" y="312" text-anchor="end" font-size="11" fill="#7a7791">Team default</text>
+    <circle cx="934" cy="353" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="956" y="358" font-size="14" fill="#15131f">Design review</text>
+    <text x="1244" y="358" text-anchor="end" font-size="11" fill="#7a7791">Shared</text>
+
+    <!-- detail card for selected view -->
+    <rect x="914" y="400" width="340" height="290" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="430" font-size="15" font-weight="600" fill="#15131f">Edit view</text>
+    <text x="934" y="458" font-size="13" fill="#514e66">Name</text>
+    <rect x="934" y="468" width="300" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="950" y="498" font-size="15" fill="#15131f">Current cycle</text>
+    <text x="934" y="561" font-size="14" fill="#15131f">Shared with team</text>
+    <rect x="1190" y="543" width="44" height="26" rx="13" fill="#6342db"/>
+    <circle cx="1223" cy="556" r="10" fill="#ffffff"/>
+    <text x="934" y="605" font-size="14" fill="#15131f">Set as team default</text>
+    <rect x="1182" y="589" width="52" height="22" rx="11" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1208" y="604" text-anchor="middle" font-size="11" fill="#7a7791">Admin</text>
+    <line x1="934" y1="630" x2="1234" y2="630" stroke="#eeedf5"/>
+    <text x="934" y="664" font-size="14" font-weight="600" fill="#e0424a">Delete view</text>
+  </g>
+
+  <!-- ======================= TABLET FRAME ======================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tclip)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2434" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="2439" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="2444" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M2452 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="2468" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="2470" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="2487" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail -->
+    <path d="M1352 138 L1426 138 L1426 888 L1378 888 Q1352 888 1352 862 Z" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="230" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="1388" y="272" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="1378" y="308" width="6" height="22" rx="2" fill="#6342db"/>
+    <rect x="1387" y="308" width="6" height="16" rx="2" fill="#6342db"/>
+    <rect x="1396" y="308" width="6" height="19" rx="2" fill="#6342db"/>
+    <text x="1388" y="350" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">Board</text>
+    <circle cx="1386" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="1392" y1="401" x2="1398" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="1388" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="1377" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="1388" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="1388" cy="553" r="11" fill="#b6b3c8"/>
+    <text x="1388" y="584" text-anchor="middle" font-size="11" fill="#7a7791">You</text>
+
+    <!-- board header + applied view filter chips -->
+    <text x="1454" y="182" font-size="18" font-weight="700" fill="#15131f">Board · ENG</text>
+    <text x="1620" y="182" font-size="13" fill="#7a7791">View: Current cycle</text>
+    <rect x="1454" y="198" width="88" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="1498" y="216" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">Cycle 7 ×</text>
+    <rect x="1550" y="198" width="64" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="1582" y="216" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">Bug ×</text>
+    <rect x="1622" y="198" width="82" height="28" rx="14" fill="#6342db" fill-opacity="0.12"/>
+    <text x="1663" y="216" text-anchor="middle" font-size="12" font-weight="600" fill="#6342db">P1–P2 ×</text>
+
+    <!-- columns -->
+    <rect x="1454" y="240" width="204" height="616" rx="12" fill="#f7f6fb"/>
+    <circle cx="1472" cy="266" r="5" fill="#6f6c86"/>
+    <text x="1484" y="271" font-size="13" font-weight="600" fill="#514e66">Todo</text>
+    <text x="1642" y="271" text-anchor="end" font-size="12" fill="#7a7791">2</text>
+    <rect x="1466" y="286" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1478" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+    <text x="1478" y="326" font-size="12" fill="#15131f">Avatar upload crops</text>
+    <text x="1478" y="342" font-size="12" fill="#15131f">offset on rotate</text>
+    <rect x="1478" y="352" width="38" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/>
+    <text x="1497" y="365" text-anchor="middle" font-size="11" font-weight="600" fill="#f2721c">P2</text>
+    <circle cx="1628" cy="360" r="9" fill="#ffb648"/>
+    <text x="1628" y="364" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">S</text>
+    <rect x="1466" y="394" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1478" y="416" font-size="11" font-weight="600" fill="#7a7791">ENG-153</text>
+    <rect x="1478" y="428" width="144" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="1478" y="442" width="100" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="1628" cy="468" r="9" fill="#6342db"/>
+    <text x="1628" y="472" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">W</text>
+
+    <rect x="1682" y="240" width="204" height="616" rx="12" fill="#f7f6fb"/>
+    <circle cx="1700" cy="266" r="5" fill="#f29d0b"/>
+    <text x="1712" y="271" font-size="13" font-weight="600" fill="#514e66">In Progress</text>
+    <text x="1870" y="271" text-anchor="end" font-size="12" fill="#7a7791">3</text>
+    <rect x="1694" y="286" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1706" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <text x="1706" y="326" font-size="12" fill="#15131f">Fix drag ghost offset</text>
+    <text x="1706" y="342" font-size="12" fill="#15131f">on Safari</text>
+    <rect x="1706" y="352" width="38" height="18" rx="9" fill="#e0424a" fill-opacity="0.15"/>
+    <text x="1725" y="365" text-anchor="middle" font-size="11" font-weight="600" fill="#e0424a">P1</text>
+    <circle cx="1856" cy="360" r="9" fill="#4f8cff"/>
+    <text x="1856" y="364" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">A</text>
+    <rect x="1694" y="394" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1706" y="416" font-size="11" font-weight="600" fill="#7a7791">ENG-147</text>
+    <rect x="1706" y="428" width="140" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="1706" y="442" width="96" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="1856" cy="468" r="9" fill="#ff6fae"/>
+    <text x="1856" y="472" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">D</text>
+    <rect x="1694" y="502" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1706" y="524" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+    <rect x="1706" y="536" width="132" height="8" rx="4" fill="#eeedf5"/>
+    <rect x="1706" y="550" width="108" height="8" rx="4" fill="#eeedf5"/>
+    <circle cx="1856" cy="576" r="9" fill="#2fd4a7"/>
+    <text x="1856" y="580" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">M</text>
+
+    <rect x="1910" y="240" width="204" height="616" rx="12" fill="#f7f6fb"/>
+    <circle cx="1928" cy="266" r="5" fill="#8b5cf6"/>
+    <text x="1940" y="271" font-size="13" font-weight="600" fill="#514e66">In Review</text>
+    <text x="2098" y="271" text-anchor="end" font-size="12" fill="#7a7791">1</text>
+    <rect x="1922" y="286" width="180" height="96" rx="10" fill="#ffffff" stroke="#eeedf5"/>
+    <text x="1934" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+    <text x="1934" y="326" font-size="12" fill="#15131f">Board virtualization</text>
+    <text x="1934" y="342" font-size="12" fill="#15131f">for large teams</text>
+    <rect x="1934" y="352" width="38" height="18" rx="9" fill="#e0424a" fill-opacity="0.15"/>
+    <text x="1953" y="365" text-anchor="middle" font-size="11" font-weight="600" fill="#e0424a">P1</text>
+    <circle cx="2084" cy="360" r="9" fill="#6342db"/>
+    <text x="2084" y="364" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">W</text>
+
+    <!-- right side sheet (360px) -->
+    <rect x="2138" y="112" width="360" height="776" fill="#ffffff"/>
+    <line x1="2138" y1="112" x2="2138" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <text x="2162" y="176" font-size="17" font-weight="700" fill="#15131f">Views</text>
+    <text x="2472" y="176" text-anchor="end" font-size="16" fill="#7a7791">×</text>
+    <circle cx="2178" cy="223" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="2200" y="228" font-size="14" fill="#15131f">All issues</text>
+    <circle cx="2178" cy="269" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="2200" y="274" font-size="14" fill="#15131f">My urgent bugs</text>
+    <rect x="2310" y="262" width="11" height="8" rx="2" fill="#7a7791"/>
+    <path d="M2312.5 262 v-3 a3 3 0 0 1 6 0 v3" fill="none" stroke="#7a7791" stroke-width="1.5"/>
+    <text x="2472" y="274" text-anchor="end" font-size="11" fill="#7a7791">Private</text>
+    <rect x="2152" y="294" width="332" height="42" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <circle cx="2178" cy="315" r="9" fill="#ffffff" stroke="#6342db" stroke-width="2"/>
+    <circle cx="2178" cy="315" r="4.5" fill="#6342db"/>
+    <text x="2200" y="320" font-size="14" font-weight="600" fill="#15131f">Current cycle</text>
+    <text x="2472" y="320" text-anchor="end" font-size="11" fill="#7a7791">Team default</text>
+    <circle cx="2178" cy="361" r="9" fill="#ffffff" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="2200" y="366" font-size="14" fill="#15131f">Design review</text>
+    <text x="2472" y="366" text-anchor="end" font-size="11" fill="#7a7791">Shared</text>
+    <line x1="2162" y1="396" x2="2474" y2="396" stroke="#eeedf5"/>
+
+    <!-- detail -->
+    <text x="2162" y="428" font-size="13" fill="#514e66">Name</text>
+    <rect x="2162" y="438" width="312" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2178" y="468" font-size="15" fill="#15131f">Current cycle</text>
+    <text x="2162" y="533" font-size="14" fill="#15131f">Shared with team</text>
+    <rect x="2418" y="515" width="44" height="26" rx="13" fill="#6342db"/>
+    <circle cx="2451" cy="528" r="10" fill="#ffffff"/>
+    <text x="2162" y="581" font-size="14" fill="#15131f">Set as team default</text>
+    <rect x="2410" y="565" width="52" height="22" rx="11" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="2436" y="580" text-anchor="middle" font-size="11" fill="#7a7791">Admin</text>
+    <line x1="2162" y1="608" x2="2474" y2="608" stroke="#eeedf5"/>
+    <text x="2162" y="642" font-size="14" font-weight="600" fill="#e0424a">Delete view</text>
+    <rect x="2162" y="790" width="312" height="44" rx="10" fill="#6342db"/>
+    <text x="2318" y="818" text-anchor="middle" font-size="15" font-weight="600" fill="#ffffff">Save changes</text>
+  </g>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" text-anchor="middle" font-size="16" fill="#7a7791">A board opens with the first view found in order: your personal default → team default → All issues.</text>
+</svg>

--- a/docs/design/mobile/152-settings.svg
+++ b/docs/design/mobile/152-settings.svg
@@ -1,0 +1,277 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Profile &amp; account settings</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <defs>
+    <clipPath id="pclip"><rect x="62" y="112" width="386" height="776" rx="26"/></clipPath>
+    <clipPath id="fclip"><rect x="532" y="112" width="736" height="776" rx="26"/></clipPath>
+    <clipPath id="tclip"><rect x="1352" y="112" width="1146" height="776" rx="26"/></clipPath>
+  </defs>
+
+  <!-- ============ PHONE FRAME ============ -->
+  <rect x="60" y="116" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#pclip)">
+    <!-- status bar -->
+    <text x="84" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="384" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="389" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="394" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M402 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="418" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="420" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="437" y="124" width="2" height="4" fill="#514e66"/>
+
+    <text x="84" y="176" font-size="20" font-weight="700" fill="#15131f">Settings</text>
+
+    <!-- ACCOUNT -->
+    <text x="84" y="212" font-size="11" font-weight="600" fill="#7a7791" letter-spacing="1.2">ACCOUNT</text>
+    <circle cx="104" cy="256" r="20" fill="#4f8cff"/>
+    <text x="104" y="261" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">WK</text>
+    <text x="136" y="252" font-size="15" font-weight="600" fill="#15131f">Waleed K.</text>
+    <text x="136" y="272" font-size="12" fill="#7a7791">@waleed</text>
+    <text x="426" y="262" text-anchor="end" font-size="16" fill="#b6b3c8">›</text>
+    <line x1="84" y1="288" x2="434" y2="288" stroke="#eeedf5"/>
+    <rect x="84" y="303" width="22" height="22" rx="6" fill="#eeedf5"/>
+    <text x="118" y="319" font-size="15" fill="#15131f">Notifications</text>
+    <text x="426" y="319" text-anchor="end" font-size="16" fill="#b6b3c8">›</text>
+    <line x1="84" y1="340" x2="434" y2="340" stroke="#eeedf5"/>
+    <rect x="84" y="355" width="22" height="22" rx="6" fill="#eeedf5"/>
+    <text x="118" y="371" font-size="15" fill="#15131f">Security</text>
+    <text x="426" y="371" text-anchor="end" font-size="16" fill="#b6b3c8">›</text>
+
+    <!-- YOUR TEAMS -->
+    <text x="84" y="424" font-size="11" font-weight="600" fill="#7a7791" letter-spacing="1.2">YOUR TEAMS</text>
+    <rect x="84" y="440" width="24" height="24" rx="7" fill="#6342db"/>
+    <text x="96" y="456" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">E</text>
+    <text x="120" y="457" font-size="15" fill="#15131f">ENG · Engineering</text>
+    <text x="426" y="457" text-anchor="end" font-size="16" fill="#b6b3c8">›</text>
+    <line x1="84" y1="480" x2="434" y2="480" stroke="#eeedf5"/>
+    <rect x="84" y="494" width="24" height="24" rx="7" fill="#ff6fae"/>
+    <text x="96" y="510" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">D</text>
+    <text x="120" y="511" font-size="15" fill="#15131f">DES · Design</text>
+    <text x="426" y="511" text-anchor="end" font-size="16" fill="#b6b3c8">›</text>
+
+    <!-- INSTANCE -->
+    <text x="84" y="574" font-size="11" font-weight="600" fill="#7a7791" letter-spacing="1.2">INSTANCE</text>
+    <circle cx="96" cy="609" r="11" fill="none" stroke="#b6b3c8" stroke-width="2"/>
+    <line x1="85" y1="609" x2="107" y2="609" stroke="#b6b3c8" stroke-width="1.5"/>
+    <path d="M96 598 c-5 6 -5 16 0 22 c5 -6 5 -16 0 -22" fill="none" stroke="#b6b3c8" stroke-width="1.5"/>
+    <text x="120" y="615" font-size="15" fill="#15131f">track.acme.dev</text>
+    <text x="426" y="615" text-anchor="end" font-size="14" font-weight="600" fill="#6342db">Switch</text>
+
+    <!-- sign out -->
+    <line x1="76" y1="656" x2="434" y2="656" stroke="#eeedf5"/>
+    <text x="84" y="695" font-size="15" font-weight="600" fill="#e0424a">Sign out</text>
+    <text x="255" y="756" text-anchor="middle" font-size="11" fill="#b6b3c8">SoftTrack 1.4.0 (212)</text>
+
+    <!-- bottom nav (You active) -->
+    <rect x="62" y="827" width="386" height="61" fill="#ffffff"/>
+    <line x1="62" y1="826" x2="448" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="838" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="99" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="166" y="838" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="175" y="838" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="184" y="838" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="177" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="253" cy="847" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="259" y1="853" x2="265" y2="859" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="255" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="322" y="838" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="333" y="879" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="411" cy="849" r="11" fill="#6342db"/>
+    <text x="411" y="879" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">You</text>
+  </g>
+
+  <!-- ======================= FOLDABLE FRAME ======================= -->
+  <rect x="530" y="116" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#fclip)">
+    <!-- status bar -->
+    <text x="554" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1204" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="1209" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="1214" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M1222 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="1238" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="1240" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="1257" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail (You active) -->
+    <path d="M532 138 L606 138 L606 888 L558 888 Q532 888 532 862 Z" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="230" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="568" y="272" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="558" y="308" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="567" y="308" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="576" y="308" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="568" y="350" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="566" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="572" y1="401" x2="578" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="568" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="557" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="568" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="568" cy="553" r="11" fill="#6342db"/>
+    <text x="568" y="584" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">You</text>
+
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+
+    <!-- left pane: settings nav list -->
+    <text x="630" y="180" font-size="18" font-weight="700" fill="#15131f">Settings</text>
+    <circle cx="648" cy="224" r="18" fill="#4f8cff"/>
+    <text x="648" y="229" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">WK</text>
+    <text x="676" y="220" font-size="14" font-weight="600" fill="#15131f">Waleed K.</text>
+    <text x="676" y="238" font-size="11" fill="#7a7791">@waleed · track.acme.dev</text>
+    <rect x="618" y="268" width="256" height="44" rx="10" fill="#6342db" fill-opacity="0.1"/>
+    <text x="638" y="296" font-size="14" font-weight="600" fill="#6342db">Profile</text>
+    <text x="858" y="296" text-anchor="end" font-size="15" fill="#6342db">›</text>
+    <text x="638" y="340" font-size="14" fill="#15131f">Notifications</text>
+    <text x="858" y="340" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="638" y="384" font-size="14" fill="#15131f">Security</text>
+    <text x="858" y="384" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="638" y="428" font-size="14" fill="#15131f">Teams</text>
+    <text x="858" y="428" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="638" y="472" font-size="14" fill="#15131f">Instance</text>
+    <text x="858" y="472" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <line x1="618" y1="500" x2="874" y2="500" stroke="#eeedf5"/>
+    <text x="638" y="536" font-size="14" font-weight="600" fill="#e0424a">Sign out</text>
+
+    <!-- right pane: profile form -->
+    <text x="926" y="182" font-size="17" font-weight="700" fill="#15131f">Profile</text>
+    <text x="926" y="214" font-size="13" fill="#514e66">Avatar color</text>
+    <circle cx="942" cy="248" r="21" fill="none" stroke="#6342db" stroke-width="2.5"/>
+    <circle cx="942" cy="248" r="16" fill="#4f8cff"/>
+    <text x="942" y="253" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">WK</text>
+    <circle cx="990" cy="248" r="16" fill="#ff6fae"/>
+    <circle cx="1034" cy="248" r="16" fill="#2fd4a7"/>
+    <circle cx="1078" cy="248" r="16" fill="#ffb648"/>
+    <circle cx="1122" cy="248" r="16" fill="#6342db"/>
+    <text x="926" y="298" font-size="13" fill="#514e66">Full name</text>
+    <rect x="926" y="308" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="942" y="338" font-size="15" fill="#15131f">Waleed K.</text>
+    <text x="926" y="384" font-size="13" fill="#514e66">Username</text>
+    <rect x="926" y="394" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="942" y="424" font-size="15" fill="#15131f">waleed</text>
+    <text x="926" y="460" font-size="12" fill="#7a7791">Letters, numbers, dashes</text>
+    <text x="926" y="492" font-size="13" fill="#514e66">Email</text>
+    <rect x="926" y="502" width="326" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="942" y="532" font-size="15" fill="#15131f">waleed@acme.dev</text>
+    <rect x="926" y="562" width="10" height="8" rx="2" fill="#7a7791"/>
+    <path d="M928 562 v-3 a3 3 0 0 1 6 0 v3" fill="none" stroke="#7a7791" stroke-width="1.5"/>
+    <text x="942" y="570" font-size="12" fill="#7a7791">Changing email requires your current password</text>
+    <rect x="926" y="596" width="150" height="44" rx="10" fill="#6342db"/>
+    <text x="1001" y="623" text-anchor="middle" font-size="15" font-weight="600" fill="#ffffff">Save changes</text>
+  </g>
+
+  <!-- ======================= TABLET FRAME ======================= -->
+  <rect x="1350" y="116" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#tclip)">
+    <!-- status bar -->
+    <text x="1374" y="132" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2434" y="125" width="3" height="6" fill="#514e66"/>
+    <rect x="2439" y="122" width="3" height="9" fill="#514e66"/>
+    <rect x="2444" y="119" width="3" height="12" fill="#514e66"/>
+    <path d="M2452 128 a6 6 0 0 1 10 0" stroke="#514e66" stroke-width="2" fill="none"/>
+    <rect x="2468" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66"/>
+    <rect x="2470" y="123" width="11" height="6" fill="#514e66"/>
+    <rect x="2487" y="124" width="2" height="4" fill="#514e66"/>
+
+    <!-- nav rail (You active) -->
+    <path d="M1352 138 L1426 138 L1426 888 L1378 888 Q1352 888 1352 862 Z" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="888" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="158" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="230" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="1388" y="272" text-anchor="middle" font-size="11" fill="#7a7791">Home</text>
+    <rect x="1378" y="308" width="6" height="22" rx="2" fill="#b6b3c8"/>
+    <rect x="1387" y="308" width="6" height="16" rx="2" fill="#b6b3c8"/>
+    <rect x="1396" y="308" width="6" height="19" rx="2" fill="#b6b3c8"/>
+    <text x="1388" y="350" text-anchor="middle" font-size="11" fill="#7a7791">Board</text>
+    <circle cx="1386" cy="395" r="8" fill="none" stroke="#b6b3c8" stroke-width="2.5"/>
+    <line x1="1392" y1="401" x2="1398" y2="407" stroke="#b6b3c8" stroke-width="2.5"/>
+    <text x="1388" y="428" text-anchor="middle" font-size="11" fill="#7a7791">Search</text>
+    <rect x="1377" y="464" width="22" height="22" rx="6" fill="#b6b3c8"/>
+    <text x="1388" y="506" text-anchor="middle" font-size="11" fill="#7a7791">Inbox</text>
+    <circle cx="1388" cy="553" r="11" fill="#6342db"/>
+    <text x="1388" y="584" text-anchor="middle" font-size="11" font-weight="600" fill="#6342db">You</text>
+
+    <!-- left: settings nav list (wider) -->
+    <text x="1454" y="184" font-size="18" font-weight="700" fill="#15131f">Settings</text>
+    <circle cx="1478" cy="232" r="20" fill="#4f8cff"/>
+    <text x="1478" y="237" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">WK</text>
+    <text x="1510" y="228" font-size="14" font-weight="600" fill="#15131f">Waleed K.</text>
+    <text x="1510" y="246" font-size="11" fill="#7a7791">@waleed · track.acme.dev</text>
+    <rect x="1450" y="276" width="304" height="44" rx="10" fill="#6342db" fill-opacity="0.1"/>
+    <text x="1470" y="304" font-size="14" font-weight="600" fill="#6342db">Profile</text>
+    <text x="1738" y="304" text-anchor="end" font-size="15" fill="#6342db">›</text>
+    <text x="1470" y="348" font-size="14" fill="#15131f">Notifications</text>
+    <text x="1738" y="348" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="1470" y="392" font-size="14" fill="#15131f">Security</text>
+    <text x="1738" y="392" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="1470" y="436" font-size="14" fill="#15131f">Teams</text>
+    <text x="1738" y="436" text-anchor="end" font-size="15" fill="#b6b3c8">›</text>
+    <text x="1470" y="480" font-size="14" fill="#15131f">Instance</text>
+    <text x="1738" y="480" text-anchor="end" font-size="12" fill="#7a7791">track.acme.dev</text>
+    <line x1="1450" y1="508" x2="1754" y2="508" stroke="#eeedf5"/>
+    <text x="1470" y="544" font-size="14" font-weight="600" fill="#e0424a">Sign out</text>
+
+    <!-- right: profile card -->
+    <rect x="1790" y="170" width="680" height="330" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1814" y="202" font-size="17" font-weight="700" fill="#15131f">Profile</text>
+    <text x="1814" y="232" font-size="13" fill="#514e66">Avatar color</text>
+    <circle cx="1830" cy="266" r="21" fill="none" stroke="#6342db" stroke-width="2.5"/>
+    <circle cx="1830" cy="266" r="16" fill="#4f8cff"/>
+    <text x="1830" y="271" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">WK</text>
+    <circle cx="1878" cy="266" r="16" fill="#ff6fae"/>
+    <circle cx="1922" cy="266" r="16" fill="#2fd4a7"/>
+    <circle cx="1966" cy="266" r="16" fill="#ffb648"/>
+    <circle cx="2010" cy="266" r="16" fill="#6342db"/>
+    <text x="1814" y="320" font-size="13" fill="#514e66">Full name</text>
+    <rect x="1814" y="330" width="300" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="1830" y="360" font-size="15" fill="#15131f">Waleed K.</text>
+    <text x="2146" y="320" font-size="13" fill="#514e66">Username</text>
+    <rect x="2146" y="330" width="300" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2162" y="360" font-size="15" fill="#15131f">waleed</text>
+    <text x="2146" y="398" font-size="12" fill="#7a7791">Letters, numbers, dashes</text>
+    <text x="1814" y="420" font-size="13" fill="#514e66">Email</text>
+    <rect x="1814" y="430" width="300" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="1830" y="460" font-size="15" fill="#15131f">waleed@acme.dev</text>
+    <rect x="2146" y="438" width="10" height="8" rx="2" fill="#7a7791"/>
+    <path d="M2148 438 v-3 a3 3 0 0 1 6 0 v3" fill="none" stroke="#7a7791" stroke-width="1.5"/>
+    <text x="2162" y="446" font-size="12" fill="#7a7791">Changing email requires your</text>
+    <text x="2162" y="462" font-size="12" fill="#7a7791">current password</text>
+    <rect x="2330" y="436" width="116" height="44" rx="10" fill="#6342db"/>
+    <text x="2388" y="463" text-anchor="middle" font-size="15" font-weight="600" fill="#ffffff">Save</text>
+
+    <!-- right: security card -->
+    <rect x="1790" y="530" width="680" height="326" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1814" y="562" font-size="17" font-weight="700" fill="#15131f">Security</text>
+    <text x="1814" y="594" font-size="13" fill="#514e66">Current password</text>
+    <rect x="1814" y="604" width="200" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="1830" y="636" font-size="15" fill="#b6b3c8">••••••••</text>
+    <text x="2036" y="594" font-size="13" fill="#514e66">New password</text>
+    <rect x="2036" y="604" width="200" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2052" y="636" font-size="15" fill="#b6b3c8">••••••••</text>
+    <text x="2258" y="594" font-size="13" fill="#514e66">Confirm new password</text>
+    <rect x="2258" y="604" width="200" height="48" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2274" y="636" font-size="15" fill="#b6b3c8">••••••••</text>
+    <rect x="1814" y="690" width="176" height="44" rx="10" fill="#6342db"/>
+    <text x="1902" y="717" text-anchor="middle" font-size="15" font-weight="600" fill="#ffffff">Update password</text>
+    <rect x="2010" y="690" width="196" height="44" rx="10" fill="#ffffff" stroke="#dedcea"/>
+    <text x="2108" y="717" text-anchor="middle" font-size="15" font-weight="600" fill="#514e66">Sign out everywhere</text>
+    <text x="1814" y="768" font-size="12" fill="#7a7791">Signs out every device except this one. Sessions end within a minute.</text>
+  </g>
+
+  <!-- Footer caption -->
+  <text x="1280" y="960" text-anchor="middle" font-size="16" fill="#7a7791">Settings are a single scrolling list on compact; beyond compact they become master–detail with the section list persistent.</text>
+</svg>

--- a/docs/design/mobile/153-team-admin.svg
+++ b/docs/design/mobile/153-team-admin.svg
@@ -1,0 +1,333 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Team administration</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE ============ -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cp)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="376" y="127" width="3" height="6" fill="#514e66"/><rect x="381" y="124" width="3" height="9" fill="#514e66"/><rect x="386" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="400" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="410" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="412.5" y="123.5" width="10" height="5" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="82" y="178" font-size="22" fill="#514e66">‹</text>
+    <text x="106" y="178" font-size="20" font-weight="700" fill="#15131f">Team settings</text>
+    <text x="106" y="200" font-size="13" fill="#7a7791">ENG — Engineering</text>
+
+    <!-- menu rows -->
+    <!-- row 1 General c=245 -->
+    <rect x="84" y="232" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <circle cx="97" cy="245" r="5" fill="none" stroke="#7a7791" stroke-width="2"/>
+    <text x="122" y="250" font-size="15" fill="#15131f">General</text>
+    <text x="428" y="251" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="272" x2="434" y2="272" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 2 Members c=299 -->
+    <rect x="84" y="286" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <circle cx="93" cy="296" r="3.5" fill="#7a7791"/><circle cx="102" cy="301" r="3.5" fill="#7a7791"/>
+    <text x="122" y="304" font-size="15" fill="#15131f">Members</text>
+    <text x="410" y="304" font-size="13" fill="#7a7791" text-anchor="end">8</text>
+    <text x="428" y="305" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="326" x2="434" y2="326" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 3 Invitations c=353 -->
+    <rect x="84" y="340" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <rect x="90" y="348" width="14" height="10" rx="2" fill="none" stroke="#7a7791" stroke-width="1.8"/>
+    <text x="122" y="358" font-size="15" fill="#15131f">Invitations</text>
+    <text x="410" y="358" font-size="13" fill="#7a7791" text-anchor="end">1 pending</text>
+    <text x="428" y="359" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="380" x2="434" y2="380" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 4 Statuses c=407 -->
+    <rect x="84" y="394" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <rect x="90" y="401" width="4" height="12" rx="1.5" fill="#7a7791"/><rect x="96" y="404" width="4" height="9" rx="1.5" fill="#7a7791"/><rect x="102" y="399" width="4" height="14" rx="1.5" fill="#7a7791"/>
+    <text x="122" y="412" font-size="15" fill="#15131f">Statuses</text>
+    <text x="410" y="412" font-size="13" fill="#7a7791" text-anchor="end">5</text>
+    <text x="428" y="413" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="434" x2="434" y2="434" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 5 Automation c=461 -->
+    <rect x="84" y="448" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <polygon points="99,452 92,463 97,463 95,470 102,459 97,459" fill="#7a7791"/>
+    <text x="122" y="466" font-size="15" fill="#15131f">Automation</text>
+    <text x="410" y="466" font-size="13" fill="#7a7791" text-anchor="end">3 rules</text>
+    <text x="428" y="467" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="488" x2="434" y2="488" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- row 6 Repositories c=515 -->
+    <rect x="84" y="502" width="26" height="26" rx="8" fill="#f7f6fb" stroke="#eeedf5"/>
+    <circle cx="92" cy="510" r="3" fill="none" stroke="#7a7791" stroke-width="1.8"/><circle cx="102" cy="521" r="3" fill="none" stroke="#7a7791" stroke-width="1.8"/><line x1="93" y1="513" x2="101" y2="519" stroke="#7a7791" stroke-width="1.8"/>
+    <text x="122" y="520" font-size="15" fill="#15131f">Repositories</text>
+    <text x="410" y="520" font-size="13" fill="#7a7791" text-anchor="end">2</text>
+    <text x="428" y="521" font-size="18" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="84" y1="542" x2="434" y2="542" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- members preview card -->
+    <rect x="76" y="562" width="358" height="232" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="94" y="592" font-size="15" font-weight="700" fill="#15131f">Members</text>
+    <text x="416" y="592" font-size="13" font-weight="600" fill="#6342db" text-anchor="end">View all ›</text>
+    <!-- member 1 c=626 -->
+    <circle cx="112" cy="626" r="16" fill="#4f8cff"/><text x="112" y="630" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="138" y="624" font-size="15" fill="#15131f">Amina K.</text>
+    <text x="138" y="642" font-size="12" fill="#7a7791">@amina</text>
+    <rect x="348" y="615" width="56" height="22" rx="11" fill="#6342db" fill-opacity="0.15"/><text x="376" y="630" font-size="12" font-weight="600" fill="#6342db" text-anchor="middle">Admin</text>
+    <circle cx="414" cy="626" r="1.8" fill="#7a7791"/><circle cx="420" cy="626" r="1.8" fill="#7a7791"/><circle cx="426" cy="626" r="1.8" fill="#7a7791"/>
+    <line x1="94" y1="655" x2="416" y2="655" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- member 2 c=684 -->
+    <circle cx="112" cy="684" r="16" fill="#2fd4a7"/><text x="112" y="688" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="138" y="682" font-size="15" fill="#15131f">Dev P.</text>
+    <text x="138" y="700" font-size="12" fill="#7a7791">@devp</text>
+    <rect x="338" y="673" width="66" height="22" rx="11" fill="#7a7791" fill-opacity="0.15"/><text x="371" y="688" font-size="12" font-weight="600" fill="#7a7791" text-anchor="middle">Member</text>
+    <circle cx="414" cy="684" r="1.8" fill="#7a7791"/><circle cx="420" cy="684" r="1.8" fill="#7a7791"/><circle cx="426" cy="684" r="1.8" fill="#7a7791"/>
+    <line x1="94" y1="713" x2="416" y2="713" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- member 3 c=742 -->
+    <circle cx="112" cy="742" r="16" fill="#ff6fae"/><text x="112" y="746" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <text x="138" y="740" font-size="15" fill="#15131f">Sara L.</text>
+    <text x="138" y="758" font-size="12" fill="#7a7791">@sara</text>
+    <rect x="338" y="731" width="66" height="22" rx="11" fill="#7a7791" fill-opacity="0.15"/><text x="371" y="746" font-size="12" font-weight="600" fill="#7a7791" text-anchor="middle">Member</text>
+    <circle cx="414" cy="742" r="1.8" fill="#7a7791"/><circle cx="420" cy="742" r="1.8" fill="#7a7791"/><circle cx="426" cy="742" r="1.8" fill="#7a7791"/>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="166" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="177" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="244" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="255" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="333" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="400" y="836" width="22" height="22" rx="6" fill="#6342db"/><text x="411" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE ============ -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cf)">
+    <!-- hinge -->
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+    <!-- status bar -->
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1196" y="127" width="3" height="6" fill="#514e66"/><rect x="1201" y="124" width="3" height="9" fill="#514e66"/><rect x="1206" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="1220" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="1230" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1232.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="557" y="268" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="303" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="557" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="557" y="454" width="22" height="22" rx="6" fill="#6342db"/><text x="568" y="489" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: admin menu -->
+    <text x="626" y="180" font-size="17" font-weight="700" fill="#15131f">ENG · Team settings</text>
+    <!-- rows h=52 from y=204 -->
+    <rect x="622" y="219" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="633" cy="230" r="4.5" fill="none" stroke="#7a7791" stroke-width="1.8"/>
+    <text x="654" y="235" font-size="14" fill="#15131f">General</text>
+    <text x="874" y="236" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="622" y1="256" x2="884" y2="256" stroke="#eeedf5"/>
+    <rect x="622" y="271" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="630" cy="279" r="3" fill="#7a7791"/><circle cx="637" cy="285" r="3" fill="#7a7791"/>
+    <text x="654" y="287" font-size="14" fill="#15131f">Members</text>
+    <text x="858" y="287" font-size="12" fill="#7a7791" text-anchor="end">8</text>
+    <text x="874" y="288" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="622" y1="308" x2="884" y2="308" stroke="#eeedf5"/>
+    <rect x="622" y="323" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><rect x="627" y="330" width="12" height="8" rx="2" fill="none" stroke="#7a7791" stroke-width="1.6"/>
+    <text x="654" y="339" font-size="14" fill="#15131f">Invitations</text>
+    <text x="858" y="339" font-size="12" fill="#7a7791" text-anchor="end">1 pending</text>
+    <text x="874" y="340" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="622" y1="360" x2="884" y2="360" stroke="#eeedf5"/>
+    <!-- selected: Statuses -->
+    <rect x="614" y="362" width="274" height="48" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <rect x="614" y="368" width="3" height="36" rx="1.5" fill="#6342db"/>
+    <rect x="622" y="375" width="22" height="22" rx="7" fill="#ffffff" stroke="#eeedf5"/><rect x="627" y="381" width="3.5" height="10" rx="1.5" fill="#6342db"/><rect x="632" y="384" width="3.5" height="7" rx="1.5" fill="#6342db"/><rect x="637" y="379" width="3.5" height="12" rx="1.5" fill="#6342db"/>
+    <text x="654" y="391" font-size="14" font-weight="600" fill="#6342db">Statuses</text>
+    <text x="858" y="391" font-size="12" fill="#6342db" text-anchor="end">5</text>
+    <text x="874" y="392" font-size="16" fill="#6342db" text-anchor="middle">›</text>
+    <line x1="622" y1="412" x2="884" y2="412" stroke="#eeedf5"/>
+    <rect x="622" y="427" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><polygon points="635,430 629,440 633,440 631,446 637,436 633,436" fill="#7a7791"/>
+    <text x="654" y="443" font-size="14" fill="#15131f">Automation</text>
+    <text x="858" y="443" font-size="12" fill="#7a7791" text-anchor="end">3 rules</text>
+    <text x="874" y="444" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="622" y1="464" x2="884" y2="464" stroke="#eeedf5"/>
+    <rect x="622" y="479" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="629" cy="486" r="2.6" fill="none" stroke="#7a7791" stroke-width="1.6"/><circle cx="638" cy="495" r="2.6" fill="none" stroke="#7a7791" stroke-width="1.6"/><line x1="630" y1="488" x2="637" y2="493" stroke="#7a7791" stroke-width="1.6"/>
+    <text x="654" y="495" font-size="14" fill="#15131f">Repositories</text>
+    <text x="858" y="495" font-size="12" fill="#7a7791" text-anchor="end">2</text>
+    <text x="874" y="496" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="622" y1="516" x2="884" y2="516" stroke="#eeedf5"/>
+    <!-- low-fi members preview -->
+    <text x="626" y="556" font-size="13" font-weight="700" fill="#514e66">Members</text>
+    <circle cx="636" cy="584" r="12" fill="#4f8cff"/><text x="636" y="588" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <rect x="658" y="576" width="130" height="8" rx="4" fill="#eeedf5"/><rect x="658" y="589" width="84" height="6" rx="3" fill="#eeedf5"/>
+    <circle cx="636" cy="622" r="12" fill="#2fd4a7"/><text x="636" y="626" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <rect x="658" y="614" width="110" height="8" rx="4" fill="#eeedf5"/><rect x="658" y="627" width="70" height="6" rx="3" fill="#eeedf5"/>
+    <circle cx="636" cy="660" r="12" fill="#ff6fae"/><text x="636" y="664" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <rect x="658" y="652" width="120" height="8" rx="4" fill="#eeedf5"/><rect x="658" y="665" width="78" height="6" rx="3" fill="#eeedf5"/>
+
+    <!-- RIGHT PANE: statuses editor -->
+    <text x="916" y="180" font-size="17" font-weight="700" fill="#15131f">Statuses</text>
+    <text x="916" y="200" font-size="12" fill="#7a7791">Drag to reorder board columns</text>
+    <!-- status rows -->
+    <rect x="916" y="216" width="338" height="54" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="249" font-size="15" fill="#b6b3c8">☰</text>
+    <circle cx="968" cy="243" r="6" fill="#9b98b0"/>
+    <text x="984" y="248" font-size="15" fill="#15131f">Backlog</text>
+    <rect x="1178" y="233" width="62" height="20" rx="10" fill="#9b98b0" fill-opacity="0.15"/><text x="1209" y="247" font-size="11" font-weight="600" fill="#9b98b0" text-anchor="middle">Backlog</text>
+    <rect x="916" y="278" width="338" height="54" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="311" font-size="15" fill="#b6b3c8">☰</text>
+    <circle cx="968" cy="305" r="6" fill="#6f6c86"/>
+    <text x="984" y="310" font-size="15" fill="#15131f">Todo</text>
+    <rect x="1168" y="295" width="72" height="20" rx="10" fill="#6f6c86" fill-opacity="0.15"/><text x="1204" y="309" font-size="11" font-weight="600" fill="#6f6c86" text-anchor="middle">Unstarted</text>
+    <rect x="916" y="340" width="338" height="54" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="373" font-size="15" fill="#b6b3c8">☰</text>
+    <circle cx="968" cy="367" r="6" fill="#f29d0b"/>
+    <text x="984" y="372" font-size="15" fill="#15131f">In Progress</text>
+    <rect x="1178" y="357" width="62" height="20" rx="10" fill="#f29d0b" fill-opacity="0.15"/><text x="1209" y="371" font-size="11" font-weight="600" fill="#f29d0b" text-anchor="middle">Started</text>
+    <rect x="916" y="402" width="338" height="54" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="435" font-size="15" fill="#b6b3c8">☰</text>
+    <circle cx="968" cy="429" r="6" fill="#8b5cf6"/>
+    <text x="984" y="434" font-size="15" fill="#15131f">In Review</text>
+    <rect x="1178" y="419" width="62" height="20" rx="10" fill="#8b5cf6" fill-opacity="0.15"/><text x="1209" y="433" font-size="11" font-weight="600" fill="#8b5cf6" text-anchor="middle">Started</text>
+    <rect x="916" y="464" width="338" height="54" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="934" y="497" font-size="15" fill="#b6b3c8">☰</text>
+    <circle cx="968" cy="491" r="6" fill="#12a474"/>
+    <text x="984" y="496" font-size="15" fill="#15131f">Done</text>
+    <rect x="1162" y="481" width="78" height="20" rx="10" fill="#12a474" fill-opacity="0.15"/><text x="1201" y="495" font-size="11" font-weight="600" fill="#12a474" text-anchor="middle">Completed</text>
+    <!-- add status -->
+    <rect x="916" y="548" width="150" height="44" rx="10" fill="#6342db"/>
+    <text x="991" y="576" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">+ Add status</text>
+    <text x="916" y="634" font-size="12" fill="#7a7791">Reordering updates the board column order for everyone.</text>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET ============ -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#ct)">
+    <!-- status bar -->
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2406" y="127" width="3" height="6" fill="#514e66"/><rect x="2411" y="124" width="3" height="9" fill="#514e66"/><rect x="2416" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="2430" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="2440" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2442.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1377" y="268" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="303" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="1377" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="1377" y="454" width="22" height="22" rx="6" fill="#6342db"/><text x="1388" y="489" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+    <!-- MENU PANE -->
+    <line x1="1710" y1="138" x2="1710" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <text x="1450" y="182" font-size="17" font-weight="700" fill="#15131f">ENG · Team settings</text>
+    <rect x="1446" y="221" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="1457" cy="232" r="4.5" fill="none" stroke="#7a7791" stroke-width="1.8"/>
+    <text x="1478" y="237" font-size="14" fill="#15131f">General</text>
+    <text x="1694" y="238" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="1446" y1="258" x2="1686" y2="258" stroke="#eeedf5"/>
+    <rect x="1446" y="273" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="1454" cy="281" r="3" fill="#7a7791"/><circle cx="1461" cy="287" r="3" fill="#7a7791"/>
+    <text x="1478" y="289" font-size="14" fill="#15131f">Members</text>
+    <text x="1678" y="289" font-size="12" fill="#7a7791" text-anchor="end">8</text>
+    <text x="1694" y="290" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="1446" y1="310" x2="1686" y2="310" stroke="#eeedf5"/>
+    <rect x="1446" y="325" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><rect x="1451" y="332" width="12" height="8" rx="2" fill="none" stroke="#7a7791" stroke-width="1.6"/>
+    <text x="1478" y="341" font-size="14" fill="#15131f">Invitations</text>
+    <text x="1678" y="341" font-size="12" fill="#7a7791" text-anchor="end">1 pending</text>
+    <text x="1694" y="342" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="1446" y1="362" x2="1686" y2="362" stroke="#eeedf5"/>
+    <rect x="1446" y="377" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><rect x="1451" y="383" width="3.5" height="10" rx="1.5" fill="#7a7791"/><rect x="1456" y="386" width="3.5" height="7" rx="1.5" fill="#7a7791"/><rect x="1461" y="381" width="3.5" height="12" rx="1.5" fill="#7a7791"/>
+    <text x="1478" y="393" font-size="14" fill="#15131f">Statuses</text>
+    <text x="1678" y="393" font-size="12" fill="#7a7791" text-anchor="end">5</text>
+    <text x="1694" y="394" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="1446" y1="414" x2="1686" y2="414" stroke="#eeedf5"/>
+    <!-- selected: Automation -->
+    <rect x="1438" y="416" width="264" height="48" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <rect x="1438" y="422" width="3" height="36" rx="1.5" fill="#6342db"/>
+    <rect x="1446" y="429" width="22" height="22" rx="7" fill="#ffffff" stroke="#eeedf5"/><polygon points="1459,432 1453,442 1457,442 1455,448 1461,438 1457,438" fill="#6342db"/>
+    <text x="1478" y="445" font-size="14" font-weight="600" fill="#6342db">Automation</text>
+    <text x="1678" y="445" font-size="12" fill="#6342db" text-anchor="end">3 rules</text>
+    <text x="1694" y="446" font-size="16" fill="#6342db" text-anchor="middle">›</text>
+    <line x1="1446" y1="466" x2="1686" y2="466" stroke="#eeedf5"/>
+    <rect x="1446" y="481" width="22" height="22" rx="7" fill="#f7f6fb" stroke="#eeedf5"/><circle cx="1453" cy="488" r="2.6" fill="none" stroke="#7a7791" stroke-width="1.6"/><circle cx="1462" cy="497" r="2.6" fill="none" stroke="#7a7791" stroke-width="1.6"/><line x1="1454" y1="490" x2="1461" y2="495" stroke="#7a7791" stroke-width="1.6"/>
+    <text x="1478" y="497" font-size="14" fill="#15131f">Repositories</text>
+    <text x="1678" y="497" font-size="12" fill="#7a7791" text-anchor="end">2</text>
+    <text x="1694" y="498" font-size="16" fill="#b6b3c8" text-anchor="middle">›</text>
+    <line x1="1446" y1="518" x2="1686" y2="518" stroke="#eeedf5"/>
+    <!-- low-fi members -->
+    <text x="1450" y="558" font-size="13" font-weight="700" fill="#514e66">Members</text>
+    <circle cx="1460" cy="586" r="12" fill="#4f8cff"/><text x="1460" y="590" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <rect x="1482" y="578" width="130" height="8" rx="4" fill="#eeedf5"/><rect x="1482" y="591" width="84" height="6" rx="3" fill="#eeedf5"/>
+    <circle cx="1460" cy="624" r="12" fill="#2fd4a7"/><text x="1460" y="628" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <rect x="1482" y="616" width="110" height="8" rx="4" fill="#eeedf5"/><rect x="1482" y="629" width="70" height="6" rx="3" fill="#eeedf5"/>
+    <circle cx="1460" cy="662" r="12" fill="#ffb648"/><text x="1460" y="666" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">MT</text>
+    <rect x="1482" y="654" width="120" height="8" rx="4" fill="#eeedf5"/><rect x="1482" y="667" width="78" height="6" rx="3" fill="#eeedf5"/>
+
+    <!-- CENTER: automation -->
+    <text x="1734" y="182" font-size="17" font-weight="700" fill="#15131f">Automation</text>
+    <text x="2136" y="182" font-size="12" fill="#7a7791" text-anchor="end">2 of 3 rules active</text>
+    <!-- rule card 1 -->
+    <rect x="1734" y="204" width="402" height="118" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2076" y="222" width="40" height="22" rx="11" fill="#6342db"/><circle cx="2106" cy="233" r="8" fill="#ffffff"/>
+    <text x="1754" y="240" font-size="14" fill="#15131f">When a pull request is merged</text>
+    <text x="1754" y="266" font-size="14" fill="#15131f">and label is</text>
+    <rect x="1844" y="252" width="46" height="20" rx="6" fill="#f7f6fb" stroke="#dedcea"/><text x="1867" y="266" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">bug</text>
+    <text x="1754" y="296" font-size="14" fill="#15131f">→  set status to</text>
+    <rect x="1868" y="282" width="52" height="20" rx="10" fill="#12a474" fill-opacity="0.15"/><text x="1894" y="296" font-size="11" font-weight="600" fill="#12a474" text-anchor="middle">Done</text>
+    <text x="1932" y="296" font-size="14" fill="#15131f">and comment</text>
+    <!-- rule card 2 -->
+    <rect x="1734" y="338" width="402" height="118" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="2076" y="356" width="40" height="22" rx="11" fill="#6342db"/><circle cx="2106" cy="367" r="8" fill="#ffffff"/>
+    <text x="1754" y="374" font-size="14" fill="#15131f">When an issue is created</text>
+    <text x="1754" y="400" font-size="14" fill="#15131f">and priority is</text>
+    <rect x="1858" y="386" width="58" height="20" rx="10" fill="#e0424a" fill-opacity="0.15"/><text x="1887" y="400" font-size="11" font-weight="600" fill="#e0424a" text-anchor="middle">Urgent</text>
+    <text x="1754" y="430" font-size="14" fill="#15131f">→  assign to</text>
+    <rect x="1842" y="416" width="76" height="20" rx="10" fill="#f7f6fb" stroke="#dedcea"/><text x="1880" y="430" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">Amina K.</text>
+    <text x="1930" y="430" font-size="14" fill="#15131f">and notify #eng</text>
+    <text x="1734" y="496" font-size="13" font-weight="600" fill="#6342db">View all 3 rules ›</text>
+    <!-- low-fi run history -->
+    <text x="1734" y="548" font-size="13" font-weight="700" fill="#514e66">Recent runs</text>
+    <circle cx="1742" cy="572" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="1760" y="567" width="240" height="9" rx="4" fill="#eeedf5"/>
+    <circle cx="1742" cy="598" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="1760" y="593" width="200" height="9" rx="4" fill="#eeedf5"/>
+    <circle cx="1742" cy="624" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="1760" y="619" width="224" height="9" rx="4" fill="#eeedf5"/>
+
+    <!-- SIDE SHEET: invitations -->
+    <rect x="2152" y="138" width="8" height="752" fill="#26243a" opacity="0.04"/>
+    <rect x="2160" y="138" width="340" height="752" fill="#ffffff"/>
+    <line x1="2160" y1="138" x2="2160" y2="890" stroke="#dedcea" stroke-width="2"/>
+    <text x="2184" y="184" font-size="17" font-weight="700" fill="#15131f">Invitations</text>
+    <text x="2472" y="184" font-size="18" fill="#7a7791" text-anchor="middle">×</text>
+    <text x="2184" y="204" font-size="12" fill="#7a7791">Invite people to ENG</text>
+    <text x="2184" y="238" font-size="13" fill="#514e66">Email address</text>
+    <rect x="2184" y="248" width="292" height="48" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2198" y="277" font-size="15" fill="#b6b3c8">teammate@company.com</text>
+    <rect x="2184" y="312" width="292" height="44" rx="10" fill="#6342db"/>
+    <text x="2330" y="340" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Create invite link</text>
+    <line x1="2184" y1="384" x2="2476" y2="384" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="2184" y="410" font-size="13" font-weight="700" fill="#514e66">Active invite links</text>
+    <rect x="2184" y="424" width="292" height="88" rx="12" fill="#f7f6fb" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="2200" y="452" font-size="14" font-weight="600" fill="#15131f">softtrack.app/i/eng-8f2c</text>
+    <text x="2200" y="472" font-size="12" fill="#7a7791">Expires in 7 days · 1 pending join</text>
+    <rect x="2200" y="486" width="9" height="11" rx="2" fill="none" stroke="#6342db" stroke-width="1.4"/>
+    <rect x="2204" y="482" width="9" height="11" rx="2" fill="#f7f6fb" stroke="#6342db" stroke-width="1.4"/>
+    <text x="2220" y="496" font-size="12" font-weight="600" fill="#6342db">Copy</text>
+    <circle cx="2286" cy="492" r="6" fill="none" stroke="#6342db" stroke-width="1.4"/>
+    <line x1="2286" y1="496" x2="2286" y2="486" stroke="#6342db" stroke-width="1.4"/>
+    <polyline points="2283,489 2286,485.5 2289,489" fill="none" stroke="#6342db" stroke-width="1.4"/>
+    <text x="2300" y="496" font-size="12" font-weight="600" fill="#6342db">Share</text>
+    <text x="2184" y="550" font-size="12" fill="#7a7791">Only admins can create or revoke invite links.</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Every admin surface is reachable on phone as a stacked settings flow; medium and expanded widths keep the admin menu persistent as a master pane with detail editors and side sheets alongside.</text>
+</svg>

--- a/docs/design/mobile/154-site-admin.svg
+++ b/docs/design/mobile/154-site-admin.svg
@@ -1,0 +1,301 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Site administration: users</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE ============ -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cp)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="376" y="127" width="3" height="6" fill="#514e66"/><rect x="381" y="124" width="3" height="9" fill="#514e66"/><rect x="386" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="400" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="410" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="412.5" y="123.5" width="10" height="5" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="84" y="178" font-size="20" font-weight="700" fill="#15131f">Site admin</text>
+    <text x="84" y="200" font-size="13" fill="#7a7791">Users · 132</text>
+
+    <!-- search input -->
+    <rect x="76" y="216" width="358" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="98" cy="238" r="6" fill="none" stroke="#b6b3c8" stroke-width="2"/>
+    <line x1="102.5" y1="242.5" x2="108" y2="248" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="118" y="243" font-size="15" fill="#b6b3c8">Search name or @username</text>
+
+    <!-- user rows -->
+    <!-- 1 Amina c=306 -->
+    <circle cx="102" cy="306" r="17" fill="#4f8cff"/><text x="102" y="310" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="130" y="304" font-size="15" fill="#15131f">Amina K.</text>
+    <rect x="214" y="294" width="76" height="20" rx="10" fill="#6342db" fill-opacity="0.15"/><text x="252" y="308" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Site admin</text>
+    <text x="130" y="322" font-size="12" fill="#7a7791">@amina</text>
+    <circle cx="412" cy="306" r="1.8" fill="#7a7791"/><circle cx="419" cy="306" r="1.8" fill="#7a7791"/><circle cx="426" cy="306" r="1.8" fill="#7a7791"/>
+    <line x1="84" y1="336" x2="434" y2="336" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- 2 Dev c=366 -->
+    <circle cx="102" cy="366" r="17" fill="#2fd4a7"/><text x="102" y="370" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="130" y="364" font-size="15" fill="#15131f">Dev P.</text>
+    <text x="130" y="382" font-size="12" fill="#7a7791">@devp</text>
+    <circle cx="412" cy="366" r="1.8" fill="#7a7791"/><circle cx="419" cy="366" r="1.8" fill="#7a7791"/><circle cx="426" cy="366" r="1.8" fill="#7a7791"/>
+    <line x1="84" y1="396" x2="434" y2="396" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- 3 Sara c=426 -->
+    <circle cx="102" cy="426" r="17" fill="#ff6fae"/><text x="102" y="430" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <text x="130" y="424" font-size="15" fill="#15131f">Sara L.</text>
+    <text x="130" y="442" font-size="12" fill="#7a7791">@sara</text>
+    <circle cx="412" cy="426" r="1.8" fill="#7a7791"/><circle cx="419" cy="426" r="1.8" fill="#7a7791"/><circle cx="426" cy="426" r="1.8" fill="#7a7791"/>
+    <line x1="84" y1="456" x2="434" y2="456" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- 4 Marcus (deactivated) c=486 -->
+    <circle cx="102" cy="486" r="17" fill="#ffb648" opacity="0.5"/><text x="102" y="490" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">MT</text>
+    <text x="130" y="484" font-size="15" fill="#7a7791">Marcus T.</text>
+    <rect x="212" y="474" width="88" height="20" rx="10" fill="#7a7791" fill-opacity="0.15"/><text x="256" y="488" font-size="11" font-weight="600" fill="#7a7791" text-anchor="middle">Deactivated</text>
+    <text x="130" y="502" font-size="12" fill="#b6b3c8">@marcus</text>
+    <circle cx="412" cy="486" r="1.8" fill="#7a7791"/><circle cx="419" cy="486" r="1.8" fill="#7a7791"/><circle cx="426" cy="486" r="1.8" fill="#7a7791"/>
+    <line x1="84" y1="516" x2="434" y2="516" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- 5 Jonas c=546 -->
+    <circle cx="102" cy="546" r="17" fill="#6342db"/><text x="102" y="550" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <text x="130" y="544" font-size="15" fill="#15131f">Jonas W.</text>
+    <text x="130" y="562" font-size="12" fill="#7a7791">@jonas</text>
+    <circle cx="412" cy="546" r="1.8" fill="#7a7791"/><circle cx="419" cy="546" r="1.8" fill="#7a7791"/><circle cx="426" cy="546" r="1.8" fill="#7a7791"/>
+    <line x1="84" y1="576" x2="434" y2="576" stroke="#eeedf5" stroke-width="1.5"/>
+    <!-- 6 Priya c=606 -->
+    <circle cx="102" cy="606" r="17" fill="#4f8cff"/><text x="102" y="610" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">PN</text>
+    <text x="130" y="604" font-size="15" fill="#15131f">Priya N.</text>
+    <text x="130" y="622" font-size="12" fill="#7a7791">@priya</text>
+    <circle cx="412" cy="606" r="1.8" fill="#7a7791"/><circle cx="419" cy="606" r="1.8" fill="#7a7791"/><circle cx="426" cy="606" r="1.8" fill="#7a7791"/>
+
+    <!-- bottom nav -->
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="166" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="177" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="244" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="255" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="333" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="400" y="836" width="22" height="22" rx="6" fill="#6342db"/><text x="411" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+    <!-- scrim + action sheet -->
+    <rect x="60" y="110" width="390" height="780" fill="#15131f" opacity="0.32"/>
+    <rect x="60" y="648" width="390" height="242" rx="20" fill="#ffffff"/>
+    <rect x="237" y="660" width="36" height="5" rx="2.5" fill="#dedcea"/>
+    <text x="255" y="688" font-size="13" font-weight="600" fill="#7a7791" text-anchor="middle">Marcus T. — @marcus</text>
+    <line x1="84" y1="702" x2="426" y2="702" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="92" cy="730" r="8" fill="none" stroke="#e0424a" stroke-width="1.8"/><line x1="88" y1="730" x2="96" y2="730" stroke="#e0424a" stroke-width="1.8"/>
+    <text x="112" y="736" font-size="16" font-weight="600" fill="#e0424a">Deactivate account</text>
+    <line x1="84" y1="756" x2="426" y2="756" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="92" cy="784" r="8" fill="none" stroke="#7a7791" stroke-width="1.8"/><circle cx="92" cy="784" r="2.5" fill="#7a7791"/>
+    <text x="112" y="790" font-size="16" fill="#15131f">Make site admin</text>
+    <line x1="84" y1="810" x2="426" y2="810" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="85" y="833" width="14" height="9" rx="3" fill="none" stroke="#7a7791" stroke-width="1.8"/><line x1="92" y1="833" x2="92" y2="828" stroke="#7a7791" stroke-width="1.8"/>
+    <text x="112" y="844" font-size="16" fill="#15131f">Set password…</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE ============ -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cf)">
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1196" y="127" width="3" height="6" fill="#514e66"/><rect x="1201" y="124" width="3" height="9" fill="#514e66"/><rect x="1206" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="1220" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="1230" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1232.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="557" y="268" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="303" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="557" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="557" y="454" width="22" height="22" rx="6" fill="#6342db"/><text x="568" y="489" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: user list -->
+    <text x="626" y="180" font-size="17" font-weight="700" fill="#15131f">Users</text>
+    <text x="884" y="180" font-size="12" fill="#7a7791" text-anchor="end">132 total</text>
+    <rect x="622" y="194" width="262" height="40" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="642" cy="214" r="5.5" fill="none" stroke="#b6b3c8" stroke-width="2"/>
+    <line x1="646" y1="218" x2="651" y2="223" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="660" y="219" font-size="13" fill="#b6b3c8">Search users</text>
+    <!-- rows h=58 from 252: centers 281,339,397,455,513,571 -->
+    <circle cx="640" cy="281" r="14" fill="#4f8cff"/><text x="640" y="285" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="664" y="279" font-size="14" fill="#15131f">Amina K.</text>
+    <rect x="736" y="269" width="66" height="18" rx="9" fill="#6342db" fill-opacity="0.15"/><text x="769" y="282" font-size="10" font-weight="600" fill="#6342db" text-anchor="middle">Site admin</text>
+    <text x="664" y="296" font-size="11" fill="#7a7791">@amina</text>
+    <circle cx="862" cy="281" r="1.6" fill="#7a7791"/><circle cx="868" cy="281" r="1.6" fill="#7a7791"/><circle cx="874" cy="281" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="310" x2="884" y2="310" stroke="#eeedf5"/>
+    <circle cx="640" cy="339" r="14" fill="#2fd4a7"/><text x="640" y="343" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="664" y="337" font-size="14" fill="#15131f">Dev P.</text>
+    <text x="664" y="354" font-size="11" fill="#7a7791">@devp</text>
+    <circle cx="862" cy="339" r="1.6" fill="#7a7791"/><circle cx="868" cy="339" r="1.6" fill="#7a7791"/><circle cx="874" cy="339" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="368" x2="884" y2="368" stroke="#eeedf5"/>
+    <circle cx="640" cy="397" r="14" fill="#ff6fae"/><text x="640" y="401" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <text x="664" y="395" font-size="14" fill="#15131f">Sara L.</text>
+    <text x="664" y="412" font-size="11" fill="#7a7791">@sara</text>
+    <circle cx="862" cy="397" r="1.6" fill="#7a7791"/><circle cx="868" cy="397" r="1.6" fill="#7a7791"/><circle cx="874" cy="397" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="426" x2="884" y2="426" stroke="#eeedf5"/>
+    <circle cx="640" cy="455" r="14" fill="#ffb648" opacity="0.5"/><text x="640" y="459" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">MT</text>
+    <text x="664" y="453" font-size="14" fill="#7a7791">Marcus T.</text>
+    <rect x="740" y="443" width="76" height="18" rx="9" fill="#7a7791" fill-opacity="0.15"/><text x="778" y="456" font-size="10" font-weight="600" fill="#7a7791" text-anchor="middle">Deactivated</text>
+    <text x="664" y="470" font-size="11" fill="#b6b3c8">@marcus</text>
+    <circle cx="862" cy="455" r="1.6" fill="#7a7791"/><circle cx="868" cy="455" r="1.6" fill="#7a7791"/><circle cx="874" cy="455" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="484" x2="884" y2="484" stroke="#eeedf5"/>
+    <!-- selected Jonas -->
+    <rect x="614" y="486" width="272" height="56" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <circle cx="640" cy="513" r="14" fill="#6342db"/><text x="640" y="517" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <text x="664" y="511" font-size="14" font-weight="600" fill="#15131f">Jonas W.</text>
+    <text x="664" y="528" font-size="11" fill="#7a7791">@jonas</text>
+    <circle cx="862" cy="513" r="1.6" fill="#7a7791"/><circle cx="868" cy="513" r="1.6" fill="#7a7791"/><circle cx="874" cy="513" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="542" x2="884" y2="542" stroke="#eeedf5"/>
+    <circle cx="640" cy="571" r="14" fill="#4f8cff"/><text x="640" y="575" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">PN</text>
+    <text x="664" y="569" font-size="14" fill="#15131f">Priya N.</text>
+    <text x="664" y="586" font-size="11" fill="#7a7791">@priya</text>
+    <circle cx="862" cy="571" r="1.6" fill="#7a7791"/><circle cx="868" cy="571" r="1.6" fill="#7a7791"/><circle cx="874" cy="571" r="1.6" fill="#7a7791"/>
+    <line x1="622" y1="600" x2="884" y2="600" stroke="#eeedf5"/>
+    <!-- low-fi extra rows -->
+    <circle cx="640" cy="629" r="14" fill="#eeedf5"/><rect x="664" y="620" width="120" height="8" rx="4" fill="#eeedf5"/><rect x="664" y="633" width="76" height="6" rx="3" fill="#eeedf5"/>
+    <circle cx="640" cy="687" r="14" fill="#eeedf5"/><rect x="664" y="678" width="104" height="8" rx="4" fill="#eeedf5"/><rect x="664" y="691" width="68" height="6" rx="3" fill="#eeedf5"/>
+    <text x="753" y="748" font-size="12" fill="#7a7791" text-anchor="middle">1–25 of 132</text>
+
+    <!-- RIGHT PANE: user detail -->
+    <rect x="920" y="170" width="330" height="470" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="1085" cy="238" r="36" fill="#6342db"/><text x="1085" y="245" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <text x="1085" y="300" font-size="19" font-weight="700" fill="#15131f" text-anchor="middle">Jonas W.</text>
+    <text x="1085" y="322" font-size="13" fill="#7a7791" text-anchor="middle">jonas@softtrack.dev</text>
+    <circle cx="1058" cy="349" r="5" fill="#12a474"/>
+    <text x="1070" y="354" font-size="13" fill="#514e66">Active</text>
+    <rect x="948" y="384" width="274" height="44" rx="10" fill="#ffffff" stroke="#e0424a" stroke-width="1.5"/>
+    <text x="1085" y="412" font-size="15" font-weight="600" fill="#e0424a" text-anchor="middle">Deactivate account</text>
+    <rect x="948" y="440" width="274" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1085" y="468" font-size="15" font-weight="600" fill="#15131f" text-anchor="middle">Grant site admin</text>
+    <rect x="948" y="496" width="274" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1085" y="524" font-size="15" font-weight="600" fill="#15131f" text-anchor="middle">Set password…</text>
+    <circle cx="956" cy="572" r="7" fill="none" stroke="#b6b3c8" stroke-width="1.5"/><text x="956" y="576" font-size="10" font-weight="700" fill="#b6b3c8" text-anchor="middle">i</text>
+    <text x="970" y="576" font-size="12" fill="#7a7791">You cannot deactivate yourself.</text>
+    <!-- low-fi activity -->
+    <text x="920" y="690" font-size="13" font-weight="700" fill="#514e66">Recent activity</text>
+    <rect x="920" y="704" width="250" height="9" rx="4" fill="#eeedf5"/>
+    <rect x="920" y="728" width="200" height="9" rx="4" fill="#eeedf5"/>
+    <rect x="920" y="752" width="230" height="9" rx="4" fill="#eeedf5"/>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET ============ -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#ct)">
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2406" y="127" width="3" height="6" fill="#514e66"/><rect x="2411" y="124" width="3" height="9" fill="#514e66"/><rect x="2416" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="2430" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="2440" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2442.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1377" y="268" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="303" font-size="11" fill="#7a7791" text-anchor="middle">Board</text>
+    <rect x="1377" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="1377" y="454" width="22" height="22" rx="6" fill="#6342db"/><text x="1388" y="489" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">You</text>
+
+    <!-- header + search -->
+    <text x="1450" y="184" font-size="19" font-weight="700" fill="#15131f">Site admin — Users</text>
+    <rect x="2200" y="156" width="276" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <circle cx="2222" cy="178" r="6" fill="none" stroke="#b6b3c8" stroke-width="2"/>
+    <line x1="2226.5" y1="182.5" x2="2232" y2="188" stroke="#b6b3c8" stroke-width="2"/>
+    <text x="2242" y="183" font-size="14" fill="#b6b3c8">Search users</text>
+
+    <!-- segmented control -->
+    <rect x="1450" y="210" width="340" height="40" rx="10" fill="#f7f6fb" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="1454" y="214" width="108" height="32" rx="8" fill="#ffffff" stroke="#dedcea"/>
+    <text x="1508" y="234" font-size="13" font-weight="600" fill="#15131f" text-anchor="middle">All</text>
+    <text x="1620" y="234" font-size="13" fill="#7a7791" text-anchor="middle">Admins</text>
+    <text x="1733" y="234" font-size="13" fill="#7a7791" text-anchor="middle">Deactivated</text>
+
+    <!-- master list rows h=56, centers 298..690 -->
+    <circle cx="1472" cy="298" r="16" fill="#4f8cff"/><text x="1472" y="302" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <text x="1500" y="296" font-size="14" fill="#15131f">Amina K.</text>
+    <rect x="1580" y="286" width="72" height="19" rx="9.5" fill="#6342db" fill-opacity="0.15"/><text x="1616" y="300" font-size="10" font-weight="600" fill="#6342db" text-anchor="middle">Site admin</text>
+    <text x="1500" y="314" font-size="11" fill="#7a7791">@amina</text>
+    <circle cx="1954" cy="298" r="1.7" fill="#7a7791"/><circle cx="1960" cy="298" r="1.7" fill="#7a7791"/><circle cx="1966" cy="298" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="326" x2="1990" y2="326" stroke="#eeedf5"/>
+    <circle cx="1472" cy="354" r="16" fill="#2fd4a7"/><text x="1472" y="358" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <text x="1500" y="352" font-size="14" fill="#15131f">Dev P.</text>
+    <text x="1500" y="370" font-size="11" fill="#7a7791">@devp</text>
+    <circle cx="1954" cy="354" r="1.7" fill="#7a7791"/><circle cx="1960" cy="354" r="1.7" fill="#7a7791"/><circle cx="1966" cy="354" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="382" x2="1990" y2="382" stroke="#eeedf5"/>
+    <circle cx="1472" cy="410" r="16" fill="#ff6fae"/><text x="1472" y="414" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <text x="1500" y="408" font-size="14" fill="#15131f">Sara L.</text>
+    <text x="1500" y="426" font-size="11" fill="#7a7791">@sara</text>
+    <circle cx="1954" cy="410" r="1.7" fill="#7a7791"/><circle cx="1960" cy="410" r="1.7" fill="#7a7791"/><circle cx="1966" cy="410" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="438" x2="1990" y2="438" stroke="#eeedf5"/>
+    <circle cx="1472" cy="466" r="16" fill="#ffb648" opacity="0.5"/><text x="1472" y="470" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">MT</text>
+    <text x="1500" y="464" font-size="14" fill="#7a7791">Marcus T.</text>
+    <rect x="1586" y="454" width="84" height="19" rx="9.5" fill="#7a7791" fill-opacity="0.15"/><text x="1628" y="468" font-size="10" font-weight="600" fill="#7a7791" text-anchor="middle">Deactivated</text>
+    <text x="1500" y="482" font-size="11" fill="#b6b3c8">@marcus</text>
+    <circle cx="1954" cy="466" r="1.7" fill="#7a7791"/><circle cx="1960" cy="466" r="1.7" fill="#7a7791"/><circle cx="1966" cy="466" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="494" x2="1990" y2="494" stroke="#eeedf5"/>
+    <!-- selected Jonas -->
+    <rect x="1442" y="496" width="556" height="54" rx="10" fill="#6342db" fill-opacity="0.08"/>
+    <circle cx="1472" cy="522" r="16" fill="#6342db"/><text x="1472" y="526" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <text x="1500" y="520" font-size="14" font-weight="600" fill="#15131f">Jonas W.</text>
+    <text x="1500" y="538" font-size="11" fill="#7a7791">@jonas</text>
+    <circle cx="1954" cy="522" r="1.7" fill="#7a7791"/><circle cx="1960" cy="522" r="1.7" fill="#7a7791"/><circle cx="1966" cy="522" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="550" x2="1990" y2="550" stroke="#eeedf5"/>
+    <circle cx="1472" cy="578" r="16" fill="#4f8cff"/><text x="1472" y="582" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">PN</text>
+    <text x="1500" y="576" font-size="14" fill="#15131f">Priya N.</text>
+    <text x="1500" y="594" font-size="11" fill="#7a7791">@priya</text>
+    <circle cx="1954" cy="578" r="1.7" fill="#7a7791"/><circle cx="1960" cy="578" r="1.7" fill="#7a7791"/><circle cx="1966" cy="578" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="606" x2="1990" y2="606" stroke="#eeedf5"/>
+    <circle cx="1472" cy="634" r="16" fill="#2fd4a7"/><text x="1472" y="638" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">OR</text>
+    <text x="1500" y="632" font-size="14" fill="#15131f">Omar R.</text>
+    <text x="1500" y="650" font-size="11" fill="#7a7791">@omar</text>
+    <circle cx="1954" cy="634" r="1.7" fill="#7a7791"/><circle cx="1960" cy="634" r="1.7" fill="#7a7791"/><circle cx="1966" cy="634" r="1.7" fill="#7a7791"/>
+    <line x1="1450" y1="662" x2="1990" y2="662" stroke="#eeedf5"/>
+    <circle cx="1472" cy="690" r="16" fill="#ff6fae"/><text x="1472" y="694" font-size="11" font-weight="700" fill="#ffffff" text-anchor="middle">LF</text>
+    <text x="1500" y="688" font-size="14" fill="#15131f">Lena F.</text>
+    <text x="1500" y="706" font-size="11" fill="#7a7791">@lena</text>
+    <circle cx="1954" cy="690" r="1.7" fill="#7a7791"/><circle cx="1960" cy="690" r="1.7" fill="#7a7791"/><circle cx="1966" cy="690" r="1.7" fill="#7a7791"/>
+
+    <!-- pagination footer -->
+    <line x1="1450" y1="724" x2="1990" y2="724" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1450" y="754" font-size="13" fill="#7a7791">1–25 of 132</text>
+    <rect x="1900" y="734" width="36" height="32" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1918" y="755" font-size="15" fill="#b6b3c8" text-anchor="middle">‹</text>
+    <rect x="1944" y="734" width="36" height="32" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="1962" y="755" font-size="15" fill="#514e66" text-anchor="middle">›</text>
+
+    <!-- DETAIL PANE -->
+    <rect x="2040" y="210" width="436" height="470" rx="14" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="2258" cy="278" r="36" fill="#6342db"/><text x="2258" y="285" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <text x="2258" y="340" font-size="19" font-weight="700" fill="#15131f" text-anchor="middle">Jonas W.</text>
+    <text x="2258" y="362" font-size="13" fill="#7a7791" text-anchor="middle">jonas@softtrack.dev</text>
+    <circle cx="2231" cy="389" r="5" fill="#12a474"/>
+    <text x="2243" y="394" font-size="13" fill="#514e66">Active</text>
+    <rect x="2090" y="420" width="336" height="44" rx="10" fill="#ffffff" stroke="#e0424a" stroke-width="1.5"/>
+    <text x="2258" y="448" font-size="15" font-weight="600" fill="#e0424a" text-anchor="middle">Deactivate account</text>
+    <rect x="2090" y="476" width="336" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2258" y="504" font-size="15" font-weight="600" fill="#15131f" text-anchor="middle">Grant site admin</text>
+    <rect x="2090" y="532" width="336" height="44" rx="10" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2258" y="560" font-size="15" font-weight="600" fill="#15131f" text-anchor="middle">Set password…</text>
+    <circle cx="2098" cy="608" r="7" fill="none" stroke="#b6b3c8" stroke-width="1.5"/><text x="2098" y="612" font-size="10" font-weight="700" fill="#b6b3c8" text-anchor="middle">i</text>
+    <text x="2112" y="612" font-size="12" fill="#7a7791">You cannot deactivate yourself or the last active site admin.</text>
+    <!-- low-fi activity -->
+    <text x="2040" y="724" font-size="13" font-weight="700" fill="#514e66">Recent activity</text>
+    <rect x="2040" y="738" width="300" height="9" rx="4" fill="#eeedf5"/>
+    <rect x="2040" y="760" width="250" height="9" rx="4" fill="#eeedf5"/>
+    <rect x="2040" y="782" width="276" height="9" rx="4" fill="#eeedf5"/>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Deactivation and role changes are guarded so the last active site admin can never be removed; medium and expanded widths pair the searchable directory with a persistent user detail pane.</text>
+</svg>

--- a/docs/design/mobile/155-offline.svg
+++ b/docs/design/mobile/155-offline.svg
@@ -1,0 +1,308 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2560 1000" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <rect width="2560" height="1000" fill="#eef0f8"/>
+  <defs>
+    <clipPath id="cp"><rect x="60" y="110" width="390" height="780" rx="28"/></clipPath>
+    <clipPath id="cf"><rect x="530" y="110" width="740" height="780" rx="28"/></clipPath>
+    <clipPath id="ct"><rect x="1350" y="110" width="1150" height="780" rx="28"/></clipPath>
+  </defs>
+
+  <!-- Title block -->
+  <text x="60" y="44" font-size="30" font-weight="700" fill="#15131f">Offline support &amp; sync</text>
+  <text x="60" y="72" font-size="18" fill="#66637c">SoftTrack Mobile · design mockup</text>
+
+  <!-- Frame labels -->
+  <text x="60" y="88" font-size="22" font-weight="600" fill="#514e66">Phone · compact (&lt;600dp)</text>
+  <text x="530" y="88" font-size="22" font-weight="600" fill="#514e66">Foldable · medium (600–839dp)</text>
+  <text x="1350" y="88" font-size="22" font-weight="600" fill="#514e66">Tablet · expanded (≥840dp)</text>
+
+  <!-- ============ PHONE ============ -->
+  <rect x="66" y="118" width="390" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cp)">
+    <!-- status bar -->
+    <text x="84" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="376" y="127" width="3" height="6" fill="#514e66"/><rect x="381" y="124" width="3" height="9" fill="#514e66"/><rect x="386" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="400" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="410" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="412.5" y="123.5" width="10" height="5" fill="#514e66"/>
+
+    <!-- header -->
+    <text x="84" y="178" font-size="20" font-weight="700" fill="#15131f">Board</text>
+    <rect x="152" y="158" width="44" height="24" rx="12" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="174" y="174" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">ENG</text>
+    <rect x="404" y="158" width="24" height="24" rx="7" fill="none" stroke="#dedcea" stroke-width="1.5"/>
+    <line x1="410" y1="166" x2="422" y2="166" stroke="#7a7791" stroke-width="1.6"/><line x1="412" y1="170" x2="420" y2="170" stroke="#7a7791" stroke-width="1.6"/><line x1="414" y1="174" x2="418" y2="174" stroke="#7a7791" stroke-width="1.6"/>
+
+    <!-- offline banner -->
+    <rect x="60" y="192" width="390" height="34" fill="#ffb648" fill-opacity="0.15"/>
+    <circle cx="84" cy="209" r="5" fill="#8a5f00"/><circle cx="91" cy="206" r="6" fill="#8a5f00"/><rect x="78" y="208" width="19" height="6" rx="3" fill="#8a5f00"/>
+    <line x1="75" y1="217" x2="99" y2="199" stroke="#8a5f00" stroke-width="2"/>
+    <text x="108" y="213" font-size="12" font-weight="600" fill="#8a5f00">Offline — changes will sync when reconnected</text>
+
+    <!-- board column -->
+    <rect x="76" y="242" width="330" height="566" rx="14" fill="#f7f6fb"/>
+    <circle cx="94" cy="266" r="5" fill="#f29d0b"/>
+    <text x="106" y="271" font-size="14" font-weight="700" fill="#514e66">In Progress</text>
+    <text x="190" y="271" font-size="13" fill="#7a7791">4</text>
+    <text x="388" y="272" font-size="16" fill="#7a7791" text-anchor="middle">+</text>
+    <!-- card 1 with queued badge -->
+    <rect x="90" y="286" width="302" height="128" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="106" y="312" font-size="12" font-weight="600" fill="#7a7791">ENG-142</text>
+    <rect x="302" y="296" width="76" height="22" rx="11" fill="#ffb648" fill-opacity="0.18"/>
+    <circle cx="316" cy="307" r="5.5" fill="none" stroke="#8a5f00" stroke-width="1.5"/>
+    <line x1="316" y1="307" x2="316" y2="303" stroke="#8a5f00" stroke-width="1.3"/><line x1="316" y1="307" x2="319" y2="309" stroke="#8a5f00" stroke-width="1.3"/>
+    <text x="328" y="311" font-size="11" font-weight="600" fill="#8a5f00">queued</text>
+    <text x="106" y="338" font-size="14" fill="#15131f">Fix drag ghost offset</text>
+    <text x="106" y="356" font-size="14" fill="#15131f">on Safari</text>
+    <rect x="106" y="370" width="46" height="20" rx="10" fill="#f2721c" fill-opacity="0.15"/><text x="129" y="384" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <rect x="160" y="370" width="42" height="20" rx="10" fill="#f2647d" fill-opacity="0.15"/><text x="181" y="384" font-size="11" font-weight="600" fill="#f2647d" text-anchor="middle">bug</text>
+    <circle cx="366" cy="380" r="12" fill="#4f8cff"/><text x="366" y="384" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <!-- card 2 -->
+    <rect x="90" y="426" width="302" height="110" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="106" y="452" font-size="12" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="106" y="478" font-size="14" fill="#15131f">Update onboarding empty states</text>
+    <rect x="106" y="494" width="58" height="20" rx="10" fill="#ef9d0b" fill-opacity="0.15"/><text x="135" y="508" font-size="11" font-weight="600" fill="#ef9d0b" text-anchor="middle">Medium</text>
+    <circle cx="366" cy="504" r="12" fill="#2fd4a7"/><text x="366" y="508" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <!-- card 3 -->
+    <rect x="90" y="548" width="302" height="110" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="106" y="574" font-size="12" font-weight="600" fill="#7a7791">ENG-151</text>
+    <text x="106" y="600" font-size="14" fill="#15131f">Board virtualization for large teams</text>
+    <rect x="106" y="616" width="42" height="20" rx="10" fill="#3f82f6" fill-opacity="0.15"/><text x="127" y="630" font-size="11" font-weight="600" fill="#3f82f6" text-anchor="middle">Low</text>
+    <circle cx="366" cy="626" r="12" fill="#ff6fae"/><text x="366" y="630" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <!-- card 4 -->
+    <rect x="90" y="670" width="302" height="110" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="106" y="696" font-size="12" font-weight="600" fill="#7a7791">ENG-149</text>
+    <text x="106" y="722" font-size="14" fill="#15131f">Improve search ranking for recents</text>
+    <rect x="106" y="738" width="46" height="20" rx="10" fill="#f2721c" fill-opacity="0.15"/><text x="129" y="752" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="366" cy="748" r="12" fill="#6342db"/><text x="366" y="752" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <!-- next column peek -->
+    <rect x="418" y="242" width="44" height="566" rx="14" fill="#f7f6fb"/>
+    <circle cx="436" cy="266" r="5" fill="#8b5cf6"/>
+    <rect x="430" y="286" width="32" height="90" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <rect x="430" y="388" width="32" height="90" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+
+    <!-- bottom nav (Board active) -->
+    <rect x="60" y="826" width="390" height="64" fill="#ffffff"/>
+    <line x1="60" y1="826" x2="450" y2="826" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="88" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="99" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="166" y="836" width="22" height="22" rx="6" fill="#6342db"/><text x="177" y="879" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <rect x="244" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="255" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="322" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="333" y="879" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="400" y="836" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="411" y="879" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+  </g>
+  <rect x="60" y="110" width="390" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ FOLDABLE ============ -->
+  <rect x="536" y="118" width="740" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#cf)">
+    <line x1="900" y1="112" x2="900" y2="888" stroke="#b6b3c8" stroke-width="2" stroke-dasharray="4 6" opacity="0.6"/>
+    <text x="554" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="1196" y="127" width="3" height="6" fill="#514e66"/><rect x="1201" y="124" width="3" height="9" fill="#514e66"/><rect x="1206" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="1220" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="1230" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="1232.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail (Board active) -->
+    <rect x="530" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="606" y1="138" x2="606" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="556" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="557" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="557" y="268" width="22" height="22" rx="6" fill="#6342db"/><text x="568" y="303" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <rect x="557" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="557" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="557" y="454" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="568" y="489" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- LEFT PANE: offline board -->
+    <text x="626" y="180" font-size="17" font-weight="700" fill="#15131f">Board</text>
+    <rect x="684" y="162" width="40" height="22" rx="11" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="704" y="177" font-size="11" font-weight="600" fill="#514e66" text-anchor="middle">ENG</text>
+    <rect x="606" y="192" width="282" height="32" fill="#ffb648" fill-opacity="0.15"/>
+    <circle cx="626" cy="208" r="4" fill="#8a5f00"/><circle cx="632" cy="205" r="5" fill="#8a5f00"/><rect x="621" y="207" width="16" height="5" rx="2.5" fill="#8a5f00"/>
+    <line x1="619" y1="215" x2="639" y2="199" stroke="#8a5f00" stroke-width="1.8"/>
+    <text x="648" y="212" font-size="11.5" font-weight="600" fill="#8a5f00">Offline — changes queued</text>
+    <rect x="622" y="238" width="258" height="560" rx="14" fill="#f7f6fb"/>
+    <circle cx="640" cy="262" r="5" fill="#f29d0b"/>
+    <text x="652" y="267" font-size="13" font-weight="700" fill="#514e66">In Progress</text>
+    <text x="730" y="267" font-size="12" fill="#7a7791">4</text>
+    <!-- card 1 queued -->
+    <rect x="634" y="282" width="234" height="104" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="648" y="308" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <rect x="788" y="292" width="68" height="20" rx="10" fill="#ffb648" fill-opacity="0.18"/>
+    <circle cx="801" cy="302" r="5" fill="none" stroke="#8a5f00" stroke-width="1.4"/>
+    <line x1="801" y1="302" x2="801" y2="298.5" stroke="#8a5f00" stroke-width="1.2"/><line x1="801" y1="302" x2="803.5" y2="303.5" stroke="#8a5f00" stroke-width="1.2"/>
+    <text x="811" y="306" font-size="11" font-weight="600" fill="#8a5f00">queued</text>
+    <text x="648" y="332" font-size="13" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="648" y="348" width="42" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/><text x="669" y="361" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="846" cy="357" r="11" fill="#4f8cff"/><text x="846" y="361" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <!-- card 2 -->
+    <rect x="634" y="398" width="234" height="88" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="648" y="424" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="648" y="446" font-size="13" fill="#15131f">Update onboarding empty states</text>
+    <circle cx="846" cy="466" r="11" fill="#2fd4a7"/><text x="846" y="470" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <!-- card 3 -->
+    <rect x="634" y="498" width="234" height="88" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="648" y="524" font-size="11" font-weight="600" fill="#7a7791">ENG-151</text>
+    <text x="648" y="546" font-size="13" fill="#15131f">Board virtualization for teams</text>
+    <circle cx="846" cy="566" r="11" fill="#ff6fae"/><text x="846" y="570" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <!-- card 4 -->
+    <rect x="634" y="598" width="234" height="88" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="648" y="624" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+    <text x="648" y="646" font-size="13" fill="#15131f">Improve search ranking</text>
+    <circle cx="846" cy="666" r="11" fill="#6342db"/><text x="846" y="670" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <!-- ghost new issue -->
+    <rect x="634" y="700" width="234" height="40" rx="10" fill="none" stroke="#dedcea" stroke-width="1.5" stroke-dasharray="5 4"/>
+    <text x="751" y="725" font-size="13" fill="#7a7791" text-anchor="middle">+ New issue</text>
+
+    <!-- RIGHT PANE: sync queue -->
+    <text x="916" y="180" font-size="17" font-weight="700" fill="#15131f">Sync queue</text>
+    <text x="916" y="200" font-size="12" fill="#7a7791">3 pending changes</text>
+    <!-- row 1 (conflict) -->
+    <rect x="916" y="216" width="338" height="76" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="940" cy="242" r="8" fill="none" stroke="#f29d0b" stroke-width="2"/>
+    <line x1="940" y1="242" x2="940" y2="236.5" stroke="#f29d0b" stroke-width="1.6"/><line x1="940" y1="242" x2="944" y2="244.5" stroke="#f29d0b" stroke-width="1.6"/>
+    <text x="958" y="246" font-size="14" font-weight="600" fill="#15131f">Move ENG-142 → Done</text>
+    <rect x="958" y="256" width="60" height="20" rx="10" fill="#e0424a" fill-opacity="0.15"/><text x="988" y="270" font-size="11" font-weight="600" fill="#e0424a" text-anchor="middle">Conflict</text>
+    <text x="1030" y="270" font-size="12" font-weight="600" fill="#6342db">Resolve</text>
+    <!-- row 2 -->
+    <rect x="916" y="304" width="338" height="64" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="940" cy="336" r="8" fill="none" stroke="#f29d0b" stroke-width="2"/>
+    <line x1="940" y1="336" x2="940" y2="330.5" stroke="#f29d0b" stroke-width="1.6"/><line x1="940" y1="336" x2="944" y2="338.5" stroke="#f29d0b" stroke-width="1.6"/>
+    <text x="958" y="332" font-size="14" font-weight="600" fill="#15131f">Comment on ENG-150</text>
+    <text x="958" y="352" font-size="11" fill="#7a7791">2 min ago · Board</text>
+    <!-- row 3 -->
+    <rect x="916" y="380" width="338" height="64" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="940" cy="412" r="8" fill="none" stroke="#f29d0b" stroke-width="2"/>
+    <line x1="940" y1="412" x2="940" y2="406.5" stroke="#f29d0b" stroke-width="1.6"/><line x1="940" y1="412" x2="944" y2="414.5" stroke="#f29d0b" stroke-width="1.6"/>
+    <text x="958" y="408" font-size="14" font-weight="600" fill="#15131f">New issue: Fix login copy</text>
+    <text x="958" y="428" font-size="11" fill="#7a7791">5 min ago · ENG</text>
+    <!-- sync now -->
+    <rect x="916" y="468" width="140" height="44" rx="10" fill="#6342db"/>
+    <text x="986" y="496" font-size="15" font-weight="600" fill="#ffffff" text-anchor="middle">Sync now</text>
+    <text x="916" y="548" font-size="12" fill="#7a7791">Queued changes apply in order once you're back online.</text>
+    <!-- low-fi history -->
+    <text x="916" y="600" font-size="13" font-weight="700" fill="#514e66">History</text>
+    <circle cx="924" cy="624" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="942" y="619" width="220" height="9" rx="4" fill="#eeedf5"/>
+    <circle cx="924" cy="650" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="942" y="645" width="180" height="9" rx="4" fill="#eeedf5"/>
+    <circle cx="924" cy="676" r="6" fill="#12a474" fill-opacity="0.35"/><rect x="942" y="671" width="200" height="9" rx="4" fill="#eeedf5"/>
+  </g>
+  <rect x="530" y="110" width="740" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- ============ TABLET ============ -->
+  <rect x="1356" y="118" width="1150" height="780" rx="28" fill="#26243a" opacity="0.06"/>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="#ffffff" stroke="#dedcea" stroke-width="2"/>
+  <g clip-path="url(#ct)">
+    <text x="1374" y="130" font-size="14" font-weight="600" fill="#514e66">9:41</text>
+    <rect x="2406" y="127" width="3" height="6" fill="#514e66"/><rect x="2411" y="124" width="3" height="9" fill="#514e66"/><rect x="2416" y="121" width="3" height="12" fill="#514e66"/>
+    <circle cx="2430" cy="127" r="4.5" fill="#514e66"/>
+    <rect x="2440" y="121" width="18" height="10" rx="2" fill="none" stroke="#514e66" stroke-width="1.5"/><rect x="2442.5" y="123.5" width="10" height="5" fill="#514e66"/>
+    <!-- nav rail (Board active) -->
+    <rect x="1350" y="138" width="76" height="752" fill="#f7f6fb"/>
+    <line x1="1426" y1="138" x2="1426" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <rect x="1376" y="152" width="24" height="24" rx="7" fill="#6342db"/>
+    <rect x="1377" y="206" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="241" font-size="11" fill="#7a7791" text-anchor="middle">Home</text>
+    <rect x="1377" y="268" width="22" height="22" rx="6" fill="#6342db"/><text x="1388" y="303" font-size="11" font-weight="600" fill="#6342db" text-anchor="middle">Board</text>
+    <rect x="1377" y="330" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="365" font-size="11" fill="#7a7791" text-anchor="middle">Search</text>
+    <rect x="1377" y="392" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="427" font-size="11" fill="#7a7791" text-anchor="middle">Inbox</text>
+    <rect x="1377" y="454" width="22" height="22" rx="6" fill="none" stroke="#7a7791" stroke-width="1.5"/><text x="1388" y="489" font-size="11" fill="#7a7791" text-anchor="middle">You</text>
+
+    <!-- BOARD REGION -->
+    <text x="1450" y="182" font-size="19" font-weight="700" fill="#15131f">Board</text>
+    <rect x="1516" y="162" width="44" height="24" rx="12" fill="#f7f6fb" stroke="#eeedf5"/>
+    <text x="1538" y="178" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">ENG</text>
+    <!-- offline banner -->
+    <rect x="1450" y="196" width="666" height="34" fill="#ffb648" fill-opacity="0.15"/>
+    <circle cx="1472" cy="213" r="5" fill="#8a5f00"/><circle cx="1479" cy="210" r="6" fill="#8a5f00"/><rect x="1466" y="212" width="19" height="6" rx="3" fill="#8a5f00"/>
+    <line x1="1463" y1="221" x2="1487" y2="203" stroke="#8a5f00" stroke-width="2"/>
+    <text x="1496" y="217" font-size="12.5" font-weight="600" fill="#8a5f00">Offline — changes will sync when reconnected</text>
+    <!-- column 1: In Progress -->
+    <rect x="1450" y="246" width="310" height="560" rx="14" fill="#f7f6fb"/>
+    <circle cx="1468" cy="270" r="5" fill="#f29d0b"/>
+    <text x="1480" y="275" font-size="13" font-weight="700" fill="#514e66">In Progress</text>
+    <text x="1560" y="275" font-size="12" fill="#7a7791">4</text>
+    <rect x="1462" y="290" width="286" height="104" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1476" y="316" font-size="11" font-weight="600" fill="#7a7791">ENG-142</text>
+    <rect x="1668" y="300" width="68" height="20" rx="10" fill="#ffb648" fill-opacity="0.18"/>
+    <circle cx="1681" cy="310" r="5" fill="none" stroke="#8a5f00" stroke-width="1.4"/>
+    <line x1="1681" y1="310" x2="1681" y2="306.5" stroke="#8a5f00" stroke-width="1.2"/><line x1="1681" y1="310" x2="1683.5" y2="311.5" stroke="#8a5f00" stroke-width="1.2"/>
+    <text x="1691" y="314" font-size="11" font-weight="600" fill="#8a5f00">queued</text>
+    <text x="1476" y="340" font-size="13" fill="#15131f">Fix drag ghost offset on Safari</text>
+    <rect x="1476" y="356" width="42" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/><text x="1497" y="369" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="1724" cy="365" r="11" fill="#4f8cff"/><text x="1724" y="369" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">AK</text>
+    <rect x="1462" y="406" width="286" height="92" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1476" y="432" font-size="11" font-weight="600" fill="#7a7791">ENG-150</text>
+    <text x="1476" y="456" font-size="13" fill="#15131f">Update onboarding empty states</text>
+    <rect x="1476" y="470" width="54" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/><text x="1503" y="483" font-size="11" font-weight="600" fill="#ef9d0b" text-anchor="middle">Medium</text>
+    <circle cx="1724" cy="479" r="11" fill="#2fd4a7"/><text x="1724" y="483" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <rect x="1462" y="510" width="286" height="92" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1476" y="536" font-size="11" font-weight="600" fill="#7a7791">ENG-149</text>
+    <text x="1476" y="560" font-size="13" fill="#15131f">Improve search ranking for recents</text>
+    <rect x="1476" y="574" width="42" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/><text x="1497" y="587" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="1724" cy="583" r="11" fill="#6342db"/><text x="1724" y="587" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">JW</text>
+    <rect x="1462" y="614" width="286" height="92" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1476" y="640" font-size="11" font-weight="600" fill="#7a7791">ENG-153</text>
+    <text x="1476" y="664" font-size="13" fill="#15131f">Polish push notification copy</text>
+    <rect x="1476" y="678" width="38" height="18" rx="9" fill="#3f82f6" fill-opacity="0.15"/><text x="1495" y="691" font-size="11" font-weight="600" fill="#3f82f6" text-anchor="middle">Low</text>
+    <circle cx="1724" cy="687" r="11" fill="#ff6fae"/><text x="1724" y="691" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">SL</text>
+    <rect x="1462" y="720" width="286" height="40" rx="10" fill="none" stroke="#dedcea" stroke-width="1.5" stroke-dasharray="5 4"/>
+    <text x="1605" y="745" font-size="13" fill="#7a7791" text-anchor="middle">+ New issue</text>
+    <!-- column 2: In Review -->
+    <rect x="1780" y="246" width="310" height="560" rx="14" fill="#f7f6fb"/>
+    <circle cx="1798" cy="270" r="5" fill="#8b5cf6"/>
+    <text x="1810" y="275" font-size="13" font-weight="700" fill="#514e66">In Review</text>
+    <text x="1880" y="275" font-size="12" fill="#7a7791">2</text>
+    <rect x="1792" y="290" width="286" height="92" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1806" y="316" font-size="11" font-weight="600" fill="#7a7791">ENG-138</text>
+    <text x="1806" y="340" font-size="13" fill="#15131f">Add webhook signature docs</text>
+    <rect x="1806" y="354" width="54" height="18" rx="9" fill="#ef9d0b" fill-opacity="0.15"/><text x="1833" y="367" font-size="11" font-weight="600" fill="#ef9d0b" text-anchor="middle">Medium</text>
+    <circle cx="2054" cy="363" r="11" fill="#ffb648"/><text x="2054" y="367" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">MT</text>
+    <rect x="1792" y="394" width="286" height="92" rx="10" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <text x="1806" y="420" font-size="11" font-weight="600" fill="#7a7791">ENG-135</text>
+    <text x="1806" y="444" font-size="13" fill="#15131f">Refactor issue cache layer</text>
+    <rect x="1806" y="458" width="42" height="18" rx="9" fill="#f2721c" fill-opacity="0.15"/><text x="1827" y="471" font-size="11" font-weight="600" fill="#f2721c" text-anchor="middle">High</text>
+    <circle cx="2054" cy="467" r="11" fill="#2fd4a7"/><text x="2054" y="471" font-size="10" font-weight="700" fill="#ffffff" text-anchor="middle">DP</text>
+    <rect x="1792" y="498" width="286" height="40" rx="10" fill="none" stroke="#dedcea" stroke-width="1.5" stroke-dasharray="5 4"/>
+    <text x="1935" y="523" font-size="13" fill="#7a7791" text-anchor="middle">+ New issue</text>
+
+    <!-- RIGHT PANEL: sync -->
+    <line x1="2140" y1="138" x2="2140" y2="890" stroke="#eeedf5" stroke-width="2"/>
+    <text x="2164" y="182" font-size="17" font-weight="700" fill="#15131f">Sync</text>
+    <!-- status card -->
+    <rect x="2164" y="202" width="312" height="60" rx="12" fill="#f7f6fb"/>
+    <circle cx="2190" cy="232" r="10" fill="#12a474"/><text x="2190" y="237" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">✓</text>
+    <text x="2208" y="228" font-size="13" font-weight="600" fill="#15131f">Last synced 2 min ago</text>
+    <text x="2208" y="248" font-size="11" fill="#7a7791">All reads served from local cache</text>
+    <!-- queue -->
+    <text x="2164" y="294" font-size="13" font-weight="700" fill="#514e66">Queue · 3</text>
+    <circle cx="2174" cy="322" r="7" fill="none" stroke="#f29d0b" stroke-width="1.8"/>
+    <line x1="2174" y1="322" x2="2174" y2="317.5" stroke="#f29d0b" stroke-width="1.4"/><line x1="2174" y1="322" x2="2177" y2="324" stroke="#f29d0b" stroke-width="1.4"/>
+    <text x="2192" y="327" font-size="13" fill="#15131f">Move ENG-142 → Done</text>
+    <line x1="2164" y1="342" x2="2476" y2="342" stroke="#eeedf5"/>
+    <circle cx="2174" cy="368" r="7" fill="none" stroke="#f29d0b" stroke-width="1.8"/>
+    <line x1="2174" y1="368" x2="2174" y2="363.5" stroke="#f29d0b" stroke-width="1.4"/><line x1="2174" y1="368" x2="2177" y2="370" stroke="#f29d0b" stroke-width="1.4"/>
+    <text x="2192" y="373" font-size="13" fill="#15131f">Comment on ENG-150</text>
+    <line x1="2164" y1="388" x2="2476" y2="388" stroke="#eeedf5"/>
+    <circle cx="2174" cy="414" r="7" fill="none" stroke="#f29d0b" stroke-width="1.8"/>
+    <line x1="2174" y1="414" x2="2174" y2="409.5" stroke="#f29d0b" stroke-width="1.4"/><line x1="2174" y1="414" x2="2177" y2="416" stroke="#f29d0b" stroke-width="1.4"/>
+    <text x="2192" y="419" font-size="13" fill="#15131f">New issue: Fix login copy</text>
+    <!-- conflict card -->
+    <rect x="2164" y="470" width="312" height="210" rx="12" fill="#ffffff" stroke="#eeedf5" stroke-width="1.5"/>
+    <circle cx="2182" cy="496" r="5" fill="#e0424a"/>
+    <text x="2192" y="501" font-size="14" font-weight="700" fill="#15131f">Conflict — ENG-142</text>
+    <rect x="2176" y="516" width="140" height="104" rx="10" fill="#f7f6fb"/>
+    <text x="2186" y="538" font-size="11" font-weight="700" fill="#7a7791">YOURS</text>
+    <rect x="2186" y="548" width="94" height="20" rx="10" fill="#12a474" fill-opacity="0.15"/><text x="2233" y="562" font-size="11" font-weight="600" fill="#12a474" text-anchor="middle">status: Done</text>
+    <rect x="2186" y="580" width="120" height="28" rx="8" fill="#6342db"/>
+    <text x="2246" y="598" font-size="12" font-weight="600" fill="#ffffff" text-anchor="middle">Keep yours</text>
+    <rect x="2324" y="516" width="140" height="104" rx="10" fill="#f7f6fb"/>
+    <text x="2334" y="538" font-size="11" font-weight="700" fill="#7a7791">SERVER</text>
+    <rect x="2334" y="548" width="122" height="20" rx="10" fill="#8b5cf6" fill-opacity="0.15"/><text x="2395" y="562" font-size="11" font-weight="600" fill="#8b5cf6" text-anchor="middle">status: In Review</text>
+    <rect x="2334" y="580" width="120" height="28" rx="8" fill="#ffffff" stroke="#dedcea" stroke-width="1.5"/>
+    <text x="2394" y="598" font-size="12" font-weight="600" fill="#514e66" text-anchor="middle">Keep server</text>
+    <text x="2176" y="652" font-size="11" fill="#7a7791">Choose which change wins before syncing resumes.</text>
+    <!-- sync now -->
+    <rect x="2164" y="706" width="130" height="40" rx="10" fill="#6342db"/>
+    <text x="2229" y="731" font-size="14" font-weight="600" fill="#ffffff" text-anchor="middle">Sync now</text>
+  </g>
+  <rect x="1350" y="110" width="1150" height="780" rx="28" fill="none" stroke="#dedcea" stroke-width="2"/>
+
+  <!-- Footer -->
+  <text x="1280" y="960" font-size="16" fill="#7a7791" text-anchor="middle">Reads are served from the on-device cache and writes queue while offline, syncing in order on reconnect — with conflicts surfaced for explicit, per-change resolution.</text>
+</svg>

--- a/docs/logo-dark.svg
+++ b/docs/logo-dark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 40" width="196" height="40" role="img" aria-label="SoftTrack">
+  <defs>
+    <linearGradient id="active" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7a5cf5"/>
+      <stop offset="1" stop-color="#4f8cff"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(-8.4 -5.6) scale(1.6)">
+    <rect x="6.5" y="7" width="5" height="11" rx="2.5" fill="#937bff" opacity="0.8"/>
+    <rect x="13.5" y="12" width="5" height="13" rx="2.5" fill="url(#active)"/>
+    <rect x="20.5" y="9" width="5" height="11" rx="2.5" fill="#937bff" opacity="0.4"/>
+  </g>
+  <text x="44" y="29.5" font-family="'Segoe UI', 'SF Pro Display', 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif" font-size="26" font-weight="600" letter-spacing="-0.5" fill="#f6f5fb">SoftTrack</text>
+</svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 40" width="196" height="40" role="img" aria-label="SoftTrack">
+  <defs>
+    <linearGradient id="active" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7a5cf5"/>
+      <stop offset="1" stop-color="#4f8cff"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(-8.4 -5.6) scale(1.6)">
+    <rect x="6.5" y="7" width="5" height="11" rx="2.5" fill="#b4a6ff"/>
+    <rect x="13.5" y="12" width="5" height="13" rx="2.5" fill="url(#active)"/>
+    <rect x="20.5" y="9" width="5" height="11" rx="2.5" fill="#d3ccff"/>
+  </g>
+  <text x="44" y="29.5" font-family="'Segoe UI', 'SF Pro Display', 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif" font-size="26" font-weight="600" letter-spacing="-0.5" fill="#15131f">SoftTrack</text>
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,5 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <rect width="32" height="32" rx="9" fill="#6342db"/>
-  <path d="M21.6 9.6h-7.2a3.4 3.4 0 0 0 0 6.8h3.2a3.4 3.4 0 0 1 0 6.8h-7.2"
-        fill="none" stroke="#fff" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#937bff"/>
+      <stop offset="0.6" stop-color="#6342db"/>
+      <stop offset="1" stop-color="#4f8cff"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="9" fill="url(#tile)"/>
+  <rect x="6.5" y="7" width="5" height="11" rx="2.5" fill="#fff" opacity="0.6"/>
+  <rect x="13.5" y="12" width="5" height="13" rx="2.5" fill="#fff"/>
+  <rect x="20.5" y="9" width="5" height="11" rx="2.5" fill="#fff" opacity="0.78"/>
 </svg>

--- a/frontend/src/ui/Logo.tsx
+++ b/frontend/src/ui/Logo.tsx
@@ -1,7 +1,7 @@
 /**
- * The SoftTrack mark: a routed path that reads as an "S" and as work moving
- * across a board. The tile carries the brand gradient with a glass highlight
- * so it belongs with the rest of the surfaces.
+ * The SoftTrack mark: three staggered board columns caught mid-wave, the
+ * active one brightest. The tile carries the brand gradient with a glass
+ * highlight so it belongs with the rest of the surfaces.
  *
  * `withWordmark` renders the full lockup. The mark alone is for tight spots
  * (favicon, collapsed sidebar); never re-typeset the wordmark by hand.
@@ -36,14 +36,9 @@ export function Logo({
       </defs>
       <rect width="32" height="32" rx="9" fill="url(#st-logo-fill)" />
       <rect width="32" height="32" rx="9" fill="url(#st-logo-sheen)" />
-      <path
-        d="M21.6 9.6h-7.2a3.4 3.4 0 0 0 0 6.8h3.2a3.4 3.4 0 0 1 0 6.8h-7.2"
-        fill="none"
-        stroke="#fff"
-        strokeWidth="3.2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <rect x="6.5" y="7" width="5" height="11" rx="2.5" fill="#fff" opacity="0.6" />
+      <rect x="13.5" y="12" width="5" height="13" rx="2.5" fill="#fff" />
+      <rect x="20.5" y="9" width="5" height="11" rx="2.5" fill="#fff" opacity="0.78" />
     </svg>
   )
 


### PR DESCRIPTION
## What this changes

Adds the design groundwork for the SoftTrack mobile app, plus the brand assets it builds on:

- **18 responsive mobile mockups** in `docs/design/mobile/` — one per mobile issue (#138–#155). Each SVG shows the same screen at three window size classes: **phone** (compact, <600dp, bottom nav), **foldable unfolded** (medium, 600–839dp, hinge-aware two-pane layouts split at the fold), and **tablet** (expanded, ≥840dp, nav rail + persistent multi-panel layouts). Every issue embeds its mockup in a "📐 Design" section with per-breakpoint behavior notes.
- **Brand assets** — the Option B "Soft Board" logo (`docs/logo.svg`, `docs/logo-dark.svg`), the README lockup, the favicon, and the `Logo.tsx` frontend component.

The mockups use the web app's existing design tokens from `frontend/src/index.css` (brand `#6342db`, tinted neutrals, status/priority colors), so mobile and web share one visual language.

## Why

The mobile app track (project [Mobile App](https://github.com/orgs/soft-track/projects/3), issues soft-track/mobile#1–#155) needs a shared, reviewable design reference before implementation starts — including explicit foldable and tablet behavior, which is easiest to get wrong if left implicit. Hosting the SVGs in-repo keeps the issue embeds versioned alongside the code.

## How it was verified

- All 18 SVGs validate as well-formed XML; a subset was render-checked in a browser (no overflow, hinge line never crossed by content).
- Issue embeds were spot-checked on GitHub to confirm the images render via raw URLs.
- No backend or frontend behavior changes beyond the `Logo.tsx` component and favicon already reviewed with the logo work.

## Checklist

- [x] `cd backend && black . && pytest` — not applicable: no backend changes
- [x] API client regeneration — not applicable: no routes/schemas changed
- [x] Alembic migration — not applicable: no schema change
- [x] New behaviour test — not applicable: docs/design assets and static branding only
- [x] Business logic placement — not applicable: no business logic
